### PR TITLE
Update API, settings, and doc link renaming

### DIFF
--- a/.github/draft-release-notes-config.yml
+++ b/.github/draft-release-notes-config.yml
@@ -2,7 +2,7 @@
 # As pull requests are merged, a draft release is kept up-to-date listing the changes, ready to publish when you’re ready
 
 template: |
-  Compatible with Kibana (**set version here**).
+  Compatible with OpenSearchDashboards (**set version here**).
   $CHANGES
 
 # Setting the formatting and sorting for the release notes body

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -28,46 +28,46 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.0.0-beta1'
+          ref: '1.x'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=beta1 -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=rc1 -Dbuild.snapshot=false
       # dependencies: common-utils
       - name: Checkout common-utils
         uses: actions/checkout@v2
         with:
           repository: 'opensearch-project/common-utils'
           path: common-utils
-          ref: '1.0.0-beta1'
+          ref: 'main'
       - name: Build common-utils
         working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-beta1
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-rc1
       # dependencies: job-scheduler
       - name: Checkout job-scheduler
         uses: actions/checkout@v2
         with:
           repository: 'opensearch-project/job-scheduler'
           path: job-scheduler
-          ref: '1.0.0-beta1'
+          ref: 'main'
       - name: Build job-scheduler
         working-directory: ./job-scheduler
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-beta1 -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-rc1 -Dbuild.snapshot=false
       # dependencies: alerting-notification
       - name: Checkout alerting
         uses: actions/checkout@v2
         with:
           repository: 'opensearch-project/alerting'
           path: alerting
-          ref: '1.0.0-beta1'
+          ref: 'main'
       - name: Build alerting
         working-directory: ./alerting
-        run: ./gradlew :alerting-notification:publishToMavenLocal -Dopensearch_version=1.0.0-beta1
+        run: ./gradlew :alerting-notification:publishToMavenLocal -Dopensearch_version=1.0.0-rc1
       - name: Checkout
         uses: actions/checkout@v2
         with:
           path: index-management
           repository: opensearch-project/index-management
-          ref: '1.0.0-beta1'
+          ref: 'main'
       - name: Run elasticsearch with plugin
         run: |
           cd index-management
@@ -83,7 +83,7 @@ jobs:
         with:
           repository: opensearch-project/OpenSearch-Dashboards
           path: OpenSearch-Dashboards
-          ref: '1.0.0-beta1'
+          ref: '1.x'
       - name: Get node and yarn versions
         id: versions
         run: |

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,5 +1,5 @@
 name: Release workflow
-# This workflow is triggered on creating tags to main or an opendistro release branch
+# This workflow is triggered on creating tags to main or an opensearch release branch
 on:
   push:
     tags:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Index Management Dashboards plugin lets you manage your [Index Management Da
 
 ## Documentation
 
-Please see our [documentation](https://opendistro.github.io/for-elasticsearch-docs/).
+Please see our [documentation](https://docs-beta.opensearch.org/).
 
 ## Setup
 
@@ -33,7 +33,7 @@ Ultimately, your directory structure should look like this:
 
 To build the plugin's distributable zip simply run `yarn build`.
 
-Example output: `./build/indexManagementDashboards-1.0.0.0-beta1.zip`
+Example output: `./build/indexManagementDashboards-1.0.0.0-rc1.zip`
 
 
 ## Run

--- a/cypress/integration/managed_indices_spec.js
+++ b/cypress/integration/managed_indices_spec.js
@@ -136,7 +136,7 @@ describe("Managed indices", () => {
       cy.createPolicy(POLICY_ID, samplePolicy);
       // Create index with rollover_alias
       cy.createIndex(SAMPLE_INDEX, POLICY_ID, {
-        settings: { opendistro: { index_state_management: { rollover_alias: FIRST_ALIAS } } },
+        settings: { plugins: { index_state_management: { rollover_alias: FIRST_ALIAS } } },
       });
     });
 
@@ -147,10 +147,7 @@ describe("Managed indices", () => {
       // Get current index settings for index
       cy.getIndexSettings(SAMPLE_INDEX).then((res) => {
         // Confirm the current rollover_alias is the first one we set
-        expect(res.body).to.have.nested.property(
-          "sample_index.settings.index.opendistro.index_state_management.rollover_alias",
-          FIRST_ALIAS
-        );
+        expect(res.body).to.have.nested.property("sample_index.settings.index.plugins.index_state_management.rollover_alias", FIRST_ALIAS);
       });
 
       // Select checkbox for our managed index
@@ -171,10 +168,7 @@ describe("Managed indices", () => {
       // Get updated index settings for index
       cy.getIndexSettings(SAMPLE_INDEX).then((res) => {
         // Confirm the rollover_alias setting is set to second alias
-        expect(res.body).to.have.nested.property(
-          "sample_index.settings.index.opendistro.index_state_management.rollover_alias",
-          SECOND_ALIAS
-        );
+        expect(res.body).to.have.nested.property("sample_index.settings.index.plugins.index_state_management.rollover_alias", SECOND_ALIAS);
       });
     });
   });

--- a/cypress/support/constants.js
+++ b/cypress/support/constants.js
@@ -24,8 +24,8 @@
  * permissions and limitations under the License.
  */
 
-export const API_ROUTE_PREFIX = "/_opendistro/_ism";
-export const API_ROUTE_PREFIX_ROLLUP = "/_opendistro/_rollup";
+export const API_ROUTE_PREFIX = "/_plugins/_ism";
+export const API_ROUTE_PREFIX_ROLLUP = "/_plugins/_rollup";
 
 export const INDEX = {
   OPENDISTRO_ISM_CONFIG: ".opendistro-ism-config",

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "indexManagementDashboards",
-  "version": "1.0.0.0-beta1",
-  "opensearchDashboardsVersion": "1.0.0-beta1",
+  "version": "1.0.0.0-rc1",
+  "opensearchDashboardsVersion": "1.0.0-rc1",
   "configPath": ["opensearch_index_management"],
   "requiredPlugins": ["navigation"],
   "server": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch_index_management_dashboards",
-  "version": "1.0.0.0-beta1",
+  "version": "1.0.0.0-rc1",
   "description": "Opensearch Dashboards plugin for Index Management",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/public/pages/ChangePolicy/components/NewPolicy/__snapshots__/NewPolicy.test.tsx.snap
+++ b/public/pages/ChangePolicy/components/NewPolicy/__snapshots__/NewPolicy.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`<NewPolicy /> spec renders the component 1`] = `
            
           <a
             class="euiLink euiLink--primary"
-            href="https://opendistro.github.io/for-elasticsearch-docs/docs/ism/"
+            href="https://docs-beta.opensearch.org/docs/im/ism/"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/public/pages/ChangePolicy/containers/ChangePolicy/__snapshots__/ChangePolicy.test.tsx.snap
+++ b/public/pages/ChangePolicy/containers/ChangePolicy/__snapshots__/ChangePolicy.test.tsx.snap
@@ -241,7 +241,7 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
              
             <a
               class="euiLink euiLink--primary"
-              href="https://opendistro.github.io/for-elasticsearch-docs/docs/ism/"
+              href="https://docs-beta.opensearch.org/docs/im/ism/"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/public/pages/CreatePolicy/components/DefinePolicy/__snapshots__/DefinePolicy.test.tsx.snap
+++ b/public/pages/CreatePolicy/components/DefinePolicy/__snapshots__/DefinePolicy.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`<DefinePolicy /> spec renders the component 1`] = `
            
           <a
             class="euiLink euiLink--primary"
-            href="https://opendistro.github.io/for-elasticsearch-docs/docs/ism/"
+            href="https://docs-beta.opensearch.org/docs/im/ism/"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/public/pages/CreatePolicy/containers/CreatePolicy/__snapshots__/CreatePolicy.test.tsx.snap
+++ b/public/pages/CreatePolicy/containers/CreatePolicy/__snapshots__/CreatePolicy.test.tsx.snap
@@ -317,7 +317,7 @@ exports[`<CreatePolicy /> spec renders the edit component 1`] = `
          
         <a
           class="euiLink euiLink--primary"
-          href="https://opendistro.github.io/for-elasticsearch-docs/docs/ism/"
+          href="https://docs-beta.opensearch.org/docs/im/ism/"
           rel="noopener noreferrer"
           target="_blank"
         >

--- a/public/pages/CreateRollup/components/AdvancedAggregation/AdvancedAggregation.tsx
+++ b/public/pages/CreateRollup/components/AdvancedAggregation/AdvancedAggregation.tsx
@@ -395,7 +395,7 @@ export default class AdvancedAggregation extends Component<AdvancedAggregationPr
               <EuiFlexItem>
                 <EuiFormHelpText>
                   The sequence of fields may influence rollup performance.
-                  <EuiLink external={true} href="https://opendistro.github.io/for-elasticsearch-docs/docs/index-rollups/">
+                  <EuiLink external={true} href="https://docs-beta.opensearch.org/docs/im/index-rollups/">
                     {" "}
                     Learn more
                   </EuiLink>

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -28,7 +28,7 @@ export const PLUGIN_NAME = "opensearch_index_management_dashboards";
 
 export const DEFAULT_EMPTY_DATA = "-";
 
-export const DOCUMENTATION_URL = "https://opendistro.github.io/for-elasticsearch-docs/docs/ism/";
+export const DOCUMENTATION_URL = "https://docs-beta.opensearch.org/docs/im/ism/";
 
 export const ROUTES = Object.freeze({
   CHANGE_POLICY: "/change-policy",

--- a/release-notes/create-release-notes.py
+++ b/release-notes/create-release-notes.py
@@ -16,7 +16,7 @@ plugin_name = "index-management-dashboards-plugin"
 plugin_version = raw_input('Plugin version (x.x.x.x): ')
 
 app_num = int(
-    raw_input('Opensearch plugin (enter 1) or Kibana plugin (enter 2)? '))
+    raw_input('OpenSearch plugin (enter 1) or OpenSearchDashboards plugin (enter 2)? '))
 app = 'Opensearch'
 if app_num is 2:
     app = 'OpenSearch-Dashboards'
@@ -24,7 +24,7 @@ if app_num is 2:
 app_version = raw_input(app + ' compatibility version (x.x.x): ')
 
 for line in fileinput.input(file_path, inplace=True):
-    # Add title and ES/Kibana compatibility
+    # Add title and OpenSearch/OpenSearchDashboards compatibility
     if fileinput.isfirstline():
         line = "## Version " + plugin_version + " " + current_date + "\n\n" \
             "Compatible with " + app + " " + app_version + "\n"
@@ -39,7 +39,7 @@ for line in fileinput.input(file_path, inplace=True):
     sys.stdout.write(line)
 
 # Rename file to be consistent with ODFE standards
-new_file_path = "opendistro-for-elasticsearch-" + plugin_name + ".release-notes-" + \
+new_file_path = "opensearch-" + plugin_name + ".release-notes-" + \
     plugin_version + ".md"
 os.rename(file_path, new_file_path)
 

--- a/server/models/interfaces.ts
+++ b/server/models/interfaces.ts
@@ -186,7 +186,7 @@ export interface FailedIndex {
 }
 
 export interface ExplainAPIManagedIndexMetaData {
-  "index.opendistro.index_state_management.policy_id": string | null;
+  "index.plugins.index_state_management.policy_id": string | null;
   index: string;
   index_uuid: string;
   policy_id: string;

--- a/server/services/IndexService.ts
+++ b/server/services/IndexService.ts
@@ -126,7 +126,7 @@ export default class IndexService {
       for (const indexName in explainResponse) {
         if (indexName === "total_managed_indices") continue;
         const explain = explainResponse[indexName] as ExplainAPIManagedIndexMetaData;
-        managed[indexName] = explain["index.opendistro.index_state_management.policy_id"] === null ? "No" : "Yes";
+        managed[indexName] = explain["index.plugins.index_state_management.policy_id"] === null ? "No" : "Yes";
       }
 
       return managed;

--- a/server/utils/constants.ts
+++ b/server/utils/constants.ts
@@ -26,8 +26,8 @@
 
 import { DefaultHeaders, IndexManagementApi } from "../models/interfaces";
 
-export const API_ROUTE_PREFIX = "/_opendistro/_ism";
-export const API_ROUTE_PREFIX_ROLLUP = "/_opendistro/_rollup";
+export const API_ROUTE_PREFIX = "/_plugins/_ism";
+export const API_ROUTE_PREFIX_ROLLUP = "/_plugins/_rollup";
 
 export const API: IndexManagementApi = {
   POLICY_BASE: `${API_ROUTE_PREFIX}/policies`,
@@ -55,5 +55,5 @@ export enum INDEX {
 }
 
 export enum Setting {
-  RolloverAlias = "opendistro.index_state_management.rollover_alias",
+  RolloverAlias = "plugins.index_state_management.rollover_alias",
 }

--- a/server/utils/helpers.ts
+++ b/server/utils/helpers.ts
@@ -31,7 +31,7 @@ import { ManagedIndexMetaData } from "../../models/interfaces";
 export function transformManagedIndexMetaData(metaData: ExplainAPIManagedIndexMetaData | undefined): ManagedIndexMetaData | null {
   if (!metaData) return null;
   // If this is not a managed index or we are still initializing we still return the
-  // opendistro.index_state_management.policy_id setting, but nothing else from the explain API
+  // plugins.index_state_management.policy_id setting, but nothing else from the explain API
   if (!metaData.index) return null;
   return {
     index: metaData.index,


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
* Updates the API calls to use the new `_plugins/` endpoint prefix in favor of the legacy `_opendistro/*` endpoint prefix.
* Updates the settings naming to use the new `plugins` prefix in favor of the legacy `opendistro` prefix.
* Updates the documentation links to point to the new home for docs: https://docs-beta.opensearch.org/

Performed local testing with cypress tests and end to end testing, which succeeded. Github workflow currently failing since Alerting and ISM github repos are not updated yet.

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file; or

(b) The contribution is based upon previous work that, to the best
of my knowledge, is covered under an appropriate open source
license and I have the right under that license to submit that
work with modifications, whether created in whole or in part
by me, under the same open source license (unless I am
permitted to submit under a different license), as indicated
in the file; or

(c) The contribution was provided directly to me by some other
person who certified (a), (b) or (c) and I have not modified
it.

(d) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.

