### PR TITLE
Adds reusable flyout footer

### DIFF
--- a/public/pages/VisualCreatePolicy/components/FlyoutFooter/FlyoutFooter.test.tsx
+++ b/public/pages/VisualCreatePolicy/components/FlyoutFooter/FlyoutFooter.test.tsx
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render } from "@testing-library/react";
+import FlyoutFooter from "./FlyoutFooter";
+import { fireEvent } from "@testing-library/dom";
+
+describe("<FlyoutFooter /> spec", () => {
+  it("renders the component", () => {
+    const { container } = render(<FlyoutFooter edit={true} action="action" onClickAction={() => {}} onClickCancel={() => {}} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("calls onClickAction  with clicking action button", async () => {
+    const onClickAction = jest.fn();
+    const { getByTestId } = render(<FlyoutFooter edit={true} action="action" onClickAction={onClickAction} onClickCancel={() => {}} />);
+
+    fireEvent.click(getByTestId("flyout-footer-action-button"));
+    expect(onClickAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClickCancel  with clicking cancel button", async () => {
+    const onClickCancel = jest.fn();
+    const { getByTestId } = render(<FlyoutFooter edit={true} action="action" onClickAction={() => {}} onClickCancel={onClickCancel} />);
+
+    fireEvent.click(getByTestId("flyout-footer-cancel-button"));
+    expect(onClickCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/public/pages/VisualCreatePolicy/components/FlyoutFooter/FlyoutFooter.tsx
+++ b/public/pages/VisualCreatePolicy/components/FlyoutFooter/FlyoutFooter.tsx
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from "react";
+import { EuiFlexGroup, EuiFlexItem, EuiButtonEmpty, EuiButton } from "@elastic/eui";
+
+interface FlyoutFooterProps {
+  edit: boolean;
+  action: string;
+  disabledAction?: boolean;
+  onClickCancel: () => void;
+  onClickAction: () => void;
+}
+
+const FlyoutFooter = ({ edit, action, disabledAction = false, onClickCancel, onClickAction }: FlyoutFooterProps) => (
+  <EuiFlexGroup justifyContent="spaceBetween">
+    <EuiFlexItem grow={false}>
+      <EuiButtonEmpty iconType="cross" onClick={onClickCancel} flush="left" data-test-subj="flyout-footer-cancel-button">
+        Cancel
+      </EuiButtonEmpty>
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiButton disabled={disabledAction} onClick={onClickAction} fill data-test-subj="flyout-footer-action-button">
+        {`${edit ? "Edit" : "Add"} ${action}`}
+      </EuiButton>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+);
+
+export default FlyoutFooter;

--- a/public/pages/VisualCreatePolicy/components/FlyoutFooter/__snapshots__/FlyoutFooter.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/FlyoutFooter/__snapshots__/FlyoutFooter.test.tsx.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<FlyoutFooter /> spec renders the component 1`] = `
+<div
+  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+>
+  <div
+    class="euiFlexItem euiFlexItem--flexGrowZero"
+  >
+    <button
+      class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--flushLeft"
+      data-test-subj="flyout-footer-cancel-button"
+      type="button"
+    >
+      <span
+        class="euiButtonContent euiButtonEmpty__content"
+      >
+        EuiIconMock
+        <span
+          class="euiButtonEmpty__text"
+        >
+          Cancel
+        </span>
+      </span>
+    </button>
+  </div>
+  <div
+    class="euiFlexItem euiFlexItem--flexGrowZero"
+  >
+    <button
+      class="euiButton euiButton--primary euiButton--fill"
+      data-test-subj="flyout-footer-action-button"
+      type="button"
+    >
+      <span
+        class="euiButtonContent euiButton__content"
+      >
+        <span
+          class="euiButton__text"
+        >
+          Edit action
+        </span>
+      </span>
+    </button>
+  </div>
+</div>
+`;

--- a/public/pages/VisualCreatePolicy/components/FlyoutFooter/index.ts
+++ b/public/pages/VisualCreatePolicy/components/FlyoutFooter/index.ts
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import FlyoutFooter from "./FlyoutFooter";
+
+export default FlyoutFooter;


### PR DESCRIPTION
Signed-off-by: Drew Baugher <46505179+dbbaughe@users.noreply.github.com>

### Description

Adds a reusable flyout footer as we have multiple "views" of the flyout for creation flow.

![Screen Shot 2021-08-10 at 9 54 55 AM](https://user-images.githubusercontent.com/46505179/128901677-df6a9f7e-db98-4ba6-bc0f-a238f76ca39e.png)

File                                                                                  | % Stmts | % Branch | % Funcs | % Lines |
--------------------------------------------------------------------------------------|---------|----------|---------|---------|
Before All files                                                                             |   47.84 |    41.09 |   44.05 |   48.38 |
After All files                                                                             |   47.88 |    41.16 |   44.11 |   48.42 |                                                                                                                
FlyoutFooter.tsx                                                                    |     100 |    66.67 |     100 |     100 | 32                                                                                                             

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

