### PR TITLE
Adds a small Badge component

### DIFF
--- a/public/pages/VisualCreatePolicy/components/Badge/Badge.test.tsx
+++ b/public/pages/VisualCreatePolicy/components/Badge/Badge.test.tsx
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render } from "@testing-library/react";
+import Badge from "./Badge";
+
+describe("<Badge /> spec", () => {
+  it("renders the component", () => {
+    const { container } = render(<Badge text="Some text" number={2} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/public/pages/VisualCreatePolicy/components/Badge/Badge.tsx
+++ b/public/pages/VisualCreatePolicy/components/Badge/Badge.tsx
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from "react";
+import { EuiText, EuiNotificationBadge, EuiTextColor } from "@elastic/eui";
+
+interface BadgeProps {
+  text: string;
+  number: number;
+  color?: "subdued" | "accent" | undefined;
+}
+
+const Badge = ({ text, number, color = "subdued" }: BadgeProps) => (
+  <EuiText size="xs" textAlign="center">
+    <EuiTextColor color={color}>
+      <p>
+        {text}{" "}
+        <EuiNotificationBadge size="s" color={color}>
+          {number}
+        </EuiNotificationBadge>
+      </p>
+    </EuiTextColor>
+  </EuiText>
+);
+
+export default Badge;

--- a/public/pages/VisualCreatePolicy/components/Badge/__snapshots__/Badge.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/Badge/__snapshots__/Badge.test.tsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Badge /> spec renders the component 1`] = `
+<div
+  class="euiText euiText--extraSmall"
+>
+  <div
+    class="euiTextAlign euiTextAlign--center"
+  >
+    <span
+      class="euiTextColor euiTextColor--subdued"
+    >
+      <p>
+        Some text
+         
+        <span
+          class="euiNotificationBadge euiNotificationBadge--subdued"
+        >
+          2
+        </span>
+      </p>
+    </span>
+  </div>
+</div>
+`;

--- a/public/pages/VisualCreatePolicy/components/Badge/index.ts
+++ b/public/pages/VisualCreatePolicy/components/Badge/index.ts
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import Badge from "./Badge";
+
+export default Badge;


### PR DESCRIPTION
Signed-off-by: Drew Baugher <46505179+dbbaughe@users.noreply.github.com>

### Description

Adds a small badge component to show number of actions and transitions in new visual UI

![Screen Shot 2021-08-10 at 9 33 02 AM](https://user-images.githubusercontent.com/46505179/128898240-bec529d7-1c10-4635-aead-51aa36a06e80.png)

File                                                                                  | % Stmts | % Branch | % Funcs | % Lines |
--------------------------------------------------------------------------------------|---------|----------|---------|---------|
Before All files                                                                             |   47.84 |    41.09 |   44.05 |   48.38 |
After All files                                                                             |   47.88 |    41.14 |   44.11 |   48.42 |                                                                                                                
Badge.tsx                                                                           |     100 |      100 |     100 |     100 |                                                                                                                

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

