### PR TITLE
Adds policy info section for new UI

### DIFF
--- a/public/pages/VisualCreatePolicy/components/PolicyInfo/PolicyInfo.test.tsx
+++ b/public/pages/VisualCreatePolicy/components/PolicyInfo/PolicyInfo.test.tsx
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render } from "@testing-library/react";
+import PolicyInfo from "./PolicyInfo";
+import { fireEvent } from "@testing-library/dom";
+import userEvent from "@testing-library/user-event/dist";
+
+describe("<PolicyInfo /> spec", () => {
+  it("renders the component", () => {
+    const { container } = render(
+      <PolicyInfo
+        isEdit={false}
+        policyId="some_id"
+        policyIdError=""
+        description="some description"
+        onChangePolicyId={() => {}}
+        onChangeDescription={() => {}}
+      />
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("calls on change policy id when typing in input", () => {
+    const onChangePolicyId = jest.fn();
+    const { getByTestId } = render(
+      <PolicyInfo
+        isEdit={false}
+        policyId="some_id"
+        policyIdError=""
+        description="some description"
+        onChangePolicyId={onChangePolicyId}
+        onChangeDescription={() => {}}
+      />
+    );
+
+    fireEvent.focus(getByTestId("create-policy-policy-id"));
+    userEvent.type(getByTestId("create-policy-policy-id"), `some_policy_id`);
+    expect(onChangePolicyId).toHaveBeenCalled();
+  });
+
+  it("calls on change description when typing in input", () => {
+    const onChangeDescription = jest.fn();
+    const { getByTestId } = render(
+      <PolicyInfo
+        isEdit={false}
+        policyId="some_id"
+        policyIdError=""
+        description="some description"
+        onChangePolicyId={() => {}}
+        onChangeDescription={onChangeDescription}
+      />
+    );
+
+    fireEvent.focus(getByTestId("create-policy-description"));
+    userEvent.type(getByTestId("create-policy-description"), `some description`);
+    expect(onChangeDescription).toHaveBeenCalled();
+  });
+});

--- a/public/pages/VisualCreatePolicy/components/PolicyInfo/PolicyInfo.tsx
+++ b/public/pages/VisualCreatePolicy/components/PolicyInfo/PolicyInfo.tsx
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React, { ChangeEvent } from "react";
+import { EuiSpacer, EuiFormRow, EuiFieldText, EuiTextArea } from "@elastic/eui";
+import { ContentPanel } from "../../../../components/ContentPanel";
+import "brace/theme/github";
+import "brace/mode/json";
+import EuiFormCustomLabel from "../EuiFormCustomLabel";
+
+interface PolicyInfoProps {
+  isEdit: boolean;
+  policyId: string;
+  policyIdError: string;
+  description: string;
+  onChangePolicyId: (value: ChangeEvent<HTMLInputElement>) => void;
+  onChangeDescription: (value: ChangeEvent<HTMLTextAreaElement>) => void;
+}
+
+const PolicyInfo = ({ isEdit, policyId, policyIdError, description, onChangePolicyId, onChangeDescription }: PolicyInfoProps) => (
+  <ContentPanel bodyStyles={{ padding: "initial" }} title="Policy info" titleSize="s">
+    <div style={{ padding: "10px 0px 0px 10px" }}>
+      <EuiFormCustomLabel title="Policy ID" helpText="Specify a unique and descriptive ID that is easy to recognize and remember." />
+
+      <EuiFormRow isInvalid={!!policyIdError} error={policyIdError}>
+        <EuiFieldText
+          disabled={isEdit}
+          isInvalid={!!policyIdError}
+          placeholder="hot_cold_workflow"
+          readOnly={false}
+          value={policyId}
+          onChange={onChangePolicyId}
+          data-test-subj="create-policy-policy-id"
+        />
+      </EuiFormRow>
+
+      <EuiSpacer size="m" />
+
+      <EuiFormCustomLabel title="Description" helpText="Describe the policy" />
+
+      <EuiFormRow isInvalid={false} error={null}>
+        <EuiTextArea
+          style={{ minHeight: "150px" }}
+          compressed={true}
+          value={description}
+          onChange={onChangeDescription}
+          data-test-subj="create-policy-description"
+        />
+      </EuiFormRow>
+    </div>
+  </ContentPanel>
+);
+
+export default PolicyInfo;

--- a/public/pages/VisualCreatePolicy/components/PolicyInfo/__snapshots__/PolicyInfo.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/PolicyInfo/__snapshots__/PolicyInfo.test.tsx.snap
@@ -1,0 +1,116 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<PolicyInfo /> spec renders the component 1`] = `
+<div
+  class="euiPanel euiPanel--paddingMedium"
+  style="padding-left: 0px; padding-right: 0px;"
+>
+  <div
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+    style="padding: 0px 10px;"
+  >
+    <div
+      class="euiFlexItem"
+    >
+      <h3
+        class="euiTitle euiTitle--small"
+      >
+        Policy info
+      </h3>
+    </div>
+  </div>
+  <hr
+    class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+  />
+  <div
+    style="padding: initial;"
+  >
+    <div
+      style="padding: 10px 0px 0px 10px;"
+    >
+      <div
+        class="euiText euiText--medium"
+        style="margin-bottom: 5px;"
+      >
+        <h5
+          style="margin-bottom: 2px;"
+        >
+          Policy ID
+        </h5>
+        <p>
+           
+          <span
+            style="color: grey; font-weight: 200; font-size: 12px;"
+          >
+            Specify a unique and descriptive ID that is easy to recognize and remember.
+          </span>
+        </p>
+      </div>
+      <div
+        class="euiFormRow"
+        id="some_html_id-row"
+      >
+        <div
+          class="euiFormRow__fieldWrapper"
+        >
+          <div
+            class="euiFormControlLayout"
+          >
+            <div
+              class="euiFormControlLayout__childrenWrapper"
+            >
+              <input
+                class="euiFieldText"
+                data-test-subj="create-policy-policy-id"
+                id="some_html_id"
+                placeholder="hot_cold_workflow"
+                type="text"
+                value="some_id"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiSpacer euiSpacer--m"
+      />
+      <div
+        class="euiText euiText--medium"
+        style="margin-bottom: 5px;"
+      >
+        <h5
+          style="margin-bottom: 2px;"
+        >
+          Description
+        </h5>
+        <p>
+           
+          <span
+            style="color: grey; font-weight: 200; font-size: 12px;"
+          >
+            Describe the policy
+          </span>
+        </p>
+      </div>
+      <div
+        class="euiFormRow"
+        id="some_html_id-row"
+      >
+        <div
+          class="euiFormRow__fieldWrapper"
+        >
+          <textarea
+            class="euiTextArea euiTextArea--resizeVertical euiTextArea--compressed"
+            data-test-subj="create-policy-description"
+            id="some_html_id"
+            rows="3"
+            style="min-height: 150px;"
+          >
+            some description
+          </textarea>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/public/pages/VisualCreatePolicy/components/PolicyInfo/index.ts
+++ b/public/pages/VisualCreatePolicy/components/PolicyInfo/index.ts
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import PolicyInfo from "./PolicyInfo";
+
+export default PolicyInfo;


### PR DESCRIPTION
Signed-off-by: Drew Baugher <46505179+dbbaughe@users.noreply.github.com>

### Description

Adds policy info section for new UI

![Screen Shot 2021-08-10 at 12 08 10 PM](https://user-images.githubusercontent.com/46505179/128920722-f667f194-284f-43af-a971-25dfa7d55f72.png)

File                                                                                  | % Stmts | % Branch | % Funcs | % Lines |
--------------------------------------------------------------------------------------|---------|----------|---------|---------|
Before recent UI All files                                                                             |   47.84 |    41.09 |   44.05 |   48.38 |
After All files                                                                             |   48.19 |    41.54 |   44.55 |   48.77 |
PolicyInfo.tsx                                                                      |     100 |      100 |     100 |     100 |

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

