### PR TITLE
[Feature] Show data streams in 'Indices' and 'Managed Indices' sections

### DIFF
--- a/cypress/fixtures/sample_data_stream_policy.json
+++ b/cypress/fixtures/sample_data_stream_policy.json
@@ -1,0 +1,40 @@
+{
+  "policy": {
+    "description": "A simple description",
+    "default_state": "hot",
+    "states": [
+      {
+        "name": "hot",
+        "actions": [
+          {
+            "replica_count": {
+              "number_of_replicas": 5
+            }
+          }
+        ],
+        "transitions": [
+          {
+            "state_name": "cold",
+            "conditions": {
+              "min_index_age": "30d"
+            }
+          }
+        ]
+      },
+      {
+        "name": "cold",
+        "actions": [
+          {
+            "replica_count": {
+              "number_of_replicas": 2
+            }
+          }
+        ],
+        "transitions": []
+      }
+    ],
+    "ism_template": {
+      "index_patterns": ["logs-*"]
+    }
+  }
+}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -133,3 +133,19 @@ Cypress.Commands.add("createIndex", (index, policyID = null, settings = {}) => {
 Cypress.Commands.add("createRollup", (rollupId, rollupJSON) => {
   cy.request("PUT", `${Cypress.env("opensearch")}${API.ROLLUP_JOBS_BASE}/${rollupId}`, rollupJSON);
 });
+
+Cypress.Commands.add("createIndexTemplate", (name, template) => {
+  cy.request("PUT", `${Cypress.env("opensearch")}${API.INDEX_TEMPLATE_BASE}/${name}`, template);
+});
+
+Cypress.Commands.add("createDataStream", (name) => {
+  cy.request("PUT", `${Cypress.env("opensearch")}${API.DATA_STREAM_BASE}/${name}`);
+});
+
+Cypress.Commands.add("deleteDataStreams", (names) => {
+  cy.request("DELETE", `${Cypress.env("opensearch")}${API.DATA_STREAM_BASE}/${names}`);
+});
+
+Cypress.Commands.add("rollover", (target) => {
+  cy.request("POST", `${Cypress.env("opensearch")}/${target}/_rollover`);
+});

--- a/cypress/support/constants.js
+++ b/cypress/support/constants.js
@@ -32,6 +32,8 @@ export const INDEX = {
 };
 
 export const API = {
+  INDEX_TEMPLATE_BASE: "/_index_template",
+  DATA_STREAM_BASE: "/_data_stream",
   POLICY_BASE: `${API_ROUTE_PREFIX}/policies`,
   EXPLAIN_BASE: `${API_ROUTE_PREFIX}/explain`,
   RETRY_BASE: `${API_ROUTE_PREFIX}/retry`,

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -34,18 +34,21 @@ declare namespace Cypress {
      * cy.wipeCluster()
      */
     deleteAllIndices(): Chainable<any>;
+
     /**
      * Creates a policy
      * @example
      * cy.createPolicy("some_policy", { "policy": { ... } })
      */
     createPolicy(policyId: string, policyJSON: object): Chainable<any>;
+
     /**
      * Gets settings for index
      * @example
      * cy.getIndexSettings("some_index")
      */
     getIndexSettings(index: string): Chainable<any>;
+
     /**
      * Updated the managed index config's start time to
      * make it run in 3 seconds after calling this
@@ -53,17 +56,47 @@ declare namespace Cypress {
      * cy.updateManagedIndexConfigStartTime("some_index")
      */
     updateManagedIndexConfigStartTime(index: string): Chainable<any>;
+
     /**
      * Creates index with policy
      * @example
      * cy.createIndex("some_index", "some_policy")
      */
     createIndex(index: string, policyID?: string, settings?: object): Chainable<any>;
+
     /**
      * Creates a rollup
      * @example
      * cy.createRollup("some_rollup", { "rollup": { ... } })
      */
     createRollup(policyId: string, policyJSON: object): Chainable<any>;
+
+    /**
+     * Creates an index template.
+     * @example
+     * cy.createIndexTemplate("some_index_template", { "index_patterns": "abc", "properties": { ... } })
+     */
+    createIndexTemplate(name: string, template: object): Chainable<any>;
+
+    /**
+     * Creates a data stream.
+     * @example
+     * cy.createDataStream("some_data_stream")
+     */
+    createDataStream(name: string): Chainable<any>;
+
+    /**
+     * Deletes one or more data streams (comma-separated).
+     * @example
+     * cy.deleteDataStreams("logs-*,metrics-*")
+     */
+    deleteDataStreams(names: string): Chainable<any>;
+
+    /**
+     * Rollovers the given target (alias or a data stream).
+     * @example
+     * cy.rollover("some_rollover_target")
+     */
+    rollover(target: string): Chainable<any>;
   }
 }

--- a/models/interfaces.ts
+++ b/models/interfaces.ts
@@ -47,6 +47,7 @@ export interface ManagedIndexMetaData {
 export interface ManagedIndexItem {
   index: string;
   indexUuid: string;
+  dataStream: string | null;
   policyId: string;
   policySeqNo: number;
   policyPrimaryTerm: number;

--- a/public/pages/ChangePolicy/components/ChangeManagedIndices/ChangeManagedIndices.tsx
+++ b/public/pages/ChangePolicy/components/ChangeManagedIndices/ChangeManagedIndices.tsx
@@ -63,7 +63,7 @@ export default class ChangeManagedIndices extends Component<ChangeManagedIndices
     this.setState({ managedIndicesIsLoading: true, managedIndices: [] });
     try {
       // only bring back the first 10 results descending by name
-      const queryObject = { from: 0, size: 10, search: searchValue, sortDirection: "desc", sortField: "name" };
+      const queryObject = { from: 0, size: 10, search: searchValue, sortDirection: "desc", sortField: "name", showDataStreams: true };
       const managedIndicesResponse = await managedIndexService.getManagedIndices(queryObject);
       if (managedIndicesResponse.ok) {
         const options = searchValue.trim() ? [{ label: `${searchValue}*` }] : [];

--- a/public/pages/CreateRollup/components/RollupIndices/RollupIndices.tsx
+++ b/public/pages/CreateRollup/components/RollupIndices/RollupIndices.tsx
@@ -71,7 +71,7 @@ export default class RollupIndices extends Component<RollupIndicesProps, RollupI
     const { indexService } = this.props;
     this.setState({ isLoading: true, indexOptions: [] });
     try {
-      const queryObject = { from: 0, size: 10, search: searchValue, sortDirection: "desc", sortField: "index" };
+      const queryObject = { from: 0, size: 10, search: searchValue, sortDirection: "desc", sortField: "index", showDataStreams: true };
       const getIndicesResponse = await indexService.getIndices(queryObject);
       if (getIndicesResponse.ok) {
         const options = searchValue.trim() ? [{ label: `${searchValue}*` }] : [];

--- a/public/pages/CreateRollup/components/RollupIndices/RollupIndices.tsx
+++ b/public/pages/CreateRollup/components/RollupIndices/RollupIndices.tsx
@@ -71,28 +71,17 @@ export default class RollupIndices extends Component<RollupIndicesProps, RollupI
     const { indexService } = this.props;
     this.setState({ isLoading: true, indexOptions: [] });
     try {
-      const queryObject = { from: 0, size: 10, search: searchValue, sortDirection: "desc", sortField: "index", showDataStreams: true };
-      const [getIndicesResponse, getDataStreamsResponse] = await Promise.all([
-        indexService.getIndices(queryObject),
-        indexService.getDataStreams({ search: searchValue }),
-      ]);
-
-      if (getIndicesResponse.ok) {
+      const dataStreamsAndIndicesNamesResponse = await indexService.getDataStreamsAndIndicesNames(searchValue);
+      if (dataStreamsAndIndicesNamesResponse.ok) {
         const options = searchValue.trim() ? [{ label: `${searchValue}*` }] : [];
-        const dataStreams = getDataStreamsResponse.ok
-          ? getDataStreamsResponse.response.dataStreams.map((ds) => ({
-              label: ds.name,
-            }))
-          : [];
-        const indices = getIndicesResponse.response.indices.map((index: IndexItem) => ({
-          label: index.index,
-        }));
+        const dataStreams = dataStreamsAndIndicesNamesResponse.response.dataStreams.map((label) => ({ label }));
+        const indices = dataStreamsAndIndicesNamesResponse.response.indices.map((label) => ({ label }));
         this.setState({ indexOptions: options.concat(dataStreams, indices), targetIndexOptions: indices });
       } else {
-        if (getIndicesResponse.error.startsWith("[index_not_found_exception]")) {
+        if (dataStreamsAndIndicesNamesResponse.error.startsWith("[index_not_found_exception]")) {
           this.context.notifications.toasts.addDanger("No index available");
         } else {
-          this.context.notifications.toasts.addDanger(getIndicesResponse.error);
+          this.context.notifications.toasts.addDanger(dataStreamsAndIndicesNamesResponse.error);
         }
       }
     } catch (err) {

--- a/public/pages/CreateRollup/components/RollupIndices/RollupIndices.tsx
+++ b/public/pages/CreateRollup/components/RollupIndices/RollupIndices.tsx
@@ -72,13 +72,22 @@ export default class RollupIndices extends Component<RollupIndicesProps, RollupI
     this.setState({ isLoading: true, indexOptions: [] });
     try {
       const queryObject = { from: 0, size: 10, search: searchValue, sortDirection: "desc", sortField: "index", showDataStreams: true };
-      const getIndicesResponse = await indexService.getIndices(queryObject);
+      const [getIndicesResponse, getDataStreamsResponse] = await Promise.all([
+        indexService.getIndices(queryObject),
+        indexService.getDataStreams({ search: searchValue }),
+      ]);
+
       if (getIndicesResponse.ok) {
         const options = searchValue.trim() ? [{ label: `${searchValue}*` }] : [];
+        const dataStreams = getDataStreamsResponse.ok
+          ? getDataStreamsResponse.response.dataStreams.map((ds) => ({
+              label: ds.name,
+            }))
+          : [];
         const indices = getIndicesResponse.response.indices.map((index: IndexItem) => ({
           label: index.index,
         }));
-        this.setState({ indexOptions: options.concat(indices), targetIndexOptions: indices });
+        this.setState({ indexOptions: options.concat(dataStreams, indices), targetIndexOptions: indices });
       } else {
         if (getIndicesResponse.error.startsWith("[index_not_found_exception]")) {
           this.context.notifications.toasts.addDanger("No index available");

--- a/public/pages/CreateRollup/containers/CreateRollupForm/CreateRollupForm.test.tsx
+++ b/public/pages/CreateRollup/containers/CreateRollupForm/CreateRollupForm.test.tsx
@@ -36,6 +36,7 @@ import { ModalProvider, ModalRoot } from "../../../../components/Modal";
 import { BREADCRUMBS, ROUTES } from "../../../../utils/constants";
 import CreateRollupForm from "./CreateRollupForm";
 import { CoreServicesContext } from "../../../../components/core_services";
+import { DataStream } from "../../../../../server/models/interfaces";
 
 const indices = [
   {
@@ -49,6 +50,24 @@ const indices = [
     status: "open",
     "store.size": "100KB",
     uuid: "some_uuid",
+  },
+];
+
+const dataStreams: DataStream[] = [
+  {
+    name: "data_stream_1",
+    indices: [
+      {
+        index_uuid: "uuid",
+        index_name: "name",
+      },
+    ],
+    status: "GREEN",
+    timestamp_field: {
+      name: "@timestamp",
+    },
+    template: "template",
+    generation: 1,
   },
 ];
 
@@ -228,6 +247,11 @@ describe("<CreateRollupForm /> creation", () => {
   browserServicesMock.indexService.getIndices = jest.fn().mockResolvedValue({
     ok: true,
     response: { indices, totalIndices: 1 },
+  });
+
+  browserServicesMock.indexService.getDataStreams = jest.fn().mockResolvedValue({
+    ok: true,
+    response: { dataStreams, totalDataStreams: 1 },
   });
 
   browserServicesMock.rollupService.getMappings = jest.fn().mockResolvedValue({

--- a/public/pages/CreateRollup/containers/CreateRollupForm/CreateRollupForm.test.tsx
+++ b/public/pages/CreateRollup/containers/CreateRollupForm/CreateRollupForm.test.tsx
@@ -38,39 +38,6 @@ import CreateRollupForm from "./CreateRollupForm";
 import { CoreServicesContext } from "../../../../components/core_services";
 import { DataStream } from "../../../../../server/models/interfaces";
 
-const indices = [
-  {
-    "docs.count": 5,
-    "docs.deleted": 2,
-    health: "green",
-    index: "index_1",
-    pri: "1",
-    "pri.store.size": "100KB",
-    rep: "0",
-    status: "open",
-    "store.size": "100KB",
-    uuid: "some_uuid",
-  },
-];
-
-const dataStreams: DataStream[] = [
-  {
-    name: "data_stream_1",
-    indices: [
-      {
-        index_uuid: "uuid",
-        index_name: "name",
-      },
-    ],
-    status: "GREEN",
-    timestamp_field: {
-      name: "@timestamp",
-    },
-    template: "template",
-    generation: 1,
-  },
-];
-
 const sampleMapping = {
   index_1: {
     mappings: {
@@ -244,14 +211,12 @@ describe("<CreateRollupForm /> spec", () => {
 });
 
 describe("<CreateRollupForm /> creation", () => {
-  browserServicesMock.indexService.getIndices = jest.fn().mockResolvedValue({
+  browserServicesMock.indexService.getDataStreamsAndIndicesNames = jest.fn().mockResolvedValue({
     ok: true,
-    response: { indices, totalIndices: 1 },
-  });
-
-  browserServicesMock.indexService.getDataStreams = jest.fn().mockResolvedValue({
-    ok: true,
-    response: { dataStreams, totalDataStreams: 1 },
+    response: {
+      indices: ["index_1"],
+      dataStreams: ["data_stream_1"],
+    },
   });
 
   browserServicesMock.rollupService.getMappings = jest.fn().mockResolvedValue({

--- a/public/pages/CreateTransform/components/TransformIndices/TransformIndices.tsx
+++ b/public/pages/CreateTransform/components/TransformIndices/TransformIndices.tsx
@@ -81,28 +81,17 @@ export default class TransformIndices extends Component<TransformIndicesProps, T
     const { indexService } = this.props;
     this.setState({ isLoading: true, indexOptions: [] });
     try {
-      const queryObject = { from: 0, size: 10, search: searchValue, sortDirection: "desc", sortField: "index", showDataStreams: true };
-      const [getIndicesResponse, getDataStreamsResponse] = await Promise.all([
-        indexService.getIndices(queryObject),
-        indexService.getDataStreams({ search: searchValue }),
-      ]);
-
-      if (getIndicesResponse.ok) {
+      const dataStreamsAndIndicesNamesResponse = await indexService.getDataStreamsAndIndicesNames(searchValue);
+      if (dataStreamsAndIndicesNamesResponse.ok) {
         const options = searchValue.trim() ? [{ label: `${searchValue}*` }] : [];
-        const dataStreams = getDataStreamsResponse.ok
-          ? getDataStreamsResponse.response.dataStreams.map((ds) => ({
-              label: ds.name,
-            }))
-          : [];
-        const indices = getIndicesResponse.response.indices.map((index: IndexItem) => ({
-          label: index.index,
-        }));
+        const dataStreams = dataStreamsAndIndicesNamesResponse.response.dataStreams.map((label) => ({ label }));
+        const indices = dataStreamsAndIndicesNamesResponse.response.indices.map((label) => ({ label }));
         this.setState({ indexOptions: options.concat(dataStreams, indices), targetIndexOptions: indices });
       } else {
-        if (getIndicesResponse.error.startsWith("[index_not_found_exception]")) {
+        if (dataStreamsAndIndicesNamesResponse.error.startsWith("[index_not_found_exception]")) {
           this.context.notifications.toasts.addDanger("No index available");
         } else {
-          this.context.notifications.toasts.addDanger(getIndicesResponse.error);
+          this.context.notifications.toasts.addDanger(dataStreamsAndIndicesNamesResponse.error);
         }
       }
     } catch (err) {

--- a/public/pages/CreateTransform/components/TransformIndices/TransformIndices.tsx
+++ b/public/pages/CreateTransform/components/TransformIndices/TransformIndices.tsx
@@ -81,7 +81,7 @@ export default class TransformIndices extends Component<TransformIndicesProps, T
     const { indexService } = this.props;
     this.setState({ isLoading: true, indexOptions: [] });
     try {
-      const queryObject = { from: 0, size: 10, search: searchValue, sortDirection: "desc", sortField: "index" };
+      const queryObject = { from: 0, size: 10, search: searchValue, sortDirection: "desc", sortField: "index", showDataStreams: true };
       const getIndicesResponse = await indexService.getIndices(queryObject);
       if (getIndicesResponse.ok) {
         const options = searchValue.trim() ? [{ label: `${searchValue}*` }] : [];

--- a/public/pages/Indices/components/IndexControls/IndexControls.test.tsx
+++ b/public/pages/Indices/components/IndexControls/IndexControls.test.tsx
@@ -65,38 +65,6 @@ describe("<IndexControls /> spec", () => {
     expect(onSearchChange).toHaveBeenCalledTimes(4);
   });
 
-  it("shows/hides pagination", async () => {
-    const { queryByTestId, rerender } = render(
-      <IndexControls activePage={0} pageCount={1} search={""} onSearchChange={() => {}} onPageClick={() => {}} onRefresh={async () => {}} />
-    );
-
-    expect(queryByTestId("indexControlsPagination")).toBeNull();
-
-    rerender(
-      <IndexControls activePage={0} pageCount={2} search={""} onSearchChange={() => {}} onPageClick={() => {}} onRefresh={async () => {}} />
-    );
-
-    expect(queryByTestId("indexControlsPagination")).not.toBeNull();
-  });
-
-  it("calls onPageClick when clicking pagination", async () => {
-    const onPageClick = jest.fn();
-    const { getByTestId } = render(
-      <IndexControls
-        activePage={0}
-        pageCount={2}
-        search={""}
-        onSearchChange={() => {}}
-        onPageClick={onPageClick}
-        onRefresh={async () => {}}
-      />
-    );
-
-    fireEvent.click(getByTestId("pagination-button-1"));
-
-    expect(onPageClick).toHaveBeenCalledTimes(1);
-  });
-
   it("calls onRefresh on an interval", async () => {
     const onRefresh = jest.fn();
     const { getByTestId } = render(

--- a/public/pages/Indices/components/IndexControls/IndexControls.test.tsx
+++ b/public/pages/Indices/components/IndexControls/IndexControls.test.tsx
@@ -42,7 +42,7 @@ describe("<IndexControls /> spec", () => {
         onPageClick={() => {}}
         onRefresh={async () => {}}
         showDataStreams={false}
-        getDataStreams={async () => {}}
+        getDataStreams={async () => []}
         toggleShowDataStreams={() => {}}
       />
     );
@@ -61,7 +61,7 @@ describe("<IndexControls /> spec", () => {
         onPageClick={() => {}}
         onRefresh={async () => {}}
         showDataStreams={false}
-        getDataStreams={async () => {}}
+        getDataStreams={async () => []}
         toggleShowDataStreams={() => {}}
       />
     );
@@ -82,7 +82,7 @@ describe("<IndexControls /> spec", () => {
         onPageClick={() => {}}
         onRefresh={onRefresh}
         showDataStreams={false}
-        getDataStreams={async () => {}}
+        getDataStreams={async () => []}
         toggleShowDataStreams={() => {}}
       />
     );
@@ -98,5 +98,50 @@ describe("<IndexControls /> spec", () => {
     fireEvent.click(getByTestId("superDatePickerToggleRefreshButton"));
 
     await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(2), { timeout: 10000 });
+  });
+
+  it("calls toggleShowDataStreams when clicked", async () => {
+    const toggleShowDataStreams = jest.fn();
+    const { getByTestId } = render(
+      <IndexControls
+        activePage={0}
+        pageCount={2}
+        search={""}
+        onSearchChange={() => {}}
+        onPageClick={() => {}}
+        onRefresh={async () => {}}
+        showDataStreams={false}
+        getDataStreams={async () => []}
+        toggleShowDataStreams={toggleShowDataStreams}
+      />
+    );
+
+    fireEvent.click(getByTestId("toggleShowDataStreams"));
+    expect(toggleShowDataStreams).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders data streams selection field", async () => {
+    const getDataStreams = jest.fn();
+    const { container, getByText } = render(
+      <IndexControls
+        activePage={0}
+        pageCount={1}
+        search={"testing"}
+        onSearchChange={() => {}}
+        onPageClick={() => {}}
+        onRefresh={async () => {}}
+        showDataStreams={true}
+        getDataStreams={getDataStreams}
+        toggleShowDataStreams={() => {}}
+      />
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+
+    const dataStreamsSelection = getByText("Data streams");
+    expect(dataStreamsSelection).not.toBeNull();
+
+    fireEvent.click(dataStreamsSelection);
+    await waitFor(() => expect(getDataStreams).toHaveBeenCalledTimes(1), { timeout: 10000 });
   });
 });

--- a/public/pages/Indices/components/IndexControls/IndexControls.test.tsx
+++ b/public/pages/Indices/components/IndexControls/IndexControls.test.tsx
@@ -41,6 +41,9 @@ describe("<IndexControls /> spec", () => {
         onSearchChange={() => {}}
         onPageClick={() => {}}
         onRefresh={async () => {}}
+        showDataStreams={false}
+        getDataStreams={async () => {}}
+        toggleShowDataStreams={() => {}}
       />
     );
 
@@ -57,6 +60,9 @@ describe("<IndexControls /> spec", () => {
         onSearchChange={onSearchChange}
         onPageClick={() => {}}
         onRefresh={async () => {}}
+        showDataStreams={false}
+        getDataStreams={async () => {}}
+        toggleShowDataStreams={() => {}}
       />
     );
 
@@ -68,7 +74,17 @@ describe("<IndexControls /> spec", () => {
   it("calls onRefresh on an interval", async () => {
     const onRefresh = jest.fn();
     const { getByTestId } = render(
-      <IndexControls activePage={0} pageCount={2} search={""} onSearchChange={() => {}} onPageClick={() => {}} onRefresh={onRefresh} />
+      <IndexControls
+        activePage={0}
+        pageCount={2}
+        search={""}
+        onSearchChange={() => {}}
+        onPageClick={() => {}}
+        onRefresh={onRefresh}
+        showDataStreams={false}
+        getDataStreams={async () => {}}
+        toggleShowDataStreams={() => {}}
+      />
     );
 
     fireEvent.click(getByTestId("superDatePickerToggleQuickMenuButton"));

--- a/public/pages/Indices/components/IndexControls/IndexControls.tsx
+++ b/public/pages/Indices/components/IndexControls/IndexControls.tsx
@@ -98,7 +98,12 @@ export default class IndexControls extends Component<IndexControlsProps, IndexCo
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiSwitch label="Show data stream indices" checked={showDataStreams} onChange={toggleShowDataStreams} />
+          <EuiSwitch
+            label="Show data stream indices"
+            checked={showDataStreams}
+            onChange={toggleShowDataStreams}
+            data-test-subj="toggleShowDataStreams"
+          />
         </EuiFlexItem>
         <EuiFlexItem grow={false} style={{ maxWidth: 250 }}>
           <EuiRefreshPicker

--- a/public/pages/Indices/components/IndexControls/IndexControls.tsx
+++ b/public/pages/Indices/components/IndexControls/IndexControls.tsx
@@ -78,7 +78,7 @@ export default class IndexControls extends Component<IndexControlsProps, IndexCo
           {
             type: "field_value_selection",
             field: "data_streams",
-            name: "Data Streams",
+            name: "Data streams",
             noOptionsMessage: "No data streams found",
             multiSelect: "or",
             cache: 60000,
@@ -98,7 +98,7 @@ export default class IndexControls extends Component<IndexControlsProps, IndexCo
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiSwitch label="Show Data Stream Indices" checked={showDataStreams} onChange={toggleShowDataStreams} />
+          <EuiSwitch label="Show data stream indices" checked={showDataStreams} onChange={toggleShowDataStreams} />
         </EuiFlexItem>
         <EuiFlexItem grow={false} style={{ maxWidth: 250 }}>
           <EuiRefreshPicker

--- a/public/pages/Indices/components/IndexControls/IndexControls.tsx
+++ b/public/pages/Indices/components/IndexControls/IndexControls.tsx
@@ -25,16 +25,20 @@
  */
 
 import React, { Component } from "react";
-import { EuiFieldSearch, EuiFlexGroup, EuiFlexItem, EuiPagination } from "@elastic/eui";
+import { ArgsWithError, ArgsWithQuery, EuiFlexGroup, EuiFlexItem, EuiPagination, EuiSearchBar, EuiSwitch } from "@elastic/eui";
 import EuiRefreshPicker from "../../../../temporary/EuiRefreshPicker";
+import { DataStream } from "../../../../../server/models/interfaces";
 
 interface IndexControlsProps {
   activePage: number;
   pageCount: number;
   search: string;
-  onSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  showDataStreams: boolean;
+  onSearchChange: (args: ArgsWithQuery | ArgsWithError) => void;
   onPageClick: (page: number) => void;
   onRefresh: () => Promise<void>;
+  getDataStreams: () => Promise<DataStream[]>;
+  toggleShowDataStreams: () => void;
 }
 
 interface IndexControlsState {
@@ -52,13 +56,52 @@ export default class IndexControls extends Component<IndexControlsProps, IndexCo
     this.setState({ isPaused, refreshInterval });
   };
 
+  getDataStreams = async () => {
+    return (await this.props.getDataStreams()).map((ds) => ({ value: ds.name }));
+  };
+
   render() {
-    const { activePage, pageCount, search, onSearchChange, onPageClick, onRefresh } = this.props;
+    const { activePage, pageCount, search, onSearchChange, onPageClick, onRefresh, showDataStreams, toggleShowDataStreams } = this.props;
     const { refreshInterval, isPaused } = this.state;
+
+    const schema = {
+      strict: true,
+      fields: {
+        indices: {
+          type: "string",
+        },
+        data_streams: {
+          type: "string",
+        },
+      },
+    };
+
+    const filters = showDataStreams
+      ? [
+          {
+            type: "field_value_selection",
+            field: "data_streams",
+            name: "Data Streams",
+            noOptionsMessage: "No data streams found",
+            multiSelect: "or",
+            cache: 60000,
+            options: () => this.getDataStreams(),
+          },
+        ]
+      : undefined;
+
     return (
-      <EuiFlexGroup style={{ padding: "0px 5px" }}>
+      <EuiFlexGroup style={{ padding: "0px 5px" }} alignItems="center">
         <EuiFlexItem>
-          <EuiFieldSearch fullWidth={true} value={search} placeholder="Search" onChange={onSearchChange} />
+          <EuiSearchBar
+            query={search}
+            box={{ placeholder: "Search", schema, incremental: true }}
+            onChange={onSearchChange}
+            filters={filters}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiSwitch label="Show Data Stream Indices" checked={showDataStreams} onChange={toggleShowDataStreams} />
         </EuiFlexItem>
         <EuiFlexItem grow={false} style={{ maxWidth: 250 }}>
           <EuiRefreshPicker

--- a/public/pages/Indices/components/IndexControls/IndexControls.tsx
+++ b/public/pages/Indices/components/IndexControls/IndexControls.tsx
@@ -25,17 +25,14 @@
  */
 
 import React, { Component } from "react";
-import { ArgsWithError, ArgsWithQuery, EuiFlexGroup, EuiFlexItem, EuiPagination, EuiSearchBar, EuiSwitch } from "@elastic/eui";
+import { ArgsWithError, ArgsWithQuery, EuiFlexGroup, EuiFlexItem, EuiSearchBar, EuiSwitch } from "@elastic/eui";
 import EuiRefreshPicker from "../../../../temporary/EuiRefreshPicker";
 import { DataStream } from "../../../../../server/models/interfaces";
 
 interface IndexControlsProps {
-  activePage: number;
-  pageCount: number;
   search: string;
   showDataStreams: boolean;
   onSearchChange: (args: ArgsWithQuery | ArgsWithError) => void;
-  onPageClick: (page: number) => void;
   onRefresh: () => Promise<void>;
   getDataStreams: () => Promise<DataStream[]>;
   toggleShowDataStreams: () => void;
@@ -61,7 +58,7 @@ export default class IndexControls extends Component<IndexControlsProps, IndexCo
   };
 
   render() {
-    const { activePage, pageCount, search, onSearchChange, onPageClick, onRefresh, showDataStreams, toggleShowDataStreams } = this.props;
+    const { search, onSearchChange, onRefresh, showDataStreams, toggleShowDataStreams } = this.props;
     const { refreshInterval, isPaused } = this.state;
 
     const schema = {
@@ -111,16 +108,6 @@ export default class IndexControls extends Component<IndexControlsProps, IndexCo
             onRefresh={onRefresh}
           />
         </EuiFlexItem>
-        {pageCount > 1 && (
-          <EuiFlexItem grow={false} style={{ justifyContent: "center" }}>
-            <EuiPagination
-              pageCount={pageCount}
-              activePage={activePage}
-              onPageClick={onPageClick}
-              data-test-subj="indexControlsPagination"
-            />
-          </EuiFlexItem>
-        )}
       </EuiFlexGroup>
     );
   }

--- a/public/pages/Indices/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
+++ b/public/pages/Indices/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`<IndexControls /> spec renders the component 1`] = `
         class="euiSwitch__label"
         id="some_html_id"
       >
-        Show Data Stream Indices
+        Show data stream indices
       </span>
     </div>
   </div>

--- a/public/pages/Indices/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
+++ b/public/pages/Indices/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
@@ -1,5 +1,191 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<IndexControls /> spec renders data streams selection field 1`] = `
+<div
+  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+  style="padding: 0px 5px;"
+>
+  <div
+    class="euiFlexItem"
+  >
+    <div
+      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+    >
+      <div
+        class="euiFlexItem euiSearchBar__searchHolder"
+      >
+        <div
+          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+        >
+          <div
+            class="euiFormControlLayout__childrenWrapper"
+          >
+            <input
+              aria-label="This is a search bar. As you type, the results lower in the page will automatically filter."
+              class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
+              placeholder="Search"
+              type="search"
+              value="testing"
+            />
+            <div
+              class="euiFormControlLayoutIcons"
+            >
+              <span
+                class="euiFormControlLayoutCustomIcon"
+              >
+                EuiIconMock
+              </span>
+            </div>
+            <div
+              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <button
+                aria-label="Clear input"
+                class="euiFormControlLayoutClearButton"
+                type="button"
+              >
+                EuiIconMock
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiFlexItem euiFlexItem--flexGrowZero euiSearchBar__filtersHolder"
+      >
+        <div
+          class="euiFilterGroup"
+        >
+          <div
+            class="euiPopover euiPopover--anchorDownCenter"
+            id="field_value_selection_0"
+          >
+            <div
+              class="euiPopover__anchor"
+            >
+              <button
+                class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                type="button"
+              >
+                <span
+                  class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                >
+                  EuiIconMock
+                  <span
+                    class="euiButtonEmpty__text"
+                  >
+                    <span
+                      class="euiFilterButton__textShift"
+                      data-text="Data streams"
+                      title="Data streams"
+                    >
+                      Data streams
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiFlexItem euiFlexItem--flexGrowZero"
+  >
+    <div
+      class="euiSwitch"
+    >
+      <button
+        aria-checked="true"
+        aria-labelledby="some_html_id"
+        class="euiSwitch__button"
+        data-test-subj="toggleShowDataStreams"
+        id="some_html_id"
+        role="switch"
+        type="button"
+      >
+        <span
+          class="euiSwitch__body"
+        >
+          <span
+            class="euiSwitch__thumb"
+          />
+          <span
+            class="euiSwitch__track"
+          >
+            EuiIconMock
+            EuiIconMock
+          </span>
+        </span>
+      </button>
+      <span
+        class="euiSwitch__label"
+        id="some_html_id"
+      >
+        Show data stream indices
+      </span>
+    </div>
+  </div>
+  <div
+    class="euiFlexItem euiFlexItem--flexGrowZero"
+    style="max-width: 250px;"
+  >
+    <div
+      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--isAutoRefreshOnly"
+    >
+      <div
+        class="euiFlexItem"
+      >
+        <div
+          class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+        >
+          <div
+            class="euiPopover euiPopover--anchorDownLeft"
+            id="QuickSelectPopover"
+          >
+            <div
+              class="euiPopover__anchor euiQuickSelectPopover__anchor"
+            >
+              <button
+                aria-label="Date quick select"
+                class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                data-test-subj="superDatePickerToggleQuickMenuButton"
+                type="button"
+              >
+                <span
+                  class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                >
+                  EuiIconMock
+                  <span
+                    class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                  >
+                    EuiIconMock
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+          <div
+            class="euiFormControlLayout__childrenWrapper"
+          >
+            <div
+              class="euiDatePickerRange euiDatePickerRange--readOnly euiDatePickerRange--inGroup"
+            >
+              <span
+                class="euiSuperDatePicker__prettyFormat"
+              >
+                Off
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<IndexControls /> spec renders the component 1`] = `
 <div
   class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
@@ -62,6 +248,7 @@ exports[`<IndexControls /> spec renders the component 1`] = `
         aria-checked="false"
         aria-labelledby="some_html_id"
         class="euiSwitch__button"
+        data-test-subj="toggleShowDataStreams"
         id="some_html_id"
         role="switch"
         type="button"

--- a/public/pages/Indices/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
+++ b/public/pages/Indices/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
@@ -2,45 +2,90 @@
 
 exports[`<IndexControls /> spec renders the component 1`] = `
 <div
-  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
   style="padding: 0px 5px;"
 >
   <div
     class="euiFlexItem"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
     >
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFlexItem euiSearchBar__searchHolder"
       >
-        <input
-          class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
-          placeholder="Search"
-          type="search"
-          value="testing"
-        />
         <div
-          class="euiFormControlLayoutIcons"
+          class="euiFormControlLayout euiFormControlLayout--fullWidth"
         >
-          <span
-            class="euiFormControlLayoutCustomIcon"
+          <div
+            class="euiFormControlLayout__childrenWrapper"
           >
-            EuiIconMock
-          </span>
-        </div>
-        <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-        >
-          <button
-            aria-label="Clear input"
-            class="euiFormControlLayoutClearButton"
-            type="button"
-          >
-            EuiIconMock
-          </button>
+            <input
+              aria-label="This is a search bar. As you type, the results lower in the page will automatically filter."
+              class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
+              placeholder="Search"
+              type="search"
+              value="testing"
+            />
+            <div
+              class="euiFormControlLayoutIcons"
+            >
+              <span
+                class="euiFormControlLayoutCustomIcon"
+              >
+                EuiIconMock
+              </span>
+            </div>
+            <div
+              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <button
+                aria-label="Clear input"
+                class="euiFormControlLayoutClearButton"
+                type="button"
+              >
+                EuiIconMock
+              </button>
+            </div>
+          </div>
         </div>
       </div>
+    </div>
+  </div>
+  <div
+    class="euiFlexItem euiFlexItem--flexGrowZero"
+  >
+    <div
+      class="euiSwitch"
+    >
+      <button
+        aria-checked="false"
+        aria-labelledby="some_html_id"
+        class="euiSwitch__button"
+        id="some_html_id"
+        role="switch"
+        type="button"
+      >
+        <span
+          class="euiSwitch__body"
+        >
+          <span
+            class="euiSwitch__thumb"
+          />
+          <span
+            class="euiSwitch__track"
+          >
+            EuiIconMock
+            EuiIconMock
+          </span>
+        </span>
+      </button>
+      <span
+        class="euiSwitch__label"
+        id="some_html_id"
+      >
+        Show Data Stream Indices
+      </span>
     </div>
   </div>
   <div

--- a/public/pages/Indices/containers/Indices/Indices.test.tsx
+++ b/public/pages/Indices/containers/Indices/Indices.test.tsx
@@ -228,7 +228,7 @@ describe("<Indices /> spec", () => {
     expect(queryByText("index_0")).toBeNull();
 
     // @ts-ignore
-    fireEvent.click(getByTestId("tableHeaderCell_docs.count_6").firstChild);
+    fireEvent.click(getByTestId("tableHeaderCell_docs.count_7").firstChild);
 
     // should load indices 0-19 after clicking sort (defaults to asc) on docs.count
     await waitFor(() => getByText("index_0"));

--- a/public/pages/Indices/containers/Indices/Indices.test.tsx
+++ b/public/pages/Indices/containers/Indices/Indices.test.tsx
@@ -228,7 +228,7 @@ describe("<Indices /> spec", () => {
     expect(queryByText("index_0")).toBeNull();
 
     // @ts-ignore
-    fireEvent.click(getByTestId("tableHeaderCell_docs.count_7").firstChild);
+    fireEvent.click(getByTestId("tableHeaderCell_docs.count_6").firstChild);
 
     // should load indices 0-19 after clicking sort (defaults to asc) on docs.count
     await waitFor(() => getByText("index_0"));

--- a/public/pages/Indices/containers/Indices/Indices.tsx
+++ b/public/pages/Indices/containers/Indices/Indices.tsx
@@ -185,11 +185,6 @@ export default class Indices extends Component<IndicesProps, IndicesState> {
     this.setState({ from: 0, search: queryText, query });
   };
 
-  onPageClick = (page: number): void => {
-    const { size } = this.state;
-    this.setState({ from: page * size });
-  };
-
   resetFilters = (): void => {
     this.setState({ search: DEFAULT_QUERY_PARAMS.search, query: Query.parse(DEFAULT_QUERY_PARAMS.search) });
   };
@@ -256,11 +251,8 @@ export default class Indices extends Component<IndicesProps, IndicesState> {
         title="Indices"
       >
         <IndexControls
-          activePage={page}
-          pageCount={Math.ceil(totalIndices / size) || 1}
           search={search}
           onSearchChange={this.onSearchChange}
-          onPageClick={this.onPageClick}
           onRefresh={this.getIndices}
           showDataStreams={showDataStreams}
           getDataStreams={this.getDataStreams}

--- a/public/pages/Indices/containers/Indices/Indices.tsx
+++ b/public/pages/Indices/containers/Indices/Indices.tsx
@@ -125,10 +125,9 @@ export default class Indices extends Component<IndicesProps, IndicesState> {
 
       const getIndicesResponse = await indexService.getIndices({
         ...queryObject,
-        // TODO: enable these once UT issues are figured out.
-        // terms: this.getTermClausesFromState(),
-        // indices: this.getFieldClausesFromState("indices"),
-        // dataStreams: this.getFieldClausesFromState("data_streams"),
+        terms: this.getTermClausesFromState(),
+        indices: this.getFieldClausesFromState("indices"),
+        dataStreams: this.getFieldClausesFromState("data_streams"),
       });
 
       if (getIndicesResponse.ok) {
@@ -159,7 +158,7 @@ export default class Indices extends Component<IndicesProps, IndicesState> {
 
   getFieldClausesFromState = (clause: string): string[] => {
     const { query } = this.state;
-    return (query.ast.getFieldClauses(clause) || []).map((field) => field.value).flat();
+    return _.flatten((query.ast.getFieldClauses(clause) || []).map((field) => field.value));
   };
 
   getTermClausesFromState = (): string[] => {

--- a/public/pages/Indices/containers/Indices/Indices.tsx
+++ b/public/pages/Indices/containers/Indices/Indices.tsx
@@ -38,6 +38,9 @@ import {
   // @ts-ignore
   Pagination,
   EuiTableSelectionType,
+  ArgsWithError,
+  ArgsWithQuery,
+  Query,
 } from "@elastic/eui";
 import { ContentPanel, ContentPanelActions } from "../../../../components/ContentPanel";
 import IndexControls from "../../components/IndexControls";
@@ -46,7 +49,7 @@ import IndexEmptyPrompt from "../../components/IndexEmptyPrompt";
 import { DEFAULT_PAGE_SIZE_OPTIONS, DEFAULT_QUERY_PARAMS, indicesColumns } from "../../utils/constants";
 import { ModalConsumer } from "../../../../components/Modal";
 import IndexService from "../../../../services/IndexService";
-import { ManagedCatIndex } from "../../../../../server/models/interfaces";
+import { DataStream, ManagedCatIndex } from "../../../../../server/models/interfaces";
 import { getURLQueryParams } from "../../utils/helpers";
 import { IndicesQueryParams } from "../../models/interfaces";
 import { BREADCRUMBS } from "../../../../utils/constants";
@@ -62,28 +65,34 @@ interface IndicesState {
   from: number;
   size: number;
   search: string;
+  query: Query;
   sortField: keyof ManagedCatIndex;
   sortDirection: Direction;
   selectedItems: ManagedCatIndex[];
   indices: ManagedCatIndex[];
   loadingIndices: boolean;
+  showDataStreams: boolean;
+  isDataStreamColumnVisible: boolean;
 }
 
 export default class Indices extends Component<IndicesProps, IndicesState> {
   static contextType = CoreServicesContext;
   constructor(props: IndicesProps) {
     super(props);
-    const { from, size, search, sortField, sortDirection } = getURLQueryParams(this.props.location);
+    const { from, size, search, sortField, sortDirection, showDataStreams } = getURLQueryParams(this.props.location);
     this.state = {
       totalIndices: 0,
       from,
       size,
       search,
+      query: Query.parse(search),
       sortField,
       sortDirection,
       selectedItems: [],
       indices: [],
       loadingIndices: true,
+      showDataStreams,
+      isDataStreamColumnVisible: showDataStreams,
     };
 
     this.getIndices = _.debounce(this.getIndices, 500, { leading: true });
@@ -102,8 +111,8 @@ export default class Indices extends Component<IndicesProps, IndicesState> {
     }
   }
 
-  static getQueryObjectFromState({ from, size, search, sortField, sortDirection }: IndicesState): IndicesQueryParams {
-    return { from, size, search, sortField, sortDirection };
+  static getQueryObjectFromState({ from, size, search, sortField, sortDirection, showDataStreams }: IndicesState): IndicesQueryParams {
+    return { from, size, search, sortField, sortDirection, showDataStreams };
   }
 
   getIndices = async (): Promise<void> => {
@@ -113,7 +122,15 @@ export default class Indices extends Component<IndicesProps, IndicesState> {
       const queryObject = Indices.getQueryObjectFromState(this.state);
       const queryParamsString = queryString.stringify(queryObject);
       history.replace({ ...this.props.location, search: queryParamsString });
-      const getIndicesResponse = await indexService.getIndices(queryObject);
+
+      const getIndicesResponse = await indexService.getIndices({
+        ...queryObject,
+        // TODO: enable these once UT issues are figured out.
+        // terms: this.getTermClausesFromState(),
+        // indices: this.getFieldClausesFromState("indices"),
+        // dataStreams: this.getFieldClausesFromState("data_streams"),
+      });
+
       if (getIndicesResponse.ok) {
         const { indices, totalIndices } = getIndicesResponse.response;
         this.setState({ indices, totalIndices });
@@ -123,7 +140,31 @@ export default class Indices extends Component<IndicesProps, IndicesState> {
     } catch (err) {
       this.context.notifications.toasts.addDanger(getErrorMessage(err, "There was a problem loading the indices"));
     }
-    this.setState({ loadingIndices: false });
+
+    // Avoiding flicker by showing/hiding the "Data Stream" column only after the results are loaded.
+    const { showDataStreams } = this.state;
+    this.setState({ loadingIndices: false, isDataStreamColumnVisible: showDataStreams });
+  };
+
+  getDataStreams = async (): Promise<DataStream[]> => {
+    const { indexService } = this.props;
+    const serverResponse = await indexService.getDataStreams();
+    return serverResponse.response.dataStreams;
+  };
+
+  toggleShowDataStreams = () => {
+    const { showDataStreams } = this.state;
+    this.setState({ showDataStreams: !showDataStreams });
+  };
+
+  getFieldClausesFromState = (clause: string): string[] => {
+    const { query } = this.state;
+    return (query.ast.getFieldClauses(clause) || []).map((field) => field.value).flat();
+  };
+
+  getTermClausesFromState = (): string[] => {
+    const { query } = this.state;
+    return (query.ast.getTermClauses() || []).map((term) => term.value);
   };
 
   onTableChange = ({ page: tablePage, sort }: Criteria<ManagedCatIndex>): void => {
@@ -136,8 +177,12 @@ export default class Indices extends Component<IndicesProps, IndicesState> {
     this.setState({ selectedItems });
   };
 
-  onSearchChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    this.setState({ from: 0, search: e.target.value });
+  onSearchChange = ({ query, queryText, error }: ArgsWithQuery | ArgsWithError): void => {
+    if (error) {
+      return;
+    }
+
+    this.setState({ from: 0, search: queryText, query });
   };
 
   onPageClick = (page: number): void => {
@@ -146,11 +191,23 @@ export default class Indices extends Component<IndicesProps, IndicesState> {
   };
 
   resetFilters = (): void => {
-    this.setState({ search: DEFAULT_QUERY_PARAMS.search });
+    this.setState({ search: DEFAULT_QUERY_PARAMS.search, query: Query.parse(DEFAULT_QUERY_PARAMS.search) });
   };
 
   render() {
-    const { totalIndices, from, size, search, sortField, sortDirection, selectedItems, indices, loadingIndices } = this.state;
+    const {
+      totalIndices,
+      from,
+      size,
+      search,
+      sortField,
+      sortDirection,
+      selectedItems,
+      indices,
+      loadingIndices,
+      showDataStreams,
+      isDataStreamColumnVisible,
+    } = this.state;
 
     const filterIsApplied = !!search;
     const page = Math.floor(from / size);
@@ -205,12 +262,15 @@ export default class Indices extends Component<IndicesProps, IndicesState> {
           onSearchChange={this.onSearchChange}
           onPageClick={this.onPageClick}
           onRefresh={this.getIndices}
+          showDataStreams={showDataStreams}
+          getDataStreams={this.getDataStreams}
+          toggleShowDataStreams={this.toggleShowDataStreams}
         />
 
         <EuiHorizontalRule margin="xs" />
 
         <EuiBasicTable
-          columns={indicesColumns}
+          columns={indicesColumns(isDataStreamColumnVisible)}
           isSelectable={true}
           itemId="index"
           items={indices}

--- a/public/pages/Indices/containers/Indices/Indices.tsx
+++ b/public/pages/Indices/containers/Indices/Indices.tsx
@@ -141,7 +141,7 @@ export default class Indices extends Component<IndicesProps, IndicesState> {
       this.context.notifications.toasts.addDanger(getErrorMessage(err, "There was a problem loading the indices"));
     }
 
-    // Avoiding flicker by showing/hiding the "Data Stream" column only after the results are loaded.
+    // Avoiding flicker by showing/hiding the "Data stream" column only after the results are loaded.
     const { showDataStreams } = this.state;
     this.setState({ loadingIndices: false, isDataStreamColumnVisible: showDataStreams });
   };

--- a/public/pages/Indices/containers/Indices/__snapshots__/Indices.test.tsx.snap
+++ b/public/pages/Indices/containers/Indices/__snapshots__/Indices.test.tsx.snap
@@ -111,6 +111,7 @@ exports[`<Indices /> spec renders the component 1`] = `
             aria-checked="false"
             aria-labelledby="some_html_id"
             class="euiSwitch__button"
+            data-test-subj="toggleShowDataStreams"
             id="some_html_id"
             role="switch"
             type="button"

--- a/public/pages/Indices/containers/Indices/__snapshots__/Indices.test.tsx.snap
+++ b/public/pages/Indices/containers/Indices/__snapshots__/Indices.test.tsx.snap
@@ -62,34 +62,117 @@ exports[`<Indices /> spec renders the component 1`] = `
     style="padding: initial;"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
       style="padding: 0px 5px;"
     >
       <div
         class="euiFlexItem"
       >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+          class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
         >
           <div
-            class="euiFormControlLayout__childrenWrapper"
+            class="euiFlexItem euiSearchBar__searchHolder"
           >
-            <input
-              class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
-              placeholder="Search"
-              type="search"
-              value=""
-            />
             <div
-              class="euiFormControlLayoutIcons"
+              class="euiFormControlLayout euiFormControlLayout--fullWidth"
             >
-              <span
-                class="euiFormControlLayoutCustomIcon"
+              <div
+                class="euiFormControlLayout__childrenWrapper"
               >
-                EuiIconMock
-              </span>
+                <input
+                  aria-label="This is a search bar. As you type, the results lower in the page will automatically filter."
+                  class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
+                  placeholder="Search"
+                  type="search"
+                  value=""
+                />
+                <div
+                  class="euiFormControlLayoutIcons"
+                >
+                  <span
+                    class="euiFormControlLayoutCustomIcon"
+                  >
+                    EuiIconMock
+                  </span>
+                </div>
+              </div>
             </div>
           </div>
+          <div
+            class="euiFlexItem euiFlexItem--flexGrowZero euiSearchBar__filtersHolder"
+          >
+            <div
+              class="euiFilterGroup"
+            >
+              <div
+                class="euiPopover euiPopover--anchorDownCenter"
+                id="field_value_selection_0"
+              >
+                <div
+                  class="euiPopover__anchor"
+                >
+                  <button
+                    class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                    type="button"
+                  >
+                    <span
+                      class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                    >
+                      EuiIconMock
+                      <span
+                        class="euiButtonEmpty__text"
+                      >
+                        <span
+                          class="euiFilterButton__textShift"
+                          data-text="Data Streams"
+                          title="Data Streams"
+                        >
+                          Data Streams
+                        </span>
+                      </span>
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiFlexItem euiFlexItem--flexGrowZero"
+      >
+        <div
+          class="euiSwitch"
+        >
+          <button
+            aria-checked="true"
+            aria-labelledby="some_html_id"
+            class="euiSwitch__button"
+            id="some_html_id"
+            role="switch"
+            type="button"
+          >
+            <span
+              class="euiSwitch__body"
+            >
+              <span
+                class="euiSwitch__thumb"
+              />
+              <span
+                class="euiSwitch__track"
+              >
+                EuiIconMock
+                EuiIconMock
+              </span>
+            </span>
+          </button>
+          <span
+            class="euiSwitch__label"
+            id="some_html_id"
+          >
+            Show Data Stream Indices
+          </span>
         </div>
       </div>
       <div
@@ -316,11 +399,42 @@ exports[`<Indices /> spec renders the component 1`] = `
                 </button>
               </th>
               <th
+                aria-live="polite"
+                aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_managed_2"
+                data-test-subj="tableHeaderCell_data_stream_2"
                 role="columnheader"
                 scope="col"
-                style="width: 150px;"
+                style="width: 120px;"
+              >
+                <button
+                  class="euiTableHeaderButton"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
+                >
+                  <span
+                    class="euiTableCellContent euiTableCellContent--alignRight"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                      title="Data Stream"
+                    >
+                      Data Stream
+                    </span>
+                    <span
+                      class="euiScreenReaderOnly"
+                    >
+                      Click to sort in ascending order
+                    </span>
+                  </span>
+                </button>
+              </th>
+              <th
+                class="euiTableHeaderCell"
+                data-test-subj="tableHeaderCell_managed_3"
+                role="columnheader"
+                scope="col"
+                style="width: 140px;"
               >
                 <div
                   class="euiTableCellContent euiTableCellContent--alignRight"
@@ -337,7 +451,7 @@ exports[`<Indices /> spec renders the component 1`] = `
                 aria-live="polite"
                 aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_status_3"
+                data-test-subj="tableHeaderCell_status_4"
                 role="columnheader"
                 scope="col"
               >
@@ -367,7 +481,7 @@ exports[`<Indices /> spec renders the component 1`] = `
                 aria-live="polite"
                 aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_store.size_4"
+                data-test-subj="tableHeaderCell_store.size_5"
                 role="columnheader"
                 scope="col"
               >
@@ -397,7 +511,7 @@ exports[`<Indices /> spec renders the component 1`] = `
                 aria-live="polite"
                 aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_pri.store.size_5"
+                data-test-subj="tableHeaderCell_pri.store.size_6"
                 role="columnheader"
                 scope="col"
               >
@@ -427,7 +541,7 @@ exports[`<Indices /> spec renders the component 1`] = `
                 aria-live="polite"
                 aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_docs.count_6"
+                data-test-subj="tableHeaderCell_docs.count_7"
                 role="columnheader"
                 scope="col"
               >
@@ -457,7 +571,7 @@ exports[`<Indices /> spec renders the component 1`] = `
                 aria-live="polite"
                 aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_docs.deleted_7"
+                data-test-subj="tableHeaderCell_docs.deleted_8"
                 role="columnheader"
                 scope="col"
               >
@@ -487,7 +601,7 @@ exports[`<Indices /> spec renders the component 1`] = `
                 aria-live="polite"
                 aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_pri_8"
+                data-test-subj="tableHeaderCell_pri_9"
                 role="columnheader"
                 scope="col"
               >
@@ -517,7 +631,7 @@ exports[`<Indices /> spec renders the component 1`] = `
                 aria-live="polite"
                 aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_rep_9"
+                data-test-subj="tableHeaderCell_rep_10"
                 role="columnheader"
                 scope="col"
               >
@@ -551,7 +665,7 @@ exports[`<Indices /> spec renders the component 1`] = `
             >
               <td
                 class="euiTableRowCell euiTableRowCell--isMobileFullWidth"
-                colspan="11"
+                colspan="12"
               >
                 <div
                   class="euiTableCellContent euiTableCellContent--alignCenter"

--- a/public/pages/Indices/containers/Indices/__snapshots__/Indices.test.tsx.snap
+++ b/public/pages/Indices/containers/Indices/__snapshots__/Indices.test.tsx.snap
@@ -99,44 +99,6 @@ exports[`<Indices /> spec renders the component 1`] = `
               </div>
             </div>
           </div>
-          <div
-            class="euiFlexItem euiFlexItem--flexGrowZero euiSearchBar__filtersHolder"
-          >
-            <div
-              class="euiFilterGroup"
-            >
-              <div
-                class="euiPopover euiPopover--anchorDownCenter"
-                id="field_value_selection_0"
-              >
-                <div
-                  class="euiPopover__anchor"
-                >
-                  <button
-                    class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
-                    type="button"
-                  >
-                    <span
-                      class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                    >
-                      EuiIconMock
-                      <span
-                        class="euiButtonEmpty__text"
-                      >
-                        <span
-                          class="euiFilterButton__textShift"
-                          data-text="Data Streams"
-                          title="Data Streams"
-                        >
-                          Data Streams
-                        </span>
-                      </span>
-                    </span>
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
         </div>
       </div>
       <div
@@ -146,7 +108,7 @@ exports[`<Indices /> spec renders the component 1`] = `
           class="euiSwitch"
         >
           <button
-            aria-checked="true"
+            aria-checked="false"
             aria-labelledby="some_html_id"
             class="euiSwitch__button"
             id="some_html_id"
@@ -171,7 +133,7 @@ exports[`<Indices /> spec renders the component 1`] = `
             class="euiSwitch__label"
             id="some_html_id"
           >
-            Show Data Stream Indices
+            Show data stream indices
           </span>
         </div>
       </div>
@@ -399,39 +361,8 @@ exports[`<Indices /> spec renders the component 1`] = `
                 </button>
               </th>
               <th
-                aria-live="polite"
-                aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_data_stream_2"
-                role="columnheader"
-                scope="col"
-                style="width: 120px;"
-              >
-                <button
-                  class="euiTableHeaderButton"
-                  data-test-subj="tableHeaderSortButton"
-                  type="button"
-                >
-                  <span
-                    class="euiTableCellContent euiTableCellContent--alignRight"
-                  >
-                    <span
-                      class="euiTableCellContent__text"
-                      title="Data Stream"
-                    >
-                      Data Stream
-                    </span>
-                    <span
-                      class="euiScreenReaderOnly"
-                    >
-                      Click to sort in ascending order
-                    </span>
-                  </span>
-                </button>
-              </th>
-              <th
-                class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_managed_3"
+                data-test-subj="tableHeaderCell_managed_2"
                 role="columnheader"
                 scope="col"
                 style="width: 140px;"
@@ -451,7 +382,7 @@ exports[`<Indices /> spec renders the component 1`] = `
                 aria-live="polite"
                 aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_status_4"
+                data-test-subj="tableHeaderCell_status_3"
                 role="columnheader"
                 scope="col"
               >
@@ -481,7 +412,7 @@ exports[`<Indices /> spec renders the component 1`] = `
                 aria-live="polite"
                 aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_store.size_5"
+                data-test-subj="tableHeaderCell_store.size_4"
                 role="columnheader"
                 scope="col"
               >
@@ -511,7 +442,7 @@ exports[`<Indices /> spec renders the component 1`] = `
                 aria-live="polite"
                 aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_pri.store.size_6"
+                data-test-subj="tableHeaderCell_pri.store.size_5"
                 role="columnheader"
                 scope="col"
               >
@@ -541,7 +472,7 @@ exports[`<Indices /> spec renders the component 1`] = `
                 aria-live="polite"
                 aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_docs.count_7"
+                data-test-subj="tableHeaderCell_docs.count_6"
                 role="columnheader"
                 scope="col"
               >
@@ -571,7 +502,7 @@ exports[`<Indices /> spec renders the component 1`] = `
                 aria-live="polite"
                 aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_docs.deleted_8"
+                data-test-subj="tableHeaderCell_docs.deleted_7"
                 role="columnheader"
                 scope="col"
               >
@@ -601,7 +532,7 @@ exports[`<Indices /> spec renders the component 1`] = `
                 aria-live="polite"
                 aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_pri_9"
+                data-test-subj="tableHeaderCell_pri_8"
                 role="columnheader"
                 scope="col"
               >
@@ -631,7 +562,7 @@ exports[`<Indices /> spec renders the component 1`] = `
                 aria-live="polite"
                 aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_rep_10"
+                data-test-subj="tableHeaderCell_rep_9"
                 role="columnheader"
                 scope="col"
               >
@@ -665,7 +596,7 @@ exports[`<Indices /> spec renders the component 1`] = `
             >
               <td
                 class="euiTableRowCell euiTableRowCell--isMobileFullWidth"
-                colspan="12"
+                colspan="11"
               >
                 <div
                   class="euiTableCellContent euiTableCellContent--alignCenter"

--- a/public/pages/Indices/models/interfaces.ts
+++ b/public/pages/Indices/models/interfaces.ts
@@ -39,4 +39,5 @@ export interface IndicesQueryParams {
   search: string;
   sortField: keyof ManagedCatIndex;
   sortDirection: Direction;
+  showDataStreams: boolean;
 }

--- a/public/pages/Indices/utils/constants.tsx
+++ b/public/pages/Indices/utils/constants.tsx
@@ -51,7 +51,7 @@ const HEALTH_TO_COLOR: {
   red: "danger",
 };
 
-export const indicesColumns: EuiTableFieldDataColumnType<ManagedCatIndex>[] = [
+const INDICES_COLUMNS: EuiTableFieldDataColumnType<ManagedCatIndex>[] = [
   {
     field: "index",
     name: "Index",
@@ -86,13 +86,23 @@ export const indicesColumns: EuiTableFieldDataColumnType<ManagedCatIndex>[] = [
     },
   },
   {
+    field: "data_stream",
+    name: "Data Stream",
+    sortable: true,
+    truncateText: true,
+    textOnly: true,
+    align: "right",
+    width: "120px",
+    render: (data_stream) => data_stream || "-",
+  },
+  {
     field: "managed",
     name: "Managed by Policy",
     sortable: false,
     truncateText: true,
     textOnly: true,
     align: "right",
-    width: "150px",
+    width: "140px",
   },
   {
     field: "status",
@@ -153,3 +163,7 @@ export const indicesColumns: EuiTableFieldDataColumnType<ManagedCatIndex>[] = [
     dataType: "number",
   },
 ];
+
+export const indicesColumns = (isDataStreamColumnVisible: boolean): EuiTableFieldDataColumnType<ManagedCatIndex>[] => {
+  return isDataStreamColumnVisible ? INDICES_COLUMNS : INDICES_COLUMNS.filter((col) => col["field"] !== "data_stream");
+};

--- a/public/pages/Indices/utils/constants.tsx
+++ b/public/pages/Indices/utils/constants.tsx
@@ -37,6 +37,7 @@ export const DEFAULT_QUERY_PARAMS = {
   search: "",
   sortField: "name",
   sortDirection: SortDirection.DESC,
+  showDataStreams: true,
 };
 
 const HEALTH_TO_COLOR: {

--- a/public/pages/Indices/utils/constants.tsx
+++ b/public/pages/Indices/utils/constants.tsx
@@ -37,7 +37,7 @@ export const DEFAULT_QUERY_PARAMS = {
   search: "",
   sortField: "name",
   sortDirection: SortDirection.DESC,
-  showDataStreams: true,
+  showDataStreams: false,
 };
 
 const HEALTH_TO_COLOR: {
@@ -87,7 +87,7 @@ const INDICES_COLUMNS: EuiTableFieldDataColumnType<ManagedCatIndex>[] = [
   },
   {
     field: "data_stream",
-    name: "Data Stream",
+    name: "Data stream",
     sortable: true,
     truncateText: true,
     textOnly: true,

--- a/public/pages/Indices/utils/helpers.ts
+++ b/public/pages/Indices/utils/helpers.ts
@@ -29,7 +29,7 @@ import { DEFAULT_QUERY_PARAMS } from "./constants";
 import { IndicesQueryParams } from "../models/interfaces";
 
 export function getURLQueryParams(location: { search: string }): IndicesQueryParams {
-  const { from, size, search, sortField, sortDirection } = queryString.parse(location.search);
+  const { from, size, search, sortField, sortDirection, showDataStreams } = queryString.parse(location.search);
   return <IndicesQueryParams>{
     // @ts-ignore
     from: isNaN(parseInt(from, 10)) ? DEFAULT_QUERY_PARAMS.from : parseInt(from, 10),
@@ -38,5 +38,6 @@ export function getURLQueryParams(location: { search: string }): IndicesQueryPar
     search: typeof search !== "string" ? DEFAULT_QUERY_PARAMS.search : search,
     sortField: typeof sortField !== "string" ? "index" : sortField,
     sortDirection: typeof sortDirection !== "string" ? DEFAULT_QUERY_PARAMS.sortDirection : sortDirection,
+    showDataStreams: showDataStreams === undefined ? DEFAULT_QUERY_PARAMS.showDataStreams : showDataStreams === "true",
   };
 }

--- a/public/pages/ManagedIndices/components/ManagedIndexControls/ManagedIndexControls.test.tsx
+++ b/public/pages/ManagedIndices/components/ManagedIndexControls/ManagedIndexControls.test.tsx
@@ -42,7 +42,7 @@ describe("<ManagedIndexControls /> spec", () => {
         onPageClick={() => {}}
         onRefresh={async () => {}}
         showDataStreams={false}
-        getDataStreams={async () => {}}
+        getDataStreams={async () => []}
         toggleShowDataStreams={() => {}}
       />
     );
@@ -61,7 +61,7 @@ describe("<ManagedIndexControls /> spec", () => {
         onPageClick={() => {}}
         onRefresh={async () => {}}
         showDataStreams={false}
-        getDataStreams={async () => {}}
+        getDataStreams={async () => []}
         toggleShowDataStreams={() => {}}
       />
     );
@@ -82,7 +82,7 @@ describe("<ManagedIndexControls /> spec", () => {
         onPageClick={() => {}}
         onRefresh={onRefresh}
         showDataStreams={false}
-        getDataStreams={async () => {}}
+        getDataStreams={async () => []}
         toggleShowDataStreams={() => {}}
       />
     );
@@ -98,5 +98,50 @@ describe("<ManagedIndexControls /> spec", () => {
     fireEvent.click(getByTestId("superDatePickerToggleRefreshButton"));
 
     await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(2), { timeout: 10000 });
+  });
+
+  it("calls toggleShowDataStreams when clicked", async () => {
+    const toggleShowDataStreams = jest.fn();
+    const { getByTestId } = render(
+      <ManagedIndexControls
+        activePage={0}
+        pageCount={2}
+        search={""}
+        onSearchChange={() => {}}
+        onPageClick={() => {}}
+        onRefresh={async () => {}}
+        showDataStreams={false}
+        getDataStreams={async () => []}
+        toggleShowDataStreams={toggleShowDataStreams}
+      />
+    );
+
+    fireEvent.click(getByTestId("toggleShowDataStreams"));
+    expect(toggleShowDataStreams).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders data streams selection field", async () => {
+    const getDataStreams = jest.fn();
+    const { container, getByText } = render(
+      <ManagedIndexControls
+        activePage={0}
+        pageCount={2}
+        search={""}
+        onSearchChange={() => {}}
+        onPageClick={() => {}}
+        onRefresh={async () => {}}
+        showDataStreams={true}
+        getDataStreams={getDataStreams}
+        toggleShowDataStreams={() => {}}
+      />
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+
+    const dataStreamsSelection = getByText("Data streams");
+    expect(dataStreamsSelection).not.toBeNull();
+
+    fireEvent.click(dataStreamsSelection);
+    await waitFor(() => expect(getDataStreams).toHaveBeenCalledTimes(1), { timeout: 10000 });
   });
 });

--- a/public/pages/ManagedIndices/components/ManagedIndexControls/ManagedIndexControls.test.tsx
+++ b/public/pages/ManagedIndices/components/ManagedIndexControls/ManagedIndexControls.test.tsx
@@ -41,6 +41,9 @@ describe("<ManagedIndexControls /> spec", () => {
         onSearchChange={() => {}}
         onPageClick={() => {}}
         onRefresh={async () => {}}
+        showDataStreams={false}
+        getDataStreams={async () => {}}
+        toggleShowDataStreams={() => {}}
       />
     );
 
@@ -57,6 +60,9 @@ describe("<ManagedIndexControls /> spec", () => {
         onSearchChange={onSearchChange}
         onPageClick={() => {}}
         onRefresh={async () => {}}
+        showDataStreams={false}
+        getDataStreams={async () => {}}
+        toggleShowDataStreams={() => {}}
       />
     );
 
@@ -75,6 +81,9 @@ describe("<ManagedIndexControls /> spec", () => {
         onSearchChange={() => {}}
         onPageClick={() => {}}
         onRefresh={onRefresh}
+        showDataStreams={false}
+        getDataStreams={async () => {}}
+        toggleShowDataStreams={() => {}}
       />
     );
 

--- a/public/pages/ManagedIndices/components/ManagedIndexControls/ManagedIndexControls.test.tsx
+++ b/public/pages/ManagedIndices/components/ManagedIndexControls/ManagedIndexControls.test.tsx
@@ -65,52 +65,6 @@ describe("<ManagedIndexControls /> spec", () => {
     expect(onSearchChange).toHaveBeenCalledTimes(4);
   });
 
-  it("shows/hides pagination", async () => {
-    const { queryByTestId, rerender } = render(
-      <ManagedIndexControls
-        activePage={0}
-        pageCount={1}
-        search={""}
-        onSearchChange={() => {}}
-        onPageClick={() => {}}
-        onRefresh={async () => {}}
-      />
-    );
-
-    expect(queryByTestId("managedIndexControlsPagination")).toBeNull();
-
-    rerender(
-      <ManagedIndexControls
-        activePage={0}
-        pageCount={2}
-        search={""}
-        onSearchChange={() => {}}
-        onPageClick={() => {}}
-        onRefresh={async () => {}}
-      />
-    );
-
-    expect(queryByTestId("managedIndexControlsPagination")).not.toBeNull();
-  });
-
-  it("calls onPageClick when clicking pagination", async () => {
-    const onPageClick = jest.fn();
-    const { getByTestId } = render(
-      <ManagedIndexControls
-        activePage={0}
-        pageCount={2}
-        search={""}
-        onSearchChange={() => {}}
-        onPageClick={onPageClick}
-        onRefresh={async () => {}}
-      />
-    );
-
-    fireEvent.click(getByTestId("pagination-button-1"));
-
-    expect(onPageClick).toHaveBeenCalledTimes(1);
-  });
-
   it("calls onRefresh on an interval", async () => {
     const onRefresh = jest.fn();
     const { getByTestId } = render(

--- a/public/pages/ManagedIndices/components/ManagedIndexControls/ManagedIndexControls.tsx
+++ b/public/pages/ManagedIndices/components/ManagedIndexControls/ManagedIndexControls.tsx
@@ -93,7 +93,12 @@ export default class ManagedIndexControls extends Component<ManagedIndexControls
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiSwitch label="Show data stream indices" checked={showDataStreams} onChange={toggleShowDataStreams} />
+          <EuiSwitch
+            label="Show data stream indices"
+            checked={showDataStreams}
+            onChange={toggleShowDataStreams}
+            data-test-subj="toggleShowDataStreams"
+          />
         </EuiFlexItem>
         <EuiFlexItem grow={false} style={{ maxWidth: 250 }}>
           <EuiRefreshPicker

--- a/public/pages/ManagedIndices/components/ManagedIndexControls/ManagedIndexControls.tsx
+++ b/public/pages/ManagedIndices/components/ManagedIndexControls/ManagedIndexControls.tsx
@@ -30,12 +30,9 @@ import EuiRefreshPicker from "../../../../temporary/EuiRefreshPicker";
 import { DataStream } from "../../../../../server/models/interfaces";
 
 interface ManagedIndexControlsProps {
-  activePage: number;
-  pageCount: number;
   search: string;
   showDataStreams: boolean;
   onSearchChange: (args: ArgsWithQuery | ArgsWithError) => void;
-  onPageClick: (page: number) => void;
   onRefresh: () => void;
   getDataStreams: () => Promise<DataStream[]>;
   toggleShowDataStreams: () => void;
@@ -56,7 +53,7 @@ export default class ManagedIndexControls extends Component<ManagedIndexControls
   };
 
   render() {
-    const { activePage, pageCount, search, onSearchChange, onPageClick, onRefresh, showDataStreams, toggleShowDataStreams } = this.props;
+    const { search, onSearchChange, onRefresh, showDataStreams, toggleShowDataStreams } = this.props;
     const { refreshInterval, isPaused } = this.state;
 
     const schema = {
@@ -106,16 +103,6 @@ export default class ManagedIndexControls extends Component<ManagedIndexControls
             onRefresh={onRefresh}
           />
         </EuiFlexItem>
-        {pageCount > 1 && (
-          <EuiFlexItem grow={false} style={{ justifyContent: "center" }}>
-            <EuiPagination
-              pageCount={pageCount}
-              activePage={activePage}
-              onPageClick={onPageClick}
-              data-test-subj="managedIndexControlsPagination"
-            />
-          </EuiFlexItem>
-        )}
       </EuiFlexGroup>
     );
   }

--- a/public/pages/ManagedIndices/components/ManagedIndexControls/ManagedIndexControls.tsx
+++ b/public/pages/ManagedIndices/components/ManagedIndexControls/ManagedIndexControls.tsx
@@ -73,7 +73,7 @@ export default class ManagedIndexControls extends Component<ManagedIndexControls
           {
             type: "field_value_selection",
             field: "data_streams",
-            name: "Data Streams",
+            name: "Data streams",
             noOptionsMessage: "No data streams found",
             multiSelect: false,
             cache: 60000,
@@ -93,7 +93,7 @@ export default class ManagedIndexControls extends Component<ManagedIndexControls
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiSwitch label="Show Data Stream Indices" checked={showDataStreams} onChange={toggleShowDataStreams} />
+          <EuiSwitch label="Show data stream indices" checked={showDataStreams} onChange={toggleShowDataStreams} />
         </EuiFlexItem>
         <EuiFlexItem grow={false} style={{ maxWidth: 250 }}>
           <EuiRefreshPicker

--- a/public/pages/ManagedIndices/components/ManagedIndexControls/__snapshots__/ManagedIndexControls.test.tsx.snap
+++ b/public/pages/ManagedIndices/components/ManagedIndexControls/__snapshots__/ManagedIndexControls.test.tsx.snap
@@ -2,45 +2,90 @@
 
 exports[`<ManagedIndexControls /> spec renders the component 1`] = `
 <div
-  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
   style="padding: 0px 5px;"
 >
   <div
     class="euiFlexItem"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
     >
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFlexItem euiSearchBar__searchHolder"
       >
-        <input
-          class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
-          placeholder="Search"
-          type="search"
-          value="testing"
-        />
         <div
-          class="euiFormControlLayoutIcons"
+          class="euiFormControlLayout euiFormControlLayout--fullWidth"
         >
-          <span
-            class="euiFormControlLayoutCustomIcon"
+          <div
+            class="euiFormControlLayout__childrenWrapper"
           >
-            EuiIconMock
-          </span>
-        </div>
-        <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-        >
-          <button
-            aria-label="Clear input"
-            class="euiFormControlLayoutClearButton"
-            type="button"
-          >
-            EuiIconMock
-          </button>
+            <input
+              aria-label="This is a search bar. As you type, the results lower in the page will automatically filter."
+              class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
+              placeholder="Search"
+              type="search"
+              value="testing"
+            />
+            <div
+              class="euiFormControlLayoutIcons"
+            >
+              <span
+                class="euiFormControlLayoutCustomIcon"
+              >
+                EuiIconMock
+              </span>
+            </div>
+            <div
+              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <button
+                aria-label="Clear input"
+                class="euiFormControlLayoutClearButton"
+                type="button"
+              >
+                EuiIconMock
+              </button>
+            </div>
+          </div>
         </div>
       </div>
+    </div>
+  </div>
+  <div
+    class="euiFlexItem euiFlexItem--flexGrowZero"
+  >
+    <div
+      class="euiSwitch"
+    >
+      <button
+        aria-checked="false"
+        aria-labelledby="some_html_id"
+        class="euiSwitch__button"
+        id="some_html_id"
+        role="switch"
+        type="button"
+      >
+        <span
+          class="euiSwitch__body"
+        >
+          <span
+            class="euiSwitch__thumb"
+          />
+          <span
+            class="euiSwitch__track"
+          >
+            EuiIconMock
+            EuiIconMock
+          </span>
+        </span>
+      </button>
+      <span
+        class="euiSwitch__label"
+        id="some_html_id"
+      >
+        Show Data Stream Indices
+      </span>
     </div>
   </div>
   <div

--- a/public/pages/ManagedIndices/components/ManagedIndexControls/__snapshots__/ManagedIndexControls.test.tsx.snap
+++ b/public/pages/ManagedIndices/components/ManagedIndexControls/__snapshots__/ManagedIndexControls.test.tsx.snap
@@ -1,5 +1,180 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<ManagedIndexControls /> spec renders data streams selection field 1`] = `
+<div
+  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+  style="padding: 0px 5px;"
+>
+  <div
+    class="euiFlexItem"
+  >
+    <div
+      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+    >
+      <div
+        class="euiFlexItem euiSearchBar__searchHolder"
+      >
+        <div
+          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+        >
+          <div
+            class="euiFormControlLayout__childrenWrapper"
+          >
+            <input
+              aria-label="This is a search bar. As you type, the results lower in the page will automatically filter."
+              class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
+              placeholder="Search"
+              type="search"
+              value=""
+            />
+            <div
+              class="euiFormControlLayoutIcons"
+            >
+              <span
+                class="euiFormControlLayoutCustomIcon"
+              >
+                EuiIconMock
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiFlexItem euiFlexItem--flexGrowZero euiSearchBar__filtersHolder"
+      >
+        <div
+          class="euiFilterGroup"
+        >
+          <div
+            class="euiPopover euiPopover--anchorDownCenter"
+            id="field_value_selection_0"
+          >
+            <div
+              class="euiPopover__anchor"
+            >
+              <button
+                class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                type="button"
+              >
+                <span
+                  class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                >
+                  EuiIconMock
+                  <span
+                    class="euiButtonEmpty__text"
+                  >
+                    <span
+                      class="euiFilterButton__textShift"
+                      data-text="Data streams"
+                      title="Data streams"
+                    >
+                      Data streams
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiFlexItem euiFlexItem--flexGrowZero"
+  >
+    <div
+      class="euiSwitch"
+    >
+      <button
+        aria-checked="true"
+        aria-labelledby="some_html_id"
+        class="euiSwitch__button"
+        data-test-subj="toggleShowDataStreams"
+        id="some_html_id"
+        role="switch"
+        type="button"
+      >
+        <span
+          class="euiSwitch__body"
+        >
+          <span
+            class="euiSwitch__thumb"
+          />
+          <span
+            class="euiSwitch__track"
+          >
+            EuiIconMock
+            EuiIconMock
+          </span>
+        </span>
+      </button>
+      <span
+        class="euiSwitch__label"
+        id="some_html_id"
+      >
+        Show data stream indices
+      </span>
+    </div>
+  </div>
+  <div
+    class="euiFlexItem euiFlexItem--flexGrowZero"
+    style="max-width: 250px;"
+  >
+    <div
+      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--isAutoRefreshOnly"
+    >
+      <div
+        class="euiFlexItem"
+      >
+        <div
+          class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+        >
+          <div
+            class="euiPopover euiPopover--anchorDownLeft"
+            id="QuickSelectPopover"
+          >
+            <div
+              class="euiPopover__anchor euiQuickSelectPopover__anchor"
+            >
+              <button
+                aria-label="Date quick select"
+                class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                data-test-subj="superDatePickerToggleQuickMenuButton"
+                type="button"
+              >
+                <span
+                  class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                >
+                  EuiIconMock
+                  <span
+                    class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                  >
+                    EuiIconMock
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+          <div
+            class="euiFormControlLayout__childrenWrapper"
+          >
+            <div
+              class="euiDatePickerRange euiDatePickerRange--readOnly euiDatePickerRange--inGroup"
+            >
+              <span
+                class="euiSuperDatePicker__prettyFormat"
+              >
+                Off
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<ManagedIndexControls /> spec renders the component 1`] = `
 <div
   class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
@@ -62,6 +237,7 @@ exports[`<ManagedIndexControls /> spec renders the component 1`] = `
         aria-checked="false"
         aria-labelledby="some_html_id"
         class="euiSwitch__button"
+        data-test-subj="toggleShowDataStreams"
         id="some_html_id"
         role="switch"
         type="button"

--- a/public/pages/ManagedIndices/components/ManagedIndexControls/__snapshots__/ManagedIndexControls.test.tsx.snap
+++ b/public/pages/ManagedIndices/components/ManagedIndexControls/__snapshots__/ManagedIndexControls.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`<ManagedIndexControls /> spec renders the component 1`] = `
         class="euiSwitch__label"
         id="some_html_id"
       >
-        Show Data Stream Indices
+        Show data stream indices
       </span>
     </div>
   </div>

--- a/public/pages/ManagedIndices/containers/ManagedIndices/ManagedIndices.tsx
+++ b/public/pages/ManagedIndices/containers/ManagedIndices/ManagedIndices.tsx
@@ -124,7 +124,7 @@ export default class ManagedIndices extends Component<ManagedIndicesProps, Manag
       },
       {
         field: "dataStream",
-        name: "Data Stream",
+        name: "Data stream",
         sortable: true,
         truncateText: true,
         textOnly: true,
@@ -266,7 +266,7 @@ export default class ManagedIndices extends Component<ManagedIndicesProps, Manag
       this.context.notifications.toasts.addDanger(getErrorMessage(err, "There was a problem loading the managed indices"));
     }
 
-    // Avoiding flicker by showing/hiding the "Data Stream" column only after the results are loaded.
+    // Avoiding flicker by showing/hiding the "Data stream" column only after the results are loaded.
     const { showDataStreams } = this.state;
     this.setState({ loadingManagedIndices: false, isDataStreamColumnVisible: showDataStreams });
   };

--- a/public/pages/ManagedIndices/containers/ManagedIndices/ManagedIndices.tsx
+++ b/public/pages/ManagedIndices/containers/ManagedIndices/ManagedIndices.tsx
@@ -335,11 +335,6 @@ export default class ManagedIndices extends Component<ManagedIndicesProps, Manag
     this.setState({ from: 0, search: queryText, query });
   };
 
-  onPageClick = (page: number): void => {
-    const { size } = this.state;
-    this.setState({ from: page * size });
-  };
-
   onClickModalEdit = (item: ManagedIndexItem, onClose: () => void): void => {
     onClose();
     if (!item || !item.policyId) return;
@@ -457,11 +452,8 @@ export default class ManagedIndices extends Component<ManagedIndicesProps, Manag
 
         <ContentPanel actions={<ContentPanelActions actions={actions} />} bodyStyles={{ padding: "initial" }} title="Indices">
           <ManagedIndexControls
-            activePage={page}
-            pageCount={Math.ceil(totalManagedIndices / size) || 1}
             search={search}
             onSearchChange={this.onSearchChange}
-            onPageClick={this.onPageClick}
             onRefresh={this.getManagedIndices}
             showDataStreams={showDataStreams}
             getDataStreams={this.getDataStreams}

--- a/public/pages/ManagedIndices/containers/ManagedIndices/ManagedIndices.tsx
+++ b/public/pages/ManagedIndices/containers/ManagedIndices/ManagedIndices.tsx
@@ -248,10 +248,9 @@ export default class ManagedIndices extends Component<ManagedIndicesProps, Manag
 
       const getManagedIndicesResponse = await managedIndexService.getManagedIndices({
         ...queryObject,
-        // TODO: enable these once UT failures are fixed
-        // terms: this.getTermClausesFromState(),
-        // indices: this.getFieldClausesFromState("indices"),
-        // dataStreams: this.getFieldClausesFromState("data_streams"),
+        terms: this.getTermClausesFromState(),
+        indices: this.getFieldClausesFromState("indices"),
+        dataStreams: this.getFieldClausesFromState("data_streams"),
       });
 
       if (getManagedIndicesResponse.ok) {
@@ -284,7 +283,7 @@ export default class ManagedIndices extends Component<ManagedIndicesProps, Manag
 
   getFieldClausesFromState = (clause: string): string[] => {
     const { query } = this.state;
-    return (query.ast.getFieldClauses(clause) || []).map((field) => field.value).flat();
+    return _.flatten((query.ast.getFieldClauses(clause) || []).map((field) => field.value));
   };
 
   getTermClausesFromState = (): string[] => {

--- a/public/pages/ManagedIndices/containers/ManagedIndices/__snapshots__/ManagedIndices.test.tsx.snap
+++ b/public/pages/ManagedIndices/containers/ManagedIndices/__snapshots__/ManagedIndices.test.tsx.snap
@@ -178,44 +178,6 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
                 </div>
               </div>
             </div>
-            <div
-              class="euiFlexItem euiFlexItem--flexGrowZero euiSearchBar__filtersHolder"
-            >
-              <div
-                class="euiFilterGroup"
-              >
-                <div
-                  class="euiPopover euiPopover--anchorDownCenter"
-                  id="field_value_selection_0"
-                >
-                  <div
-                    class="euiPopover__anchor"
-                  >
-                    <button
-                      class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
-                      type="button"
-                    >
-                      <span
-                        class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                      >
-                        EuiIconMock
-                        <span
-                          class="euiButtonEmpty__text"
-                        >
-                          <span
-                            class="euiFilterButton__textShift"
-                            data-text="Data Streams"
-                            title="Data Streams"
-                          >
-                            Data Streams
-                          </span>
-                        </span>
-                      </span>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
           </div>
         </div>
         <div
@@ -225,7 +187,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
             class="euiSwitch"
           >
             <button
-              aria-checked="true"
+              aria-checked="false"
               aria-labelledby="some_html_id"
               class="euiSwitch__button"
               id="some_html_id"
@@ -250,7 +212,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
               class="euiSwitch__label"
               id="some_html_id"
             >
-              Show Data Stream Indices
+              Show data stream indices
             </span>
           </div>
         </div>
@@ -451,38 +413,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
                   aria-live="polite"
                   aria-sort="none"
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_dataStream_1"
-                  role="columnheader"
-                  scope="col"
-                  style="width: 120px;"
-                >
-                  <button
-                    class="euiTableHeaderButton"
-                    data-test-subj="tableHeaderSortButton"
-                    type="button"
-                  >
-                    <span
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                        title="Data Stream"
-                      >
-                        Data Stream
-                      </span>
-                      <span
-                        class="euiScreenReaderOnly"
-                      >
-                        Click to sort in ascending order
-                      </span>
-                    </span>
-                  </button>
-                </th>
-                <th
-                  aria-live="polite"
-                  aria-sort="none"
-                  class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_policyId_2"
+                  data-test-subj="tableHeaderCell_policyId_1"
                   role="columnheader"
                   scope="col"
                   style="width: 140px;"
@@ -511,7 +442,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
                 </th>
                 <th
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_managedIndexMetaData.state.name_3"
+                  data-test-subj="tableHeaderCell_managedIndexMetaData.state.name_2"
                   role="columnheader"
                   scope="col"
                   style="width: 150px;"
@@ -529,7 +460,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
                 </th>
                 <th
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_managedIndexMetaData.action.name_4"
+                  data-test-subj="tableHeaderCell_managedIndexMetaData.action.name_3"
                   role="columnheader"
                   scope="col"
                   style="width: 150px;"
@@ -547,7 +478,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
                 </th>
                 <th
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_managedIndexMetaData.info_5"
+                  data-test-subj="tableHeaderCell_managedIndexMetaData.info_4"
                   role="columnheader"
                   scope="col"
                   style="width: 150px;"
@@ -565,7 +496,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
                 </th>
                 <th
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_index_6"
+                  data-test-subj="tableHeaderCell_index_5"
                   role="columnheader"
                   scope="col"
                   style="width: 150px;"
@@ -589,7 +520,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
               >
                 <td
                   class="euiTableRowCell euiTableRowCell--isMobileFullWidth"
-                  colspan="8"
+                  colspan="7"
                 >
                   <div
                     class="euiTableCellContent euiTableCellContent--alignCenter"

--- a/public/pages/ManagedIndices/containers/ManagedIndices/__snapshots__/ManagedIndices.test.tsx.snap
+++ b/public/pages/ManagedIndices/containers/ManagedIndices/__snapshots__/ManagedIndices.test.tsx.snap
@@ -141,34 +141,117 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
       style="padding: initial;"
     >
       <div
-        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
         style="padding: 0px 5px;"
       >
         <div
           class="euiFlexItem"
         >
           <div
-            class="euiFormControlLayout euiFormControlLayout--fullWidth"
+            class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
           >
             <div
-              class="euiFormControlLayout__childrenWrapper"
+              class="euiFlexItem euiSearchBar__searchHolder"
             >
-              <input
-                class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
-                placeholder="Search"
-                type="search"
-                value=""
-              />
               <div
-                class="euiFormControlLayoutIcons"
+                class="euiFormControlLayout euiFormControlLayout--fullWidth"
               >
-                <span
-                  class="euiFormControlLayoutCustomIcon"
+                <div
+                  class="euiFormControlLayout__childrenWrapper"
                 >
-                  EuiIconMock
-                </span>
+                  <input
+                    aria-label="This is a search bar. As you type, the results lower in the page will automatically filter."
+                    class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
+                    placeholder="Search"
+                    type="search"
+                    value=""
+                  />
+                  <div
+                    class="euiFormControlLayoutIcons"
+                  >
+                    <span
+                      class="euiFormControlLayoutCustomIcon"
+                    >
+                      EuiIconMock
+                    </span>
+                  </div>
+                </div>
               </div>
             </div>
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero euiSearchBar__filtersHolder"
+            >
+              <div
+                class="euiFilterGroup"
+              >
+                <div
+                  class="euiPopover euiPopover--anchorDownCenter"
+                  id="field_value_selection_0"
+                >
+                  <div
+                    class="euiPopover__anchor"
+                  >
+                    <button
+                      class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                      type="button"
+                    >
+                      <span
+                        class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                      >
+                        EuiIconMock
+                        <span
+                          class="euiButtonEmpty__text"
+                        >
+                          <span
+                            class="euiFilterButton__textShift"
+                            data-text="Data Streams"
+                            title="Data Streams"
+                          >
+                            Data Streams
+                          </span>
+                        </span>
+                      </span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="euiFlexItem euiFlexItem--flexGrowZero"
+        >
+          <div
+            class="euiSwitch"
+          >
+            <button
+              aria-checked="true"
+              aria-labelledby="some_html_id"
+              class="euiSwitch__button"
+              id="some_html_id"
+              role="switch"
+              type="button"
+            >
+              <span
+                class="euiSwitch__body"
+              >
+                <span
+                  class="euiSwitch__thumb"
+                />
+                <span
+                  class="euiSwitch__track"
+                >
+                  EuiIconMock
+                  EuiIconMock
+                </span>
+              </span>
+            </button>
+            <span
+              class="euiSwitch__label"
+              id="some_html_id"
+            >
+              Show Data Stream Indices
+            </span>
           </div>
         </div>
         <div
@@ -368,10 +451,41 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
                   aria-live="polite"
                   aria-sort="none"
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_policyId_1"
+                  data-test-subj="tableHeaderCell_dataStream_1"
                   role="columnheader"
                   scope="col"
-                  style="width: 150px;"
+                  style="width: 120px;"
+                >
+                  <button
+                    class="euiTableHeaderButton"
+                    data-test-subj="tableHeaderSortButton"
+                    type="button"
+                  >
+                    <span
+                      class="euiTableCellContent"
+                    >
+                      <span
+                        class="euiTableCellContent__text"
+                        title="Data Stream"
+                      >
+                        Data Stream
+                      </span>
+                      <span
+                        class="euiScreenReaderOnly"
+                      >
+                        Click to sort in ascending order
+                      </span>
+                    </span>
+                  </button>
+                </th>
+                <th
+                  aria-live="polite"
+                  aria-sort="none"
+                  class="euiTableHeaderCell"
+                  data-test-subj="tableHeaderCell_policyId_2"
+                  role="columnheader"
+                  scope="col"
+                  style="width: 140px;"
                 >
                   <button
                     class="euiTableHeaderButton"
@@ -397,7 +511,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
                 </th>
                 <th
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_managedIndexMetaData.state.name_2"
+                  data-test-subj="tableHeaderCell_managedIndexMetaData.state.name_3"
                   role="columnheader"
                   scope="col"
                   style="width: 150px;"
@@ -415,7 +529,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
                 </th>
                 <th
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_managedIndexMetaData.action.name_3"
+                  data-test-subj="tableHeaderCell_managedIndexMetaData.action.name_4"
                   role="columnheader"
                   scope="col"
                   style="width: 150px;"
@@ -433,7 +547,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
                 </th>
                 <th
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_managedIndexMetaData.info_4"
+                  data-test-subj="tableHeaderCell_managedIndexMetaData.info_5"
                   role="columnheader"
                   scope="col"
                   style="width: 150px;"
@@ -451,7 +565,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
                 </th>
                 <th
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_index_5"
+                  data-test-subj="tableHeaderCell_index_6"
                   role="columnheader"
                   scope="col"
                   style="width: 150px;"
@@ -475,7 +589,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
               >
                 <td
                   class="euiTableRowCell euiTableRowCell--isMobileFullWidth"
-                  colspan="7"
+                  colspan="8"
                 >
                   <div
                     class="euiTableCellContent euiTableCellContent--alignCenter"

--- a/public/pages/ManagedIndices/containers/ManagedIndices/__snapshots__/ManagedIndices.test.tsx.snap
+++ b/public/pages/ManagedIndices/containers/ManagedIndices/__snapshots__/ManagedIndices.test.tsx.snap
@@ -190,6 +190,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
               aria-checked="false"
               aria-labelledby="some_html_id"
               class="euiSwitch__button"
+              data-test-subj="toggleShowDataStreams"
               id="some_html_id"
               role="switch"
               type="button"

--- a/public/pages/ManagedIndices/models/interfaces.ts
+++ b/public/pages/ManagedIndices/models/interfaces.ts
@@ -33,4 +33,5 @@ export interface ManagedIndicesQueryParams {
   search: string;
   sortField: keyof ManagedIndexItem;
   sortDirection: Direction;
+  showDataStreams: boolean;
 }

--- a/public/pages/ManagedIndices/utils/constants.ts
+++ b/public/pages/ManagedIndices/utils/constants.ts
@@ -33,4 +33,5 @@ export const DEFAULT_QUERY_PARAMS: ManagedIndicesQueryParams = {
   search: "",
   sortField: "index",
   sortDirection: "desc",
+  showDataStreams: true,
 };

--- a/public/pages/ManagedIndices/utils/constants.ts
+++ b/public/pages/ManagedIndices/utils/constants.ts
@@ -33,5 +33,5 @@ export const DEFAULT_QUERY_PARAMS: ManagedIndicesQueryParams = {
   search: "",
   sortField: "index",
   sortDirection: "desc",
-  showDataStreams: true,
+  showDataStreams: false,
 };

--- a/public/pages/ManagedIndices/utils/helpers.ts
+++ b/public/pages/ManagedIndices/utils/helpers.ts
@@ -29,7 +29,7 @@ import { DEFAULT_QUERY_PARAMS } from "./constants";
 import { ManagedIndicesQueryParams } from "../models/interfaces";
 
 export function getURLQueryParams(location: { search: string }): ManagedIndicesQueryParams {
-  const { from, size, search, sortField, sortDirection } = queryString.parse(location.search);
+  const { from, size, search, sortField, sortDirection, showDataStreams } = queryString.parse(location.search);
 
   return <ManagedIndicesQueryParams>{
     // @ts-ignore
@@ -39,5 +39,6 @@ export function getURLQueryParams(location: { search: string }): ManagedIndicesQ
     search: typeof search !== "string" ? DEFAULT_QUERY_PARAMS.search : search,
     sortField: typeof sortField !== "string" ? DEFAULT_QUERY_PARAMS.sortField : sortField,
     sortDirection: typeof sortDirection !== "string" ? DEFAULT_QUERY_PARAMS.sortDirection : sortDirection,
+    showDataStreams: showDataStreams === undefined ? DEFAULT_QUERY_PARAMS.showDataStreams : "true" === showDataStreams,
   };
 }

--- a/public/services/IndexService.test.ts
+++ b/public/services/IndexService.test.ts
@@ -40,6 +40,15 @@ describe("IndexService spec", () => {
     expect(httpClientMock.get).toHaveBeenCalledWith(`..${NODE_API._INDICES}`, { query: queryObject });
   });
 
+  it("calls get data streams nodejs route when calling getDataStreams", async () => {
+    httpClientMock.get = jest.fn().mockResolvedValue({ data: {} });
+    const queryObject = {};
+    await indexService.getDataStreams(queryObject);
+
+    expect(httpClientMock.get).toHaveBeenCalledTimes(1);
+    expect(httpClientMock.get).toHaveBeenCalledWith(`..${NODE_API._DATA_STREAMS}`, { query: queryObject });
+  });
+
   it("calls apply policy nodejs route when calling applyPolicy", async () => {
     httpClientMock.post = jest.fn().mockResolvedValue({ data: {} });
     const indices = ["one", "two"];

--- a/public/services/IndexService.ts
+++ b/public/services/IndexService.ts
@@ -25,7 +25,13 @@
  */
 
 import { HttpFetchQuery, HttpSetup } from "opensearch-dashboards/public";
-import { AcknowledgedResponse, ApplyPolicyResponse, GetIndicesResponse, GetPoliciesResponse } from "../../server/models/interfaces";
+import {
+  AcknowledgedResponse,
+  ApplyPolicyResponse,
+  GetDataStreamsResponse,
+  GetIndicesResponse,
+  GetPoliciesResponse,
+} from "../../server/models/interfaces";
 import { ServerResponse } from "../../server/models/types";
 import { NODE_API } from "../../utils/constants";
 
@@ -40,6 +46,11 @@ export default class IndexService {
     let url = `..${NODE_API._INDICES}`;
     const response = (await this.httpClient.get(url, { query: queryObject })) as ServerResponse<GetIndicesResponse>;
     return response;
+  };
+
+  getDataStreams = async (): Promise<ServerResponse<GetDataStreamsResponse>> => {
+    const url = `..${NODE_API._DATA_STREAMS}`;
+    return await this.httpClient.get(url);
   };
 
   applyPolicy = async (indices: string[], policyId: string): Promise<ServerResponse<ApplyPolicyResponse>> => {

--- a/public/services/IndexService.ts
+++ b/public/services/IndexService.ts
@@ -48,9 +48,9 @@ export default class IndexService {
     return response;
   };
 
-  getDataStreams = async (): Promise<ServerResponse<GetDataStreamsResponse>> => {
+  getDataStreams = async (queryObject: HttpFetchQuery): Promise<ServerResponse<GetDataStreamsResponse>> => {
     const url = `..${NODE_API._DATA_STREAMS}`;
-    return await this.httpClient.get(url);
+    return await this.httpClient.get(url, { query: queryObject });
   };
 
   applyPolicy = async (indices: string[], policyId: string): Promise<ServerResponse<ApplyPolicyResponse>> => {

--- a/public/services/ManagedIndexService.test.ts
+++ b/public/services/ManagedIndexService.test.ts
@@ -49,6 +49,14 @@ describe("ManagedIndexService spec", () => {
     expect(httpClientMock.get).toHaveBeenCalledWith(`..${NODE_API.MANAGED_INDICES}`, { query: queryObject });
   });
 
+  it("calls get data streams nodejs route when calling getDataStreams", async () => {
+    httpClientMock.get = jest.fn().mockResolvedValue({ data: {} });
+    await managedIndexService.getDataStreams();
+
+    expect(httpClientMock.get).toHaveBeenCalledTimes(1);
+    expect(httpClientMock.get).toHaveBeenCalledWith(`..${NODE_API._DATA_STREAMS}`);
+  });
+
   it("calls retry policy nodejs route when calling retryManagedIndexPolicy", async () => {
     httpClientMock.post = jest.fn().mockResolvedValue({ data: {} });
     const index = ["one", "two"];

--- a/public/services/ManagedIndexService.ts
+++ b/public/services/ManagedIndexService.ts
@@ -27,6 +27,7 @@
 import { HttpSetup } from "opensearch-dashboards/public";
 import {
   ChangePolicyResponse,
+  GetDataStreamsResponse,
   GetManagedIndicesResponse,
   RemovePolicyResponse,
   RetryManagedIndexResponse,
@@ -50,6 +51,11 @@ export default class ManagedIndexService {
     let url = `..${NODE_API.MANAGED_INDICES}`;
     const response = (await this.httpClient.get(url, { query: queryObject })) as ServerResponse<GetManagedIndicesResponse>;
     return response;
+  };
+
+  getDataStreams = async (): Promise<ServerResponse<GetDataStreamsResponse>> => {
+    const url = `..${NODE_API._DATA_STREAMS}`;
+    return await this.httpClient.get(url);
   };
 
   retryManagedIndexPolicy = async (index: string[], state: string | null): Promise<ServerResponse<RetryManagedIndexResponse>> => {

--- a/server/models/interfaces.ts
+++ b/server/models/interfaces.ts
@@ -89,6 +89,11 @@ export interface GetDataStreamsResponse {
   totalDataStreams: number;
 }
 
+export interface GetDataStreamsAndIndicesNamesResponse {
+  dataStreams: string[];
+  indices: string[];
+}
+
 export interface GetFieldsResponse {
   result: string;
 }

--- a/server/models/interfaces.ts
+++ b/server/models/interfaces.ts
@@ -24,11 +24,12 @@
  * permissions and limitations under the License.
  */
 
-import { IndexService, ManagedIndexService, PolicyService, RollupService, TransformService } from "../services";
+import { DataStreamService, IndexService, ManagedIndexService, PolicyService, RollupService, TransformService } from "../services";
 import { DocumentPolicy, DocumentRollup, DocumentTransform, ManagedIndexItem, Rollup, Transform } from "../../models/interfaces";
 
 export interface NodeServices {
   indexService: IndexService;
+  dataStreamService: DataStreamService;
   managedIndexService: ManagedIndexService;
   policyService: PolicyService;
   rollupService: RollupService;
@@ -81,6 +82,11 @@ export interface DeleteRollupResponse {
 export interface GetIndicesResponse {
   indices: ManagedCatIndex[];
   totalIndices: number;
+}
+
+export interface GetDataStreamsResponse {
+  dataStreams: DataStream[];
+  totalDataStreams: number;
 }
 
 export interface GetFieldsResponse {
@@ -284,8 +290,27 @@ export interface CatIndex {
   status: string;
   "store.size": string;
   uuid: string;
+  data_stream: string | null;
 }
 
 export interface ManagedCatIndex extends CatIndex {
   managed: string;
+}
+
+export interface DataStream {
+  name: string;
+  timestamp_field: DataStreamTimestampField;
+  indices: DataStreamIndex[];
+  generation: number;
+  status: string;
+  template?: string;
+}
+
+export interface DataStreamTimestampField {
+  name: string;
+}
+
+export interface DataStreamIndex {
+  index_name: string;
+  index_uuid: string;
 }

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -27,8 +27,9 @@
 import { IndexManagementPluginSetup, IndexManagementPluginStart } from ".";
 import { Plugin, CoreSetup, CoreStart, ILegacyCustomClusterClient } from "../../../src/core/server";
 import ismPlugin from "./clusters/ism/ismPlugin";
-import { PolicyService, ManagedIndexService, IndexService, RollupService, TransformService } from "./services";
+import { PolicyService, ManagedIndexService, IndexService, RollupService, TransformService, DataStreamService } from "./services";
 import { indices, policies, managedIndices, rollups, transforms } from "../server/routes";
+import dataStreams from "./routes/dataStreams";
 
 export class IndexPatternManagementPlugin implements Plugin<IndexManagementPluginSetup, IndexManagementPluginStart> {
   public async setup(core: CoreSetup) {
@@ -39,16 +40,18 @@ export class IndexPatternManagementPlugin implements Plugin<IndexManagementPlugi
 
     // Initialize services
     const indexService = new IndexService(osDriver);
+    const dataStreamService = new DataStreamService(osDriver);
     const policyService = new PolicyService(osDriver);
     const managedIndexService = new ManagedIndexService(osDriver);
     const rollupService = new RollupService(osDriver);
     const transformService = new TransformService(osDriver);
-    const services = { indexService, policyService, managedIndexService, rollupService, transformService };
+    const services = { indexService, dataStreamService, policyService, managedIndexService, rollupService, transformService };
 
     // create router
     const router = core.http.createRouter();
     // Add server routes
     indices(services, router);
+    dataStreams(services, router);
     policies(services, router);
     managedIndices(services, router);
     rollups(services, router);

--- a/server/routes/dataStreams.ts
+++ b/server/routes/dataStreams.ts
@@ -9,6 +9,7 @@
  * GitHub history for details.
  */
 
+import { schema } from "@osd/config-schema";
 import { NodeServices } from "../models/interfaces";
 import { NODE_API } from "../../utils/constants";
 import { IRouter } from "../../../../src/core/server";
@@ -19,7 +20,11 @@ export default function (services: NodeServices, router: IRouter) {
   router.get(
     {
       path: NODE_API._DATA_STREAMS,
-      validate: {},
+      validate: {
+        query: schema.object({
+          search: schema.maybe(schema.string()),
+        }),
+      },
     },
     dataStreamService.getDataStreams
   );

--- a/server/routes/dataStreams.ts
+++ b/server/routes/dataStreams.ts
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { NodeServices } from "../models/interfaces";
+import { NODE_API } from "../../utils/constants";
+import { IRouter } from "../../../../src/core/server";
+
+export default function (services: NodeServices, router: IRouter) {
+  const { dataStreamService } = services;
+
+  router.get(
+    {
+      path: NODE_API._DATA_STREAMS,
+      validate: {},
+    },
+    dataStreamService.getDataStreams
+  );
+}

--- a/server/routes/indices.ts
+++ b/server/routes/indices.ts
@@ -55,7 +55,7 @@ export default function (services: NodeServices, router: IRouter) {
           terms: schema.maybe(schema.any()),
           indices: schema.maybe(schema.any()),
           dataStreams: schema.maybe(schema.any()),
-          showDataStreams: schema.maybe(schema.boolean()), // TODO: remove maybe
+          showDataStreams: schema.boolean(),
         }),
       },
     },

--- a/server/routes/indices.ts
+++ b/server/routes/indices.ts
@@ -52,6 +52,10 @@ export default function (services: NodeServices, router: IRouter) {
           search: schema.string(),
           sortField: schema.string(),
           sortDirection: schema.string(),
+          terms: schema.maybe(schema.any()),
+          indices: schema.maybe(schema.any()),
+          dataStreams: schema.maybe(schema.any()),
+          showDataStreams: schema.maybe(schema.boolean()), // TODO: remove maybe
         }),
       },
     },

--- a/server/routes/managedIndices.ts
+++ b/server/routes/managedIndices.ts
@@ -45,7 +45,7 @@ export default function (services: NodeServices, router: IRouter) {
           terms: schema.maybe(schema.any()),
           indices: schema.maybe(schema.any()),
           dataStreams: schema.maybe(schema.any()),
-          showDataStreams: schema.maybe(schema.boolean()), // TODO: remove maybe
+          showDataStreams: schema.boolean(),
         }),
       },
     },

--- a/server/routes/managedIndices.ts
+++ b/server/routes/managedIndices.ts
@@ -42,6 +42,10 @@ export default function (services: NodeServices, router: IRouter) {
           search: schema.string(),
           sortField: schema.string(),
           sortDirection: schema.string(),
+          terms: schema.maybe(schema.any()),
+          indices: schema.maybe(schema.any()),
+          dataStreams: schema.maybe(schema.any()),
+          showDataStreams: schema.maybe(schema.boolean()), // TODO: remove maybe
         }),
       },
     },

--- a/server/services/DataStreamService.ts
+++ b/server/services/DataStreamService.ts
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import {
+  RequestHandlerContext,
+  OpenSearchDashboardsRequest,
+  OpenSearchDashboardsResponseFactory,
+  IOpenSearchDashboardsResponse,
+  ILegacyCustomClusterClient,
+  ILegacyScopedClusterClient,
+} from "opensearch-dashboards/server";
+import { ServerResponse } from "../models/types";
+import { DataStream, GetDataStreamsResponse } from "../models/interfaces";
+
+export default class DataStreamService {
+  osDriver: ILegacyCustomClusterClient;
+
+  constructor(osDriver: ILegacyCustomClusterClient) {
+    this.osDriver = osDriver;
+  }
+
+  getDataStreams = async (
+    context: RequestHandlerContext,
+    request: OpenSearchDashboardsRequest,
+    response: OpenSearchDashboardsResponseFactory
+  ): Promise<IOpenSearchDashboardsResponse<ServerResponse<GetDataStreamsResponse>>> => {
+    try {
+      const client = this.osDriver.asScoped(request);
+      const dataStreams = await getDataStreams(client);
+
+      return response.custom({
+        statusCode: 200,
+        body: {
+          ok: true,
+          response: {
+            dataStreams: dataStreams,
+            totalDataStreams: dataStreams.length,
+          },
+        },
+      });
+    } catch (err) {
+      console.error("Index Management - DataStreamService - getDataStreams:", err);
+      return response.custom({
+        statusCode: 200,
+        body: {
+          ok: false,
+          error: err.message,
+        },
+      });
+    }
+  };
+}
+
+export async function getDataStreams({ callAsCurrentUser: callWithRequest }: ILegacyScopedClusterClient): Promise<DataStream[]> {
+  const dataStreamsResponse = await callWithRequest("transport.request", {
+    path: "/_data_stream",
+    method: "GET",
+  });
+
+  return dataStreamsResponse["data_streams"];
+}
+
+export async function getIndexToDataStreamMapping({
+  callAsCurrentUser: callWithRequest,
+}: ILegacyScopedClusterClient): Promise<{ [indexName: string]: string }> {
+  const dataStreams: DataStream[] = await getDataStreams({ callAsCurrentUser: callWithRequest });
+
+  const mapping: { [indexName: string]: string } = {};
+  dataStreams.forEach((dataStream) => {
+    dataStream.indices.forEach((index) => {
+      mapping[index.index_name] = dataStream.name;
+    });
+  });
+
+  return mapping;
+}

--- a/server/services/DataStreamService.ts
+++ b/server/services/DataStreamService.ts
@@ -33,8 +33,12 @@ export default class DataStreamService {
     response: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<ServerResponse<GetDataStreamsResponse>>> => {
     try {
+      const { search } = request.query as {
+        search?: string;
+      };
+
       const client = this.osDriver.asScoped(request);
-      const dataStreams = await getDataStreams(client);
+      const dataStreams = await getDataStreams(client, search);
 
       return response.custom({
         statusCode: 200,
@@ -59,9 +63,14 @@ export default class DataStreamService {
   };
 }
 
-export async function getDataStreams({ callAsCurrentUser: callWithRequest }: ILegacyScopedClusterClient): Promise<DataStream[]> {
+export async function getDataStreams(
+  { callAsCurrentUser: callWithRequest }: ILegacyScopedClusterClient,
+  search?: string
+): Promise<DataStream[]> {
+  const searchPattern = search ? `*${search}*` : "*";
+
   const dataStreamsResponse = await callWithRequest("transport.request", {
-    path: "/_data_stream",
+    path: `/_data_stream/${searchPattern}`,
     method: "GET",
   });
 

--- a/server/services/IndexService.ts
+++ b/server/services/IndexService.ts
@@ -74,7 +74,6 @@ export default class IndexService {
         index: getSearchString(terms, indices, dataStreams),
         format: "json",
         s: `${sortField}:${sortDirection}`,
-        expand_wildcards: "all",
       };
 
       const { callAsCurrentUser: callWithRequest } = this.osDriver.asScoped(request);

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -25,9 +25,10 @@
  */
 
 import IndexService from "./IndexService";
+import DataStreamService from "./DataStreamService";
 import PolicyService from "./PolicyService";
 import ManagedIndexService from "./ManagedIndexService";
 import RollupService from "./RollupService";
 import TransformService from "./TransformService";
 
-export { IndexService, PolicyService, ManagedIndexService, RollupService, TransformService };
+export { IndexService, DataStreamService, PolicyService, ManagedIndexService, RollupService, TransformService };

--- a/server/utils/helpers.ts
+++ b/server/utils/helpers.ts
@@ -24,6 +24,7 @@
  * permissions and limitations under the License.
  */
 
+import _ from "lodash";
 import { ExplainAPIManagedIndexMetaData, QueryStringQuery } from "../models/interfaces";
 import { MatchAllQuery } from "../models/types";
 import { ManagedIndexMetaData } from "../../models/interfaces";
@@ -77,11 +78,11 @@ export function getMustQuery<T extends string>(field: T, search: string): MatchA
 
 export function getSearchString(terms?: string[], indices?: string[], dataStreams?: string[]): string {
   // Terms are searched with a wildcard around them.
-  const searchTerms = terms ? `*${[terms].flat().join("*,*")}*` : "";
+  const searchTerms = terms ? `*${_.castArray(terms).join("*,*")}*` : "";
 
   // Indices and data streams are searched with an exact match.
-  const searchIndices = indices ? [indices].flat().join(",") : "";
-  const searchDataStreams = dataStreams ? [dataStreams].flat().join(",") : "";
+  const searchIndices = indices ? _.castArray(indices).join(",") : "";
+  const searchDataStreams = dataStreams ? _.castArray(dataStreams).join(",") : "";
 
   // The overall search string is a combination of terms, indices, and data streams.
   // If the search string is blank, then '*' is used to match everything.

--- a/server/utils/helpers.ts
+++ b/server/utils/helpers.ts
@@ -74,3 +74,16 @@ export function getMustQuery<T extends string>(field: T, search: string): MatchA
 
   return { match_all: {} };
 }
+
+export function getSearchString(terms?: string[], indices?: string[], dataStreams?: string[]): string {
+  // Terms are searched with a wildcard around them.
+  const searchTerms = terms ? `*${[terms].flat().join("*,*")}*` : "";
+
+  // Indices and data streams are searched with an exact match.
+  const searchIndices = indices ? [indices].flat().join(",") : "";
+  const searchDataStreams = dataStreams ? [dataStreams].flat().join(",") : "";
+
+  // The overall search string is a combination of terms, indices, and data streams.
+  // If the search string is blank, then '*' is used to match everything.
+  return [searchTerms, searchIndices, searchDataStreams].filter((value) => value !== "").join(",") || "*";
+}

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -29,6 +29,7 @@ export const NODE_API = Object.freeze({
   _SEARCH: `${BASE_API_PATH}/_search`,
   _SEARCH_SAMPLE_DATA: `${BASE_API_PATH}/_searchSampleData`,
   _INDICES: `${BASE_API_PATH}/_indices`,
+  _DATA_STREAMS: `${BASE_API_PATH}/_data_streams`,
   _MAPPINGS: `${BASE_API_PATH}/_mappings`,
   APPLY_POLICY: `${BASE_API_PATH}/applyPolicy`,
   EDIT_ROLLOVER_ALIAS: `${BASE_API_PATH}/editRolloverAlias`,


### PR DESCRIPTION
### Description
+ Added an additional column to show the name of the parent data stream.
+ Added a toggle switch to show/hide indices belonging to a data stream.
+ Added a multi-select drop-down to easily filter indices belonging to one or more data streams.
+ Disabled 'Edit Rollover Alias' option when managing the backing index of a data stream.
+ Removed redundant pagination options from top of the table to allow space for other options.

### Issues Resolved
+ Closes https://github.com/opensearch-project/index-management-dashboards-plugin/issues/22


By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file; or

(b) The contribution is based upon previous work that, to the best
of my knowledge, is covered under an appropriate open source
license and I have the right under that license to submit that
work with modifications, whether created in whole or in part
by me, under the same open source license (unless I am
permitted to submit under a different license), as indicated
in the file; or

(c) The contribution was provided directly to me by some other
person who certified (a), (b) or (c) and I have not modified
it.

(d) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check here.

Signed-off-by: Ketan Verma ketan9495@gmail.com