### PR TITLE
Adding support to correctly set the dashboards and opensearch endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Unit tests](https://github.com/opensearch-project/index-management-dashboards-plugin/workflows/Unit%20tests%20workflow/badge.svg)](https://github.com/opensearch-project/index-management-dashboards-plugin/actions?query=workflow%3A%22Unit+tests+workflow%22)
 [![Integration tests](https://github.com/opensearch-project/index-management-dashboards-plugin/workflows/E2E%20tests%20workflow/badge.svg)](https://github.com/opensearch-project/index-management-dashboards-plugin/actions?query=workflow%3A%22E2E+tests+workflow%22)
 [![codecov](https://codecov.io/gh/opensearch-project/index-management-dashboards-plugin/branch/main/graph/badge.svg)](https://codecov.io/gh/opensearch-project/index-management-dashboards-plugin)
-[![Documentation](https://img.shields.io/badge/doc-reference-blue)](https://docs-beta.opensearch.org/monitoring-plugins/ad/index/)
+[![Documentation](https://img.shields.io/badge/doc-reference-blue)](https://opensearch.org/docs/im-plugin/index/)
 [![Forum](https://img.shields.io/badge/chat-on%20forums-blue)](https://discuss.opendistrocommunity.dev/c/Use-this-category-for-all-questions-around-machine-learning-plugins)
 ![PRs welcome!](https://img.shields.io/badge/PRs-welcome!-success)
 
@@ -21,7 +21,7 @@ The Index Management Dashboards plugin lets you manage your [Index Management Da
 
 ## Documentation
 
-Please see our [documentation](https://docs-beta.opensearch.org/monitoring-plugins/ad/index/).
+Please see our [documentation](https://opensearch.org/docs/im-plugin/index/).
 
 ## Contributing
 

--- a/cypress.json
+++ b/cypress.json
@@ -3,8 +3,8 @@
   "viewportWidth": 1440,
   "defaultCommandTimeout": 10000,
   "env": {
-    "opensearch": "localhost:9200",
-    "opensearch_dashboards": "localhost:5601",
+    "opensearch_url": "localhost:9200",
+    "opensearch_dashboards_url": "localhost:5601",
     "security_enabled": false
   }
 }

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -45,7 +45,11 @@ import "./commands";
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 
-// Switch the base URL of Opensearch when security enabled in the cluster
+// Switch the HTTPS url of Opensearch and Dashboards when security enabled in the cluster
 if (Cypress.env("security_enabled")) {
-  Cypress.env("opensearch", "https://localhost:9200");
+  Cypress.env("opensearch", `https://${Cypress.env("opensearch_url")}`);
+  Cypress.env("opensearch_dashboards", `https://${Cypress.env("opensearch_dasbhoards_url")}`);
+} else {
+  Cypress.env("opensearch", `http://${Cypress.env("opensearch_url")}`);
+  Cypress.env("opensearch_dashboards", `http://${Cypress.env("opensearch_dashboards_url")}`);
 }


### PR DESCRIPTION
### Description

* Provide mechanism to set the OpenSearch and Dashboards endpoint when running cypress tests.
* Fix broken link

### Issues Resolved

N/A

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

