### PR TITLE
Adds custom label to use with EuiForm component

### DIFF
--- a/public/pages/VisualCreatePolicy/components/EuiFormCustomLabel/EuiFormCustomLabel.test.tsx
+++ b/public/pages/VisualCreatePolicy/components/EuiFormCustomLabel/EuiFormCustomLabel.test.tsx
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render } from "@testing-library/react";
+import EuiFormCustomLabel from "./EuiFormCustomLabel";
+
+describe("<EuiFormCustomLabel /> spec", () => {
+  it("renders the component", () => {
+    const { container } = render(<EuiFormCustomLabel title="Some title" helpText="Some helpful text" />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/public/pages/VisualCreatePolicy/components/EuiFormCustomLabel/EuiFormCustomLabel.tsx
+++ b/public/pages/VisualCreatePolicy/components/EuiFormCustomLabel/EuiFormCustomLabel.tsx
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from "react";
+import { EuiText } from "@elastic/eui";
+
+interface EuiFormCustomLabelProps {
+  title: string;
+  helpText?: string;
+  textStyle?: object;
+  headerStyle?: object;
+}
+
+// New pattern for label and help text both being above the form row instead of label above and help below.
+const EuiFormCustomLabel = ({
+  title,
+  helpText,
+  textStyle = { marginBottom: "5px" },
+  headerStyle = { marginBottom: "2px" },
+}: EuiFormCustomLabelProps) => (
+  <EuiText style={textStyle}>
+    <h5 style={headerStyle}>{title}</h5>
+    <p>
+      {" "}
+      {/* Keep the <p> tag even if no helpText to remove last child styling on h tags */}
+      {helpText && <span style={{ color: "grey", fontWeight: 200, fontSize: "12px" }}>{helpText}</span>}
+    </p>
+  </EuiText>
+);
+
+export default EuiFormCustomLabel;

--- a/public/pages/VisualCreatePolicy/components/EuiFormCustomLabel/__snapshots__/EuiFormCustomLabel.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/EuiFormCustomLabel/__snapshots__/EuiFormCustomLabel.test.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<EuiFormCustomLabel /> spec renders the component 1`] = `
+<div
+  class="euiText euiText--medium"
+  style="margin-bottom: 5px;"
+>
+  <h5
+    style="margin-bottom: 2px;"
+  >
+    Some title
+  </h5>
+  <p>
+     
+    <span
+      style="color: grey; font-weight: 200; font-size: 12px;"
+    >
+      Some helpful text
+    </span>
+  </p>
+</div>
+`;

--- a/public/pages/VisualCreatePolicy/components/EuiFormCustomLabel/index.ts
+++ b/public/pages/VisualCreatePolicy/components/EuiFormCustomLabel/index.ts
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import EuiFormCustomLabel from "./EuiFormCustomLabel";
+
+export default EuiFormCustomLabel;


### PR DESCRIPTION
Signed-off-by: Drew Baugher <46505179+dbbaughe@users.noreply.github.com>

### Description

UI/UX team wanted to move help text under title instead of below input. EuiForm component didn't support that, so this is just a small custom label component to use instead.

![Screen Shot 2021-08-10 at 9 45 17 AM](https://user-images.githubusercontent.com/46505179/128899948-049fac7a-0ca9-4c06-b6fc-6406c6317b2f.png)


File                                                                                  | % Stmts | % Branch | % Funcs | % Lines |
--------------------------------------------------------------------------------------|---------|----------|---------|---------|
Before All files                                                                             |   47.84 |    41.09 |   44.05 |   48.38 |
After All files                                                                             |   47.88 |    41.29 |   44.11 |   48.42 |                                                                                                                
EuiFormCustomLabel.tsx                                                              |     100 |      100 |     100 |     100 |                                                                                                                

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

