### PR TITLE
Adds error notification UI container and updates snapshots

### DIFF
--- a/models/interfaces.ts
+++ b/models/interfaces.ts
@@ -89,13 +89,39 @@ export interface DocumentTransform {
   metadata: any;
 }
 
-// TODO: Fill out when needed
-// TODO: separate a frontend Policy from backendPolicy
 export interface Policy {
   description: string;
   default_state: string;
   states: State[];
   ism_template: any;
+}
+
+export interface ErrorNotification {
+  destination?: Destination;
+  channel?: Channel;
+  message_template: MessageTemplate;
+}
+
+export interface Channel {
+  id: string;
+}
+
+export interface Destination {
+  chime?: {
+    url: string;
+  };
+  slack?: {
+    url: string;
+  };
+  custom_webhook?: {
+    url: string;
+    [other: string]: any; // custom webhook also allows users to create by part including customizing headers/query params, port/host, etc.
+  };
+}
+
+export interface MessageTemplate {
+  source: string;
+  lang?: string;
 }
 
 export interface State {

--- a/public/components/ContentPanel/ContentPanel.tsx
+++ b/public/components/ContentPanel/ContentPanel.tsx
@@ -25,11 +25,12 @@
  */
 
 import React from "react";
-import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule, EuiPanel, EuiTitle } from "@elastic/eui";
+import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule, EuiPanel, EuiTitle, EuiText } from "@elastic/eui";
 
 interface ContentPanelProps {
-  title?: string;
+  title?: string | JSX.Element;
   titleSize?: "xxxs" | "xxs" | "xs" | "s" | "m" | "l";
+  subTitleText?: string | JSX.Element;
   bodyStyles?: object;
   panelStyles?: object;
   horizontalRuleClassName?: string;
@@ -37,9 +38,22 @@ interface ContentPanelProps {
   children: React.ReactNode | React.ReactNode[];
 }
 
+const renderSubTitleText = (subTitleText: string | JSX.Element): JSX.Element | null => {
+  if (typeof subTitleText === "string") {
+    if (!subTitleText) return null;
+    return (
+      <EuiText size="s">
+        <span style={{ color: "grey", fontWeight: 200, fontSize: "15px" }}>{subTitleText}</span>
+      </EuiText>
+    );
+  }
+  return subTitleText;
+};
+
 const ContentPanel: React.SFC<ContentPanelProps> = ({
   title = "",
   titleSize = "l",
+  subTitleText = "",
   bodyStyles = {},
   panelStyles = {},
   horizontalRuleClassName = "",
@@ -49,9 +63,14 @@ const ContentPanel: React.SFC<ContentPanelProps> = ({
   <EuiPanel style={{ paddingLeft: "0px", paddingRight: "0px", ...panelStyles }}>
     <EuiFlexGroup style={{ padding: "0px 10px" }} justifyContent="spaceBetween" alignItems="center">
       <EuiFlexItem>
-        <EuiTitle size={titleSize}>
-          <h3>{title}</h3>
-        </EuiTitle>
+        {typeof title === "string" ? (
+          <EuiTitle size={titleSize}>
+            <h3>{title}</h3>
+          </EuiTitle>
+        ) : (
+          title
+        )}
+        {renderSubTitleText(subTitleText)}
       </EuiFlexItem>
       {actions ? (
         <EuiFlexItem grow={false}>

--- a/public/pages/ChangePolicy/components/NewPolicy/__snapshots__/NewPolicy.test.tsx.snap
+++ b/public/pages/ChangePolicy/components/NewPolicy/__snapshots__/NewPolicy.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`<NewPolicy /> spec renders the component 1`] = `
            
           <a
             class="euiLink euiLink--primary"
-            href="https://docs-beta.opensearch.org/docs/im/ism/"
+            href="https://opensearch.org/docs/im-plugin/ism/index/"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/public/pages/ChangePolicy/containers/ChangePolicy/__snapshots__/ChangePolicy.test.tsx.snap
+++ b/public/pages/ChangePolicy/containers/ChangePolicy/__snapshots__/ChangePolicy.test.tsx.snap
@@ -241,7 +241,7 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
              
             <a
               class="euiLink euiLink--primary"
-              href="https://docs-beta.opensearch.org/docs/im/ism/"
+              href="https://opensearch.org/docs/im-plugin/ism/index/"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/public/pages/CreatePolicy/components/DefinePolicy/__snapshots__/DefinePolicy.test.tsx.snap
+++ b/public/pages/CreatePolicy/components/DefinePolicy/__snapshots__/DefinePolicy.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`<DefinePolicy /> spec renders the component 1`] = `
            
           <a
             class="euiLink euiLink--primary"
-            href="https://docs-beta.opensearch.org/docs/im/ism/"
+            href="https://opensearch.org/docs/im-plugin/ism/index/"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/public/pages/CreatePolicy/containers/CreatePolicy/__snapshots__/CreatePolicy.test.tsx.snap
+++ b/public/pages/CreatePolicy/containers/CreatePolicy/__snapshots__/CreatePolicy.test.tsx.snap
@@ -317,7 +317,7 @@ exports[`<CreatePolicy /> spec renders the edit component 1`] = `
          
         <a
           class="euiLink euiLink--primary"
-          href="https://docs-beta.opensearch.org/docs/im/ism/"
+          href="https://opensearch.org/docs/im-plugin/ism/index/"
           rel="noopener noreferrer"
           target="_blank"
         >

--- a/public/pages/VisualCreatePolicy/containers/ErrorNotification/ErrorNotification.test.tsx
+++ b/public/pages/VisualCreatePolicy/containers/ErrorNotification/ErrorNotification.test.tsx
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render } from "@testing-library/react";
+import ErrorNotification from "./ErrorNotification";
+import { ServicesConsumer, ServicesContext } from "../../../../services";
+import { browserServicesMock } from "../../../../../test/mocks";
+import { BrowserServices } from "../../../../models/interfaces";
+import { ErrorNotification as IErrorNotification } from "../../../../../models/interfaces";
+
+function renderErrorNotification(errorNotification: IErrorNotification) {
+  return {
+    ...render(
+      <ServicesContext.Provider value={browserServicesMock}>
+        <ServicesConsumer>
+          {(services: BrowserServices | null) =>
+            services && (
+              <ErrorNotification
+                errorNotification={errorNotification}
+                errorNotificationJsonString={""}
+                onChangeChannelId={() => {}}
+                onChangeMessage={() => {}}
+                onChangeErrorNotificationJsonString={() => {}}
+                onSwitchToChannels={() => {}}
+                notificationService={services?.notificationService}
+              />
+            )
+          }
+        </ServicesConsumer>
+      </ServicesContext.Provider>
+    ),
+  };
+}
+
+describe("<ErrorNotification /> spec", () => {
+  it("renders the component", () => {
+    const { container } = render(
+      <ErrorNotification
+        errorNotification={{ channel: { id: "some_id" }, message_template: { source: "some source message" } }}
+        errorNotificationJsonString={""}
+        onChangeChannelId={() => {}}
+        onChangeMessage={() => {}}
+        onChangeErrorNotificationJsonString={() => {}}
+        onSwitchToChannels={() => {}}
+        notificationService={browserServicesMock.notificationService}
+      />
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("renders the channel ui editor for channels", () => {
+    const errorNotification = { channel: { id: "some_id" }, message_template: { source: "some source message" } };
+    const { queryByTestId } = renderErrorNotification(errorNotification);
+
+    expect(queryByTestId("channel-notification-refresh")).not.toBeNull();
+    expect(queryByTestId("create-policy-legacy-notification")).toBeNull();
+  });
+
+  it("renders the json legacy editor for destinations", () => {
+    const errorNotification = { destination: { slack: { url: "https://slack.com" } }, message_template: { source: "some source message" } };
+    const { queryByTestId } = renderErrorNotification(errorNotification);
+
+    expect(queryByTestId("channel-notification-refresh")).toBeNull();
+    expect(queryByTestId("create-policy-legacy-notification")).not.toBeNull();
+  });
+});

--- a/public/pages/VisualCreatePolicy/containers/ErrorNotification/ErrorNotification.tsx
+++ b/public/pages/VisualCreatePolicy/containers/ErrorNotification/ErrorNotification.tsx
@@ -1,0 +1,140 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React, { ChangeEvent, Component } from "react";
+import { EuiLink, EuiIcon, EuiFlexGroup, EuiFlexItem, EuiText } from "@elastic/eui";
+import { ContentPanel } from "../../../../components/ContentPanel";
+import "brace/theme/github";
+import "brace/mode/json";
+import { FeatureChannelList } from "../../../../../server/models/interfaces";
+import { NotificationService } from "../../../../services";
+import { ErrorNotification as IErrorNotification } from "../../../../../models/interfaces";
+import { getErrorMessage } from "../../../../utils/helpers";
+import { CoreServicesContext } from "../../../../components/core_services";
+import ChannelNotification from "../../components/ChannelNotification";
+import LegacyNotification from "../../components/LegacyNotification";
+import { DOCUMENTATION_URL } from "../../../../utils/constants";
+
+interface ErrorNotificationProps {
+  errorNotification: IErrorNotification | undefined;
+  errorNotificationJsonString: string;
+  onChangeChannelId: (value: ChangeEvent<HTMLSelectElement>) => void;
+  onChangeMessage: (value: ChangeEvent<HTMLTextAreaElement>) => void;
+  onChangeErrorNotificationJsonString: (str: string) => void;
+  onSwitchToChannels: () => void;
+  notificationService: NotificationService;
+}
+
+interface ErrorNotificationState {
+  channels: FeatureChannelList[];
+  loadingChannels: boolean;
+}
+
+export default class ErrorNotification extends Component<ErrorNotificationProps, ErrorNotificationState> {
+  static contextType = CoreServicesContext;
+  constructor(props: ErrorNotificationProps) {
+    super(props);
+
+    this.state = {
+      channels: [],
+      loadingChannels: true,
+    };
+  }
+
+  componentDidMount = async (): Promise<void> => {
+    await this.getChannels();
+  };
+
+  getChannels = async (): Promise<void> => {
+    this.setState({ loadingChannels: true });
+    try {
+      const { notificationService } = this.props;
+      const response = await notificationService.getChannels();
+      if (response.ok) {
+        this.setState({ channels: response.response.feature_channel_list });
+      } else {
+        this.context.notifications.toasts.addDanger(`Could not load notification channels: ${response.error}`);
+      }
+    } catch (err) {
+      this.context.notifications.toasts.addDanger(getErrorMessage(err, "Could not load the notification channels"));
+    }
+    this.setState({ loadingChannels: false });
+  };
+
+  render() {
+    const {
+      errorNotification,
+      errorNotificationJsonString,
+      onChangeChannelId,
+      onChangeMessage,
+      onChangeErrorNotificationJsonString,
+      onSwitchToChannels,
+    } = this.props;
+    const { channels, loadingChannels } = this.state;
+    const hasDestination = !!errorNotification?.destination;
+
+    let content = (
+      <ChannelNotification
+        channelId={errorNotification?.channel?.id || ""}
+        channels={channels}
+        loadingChannels={loadingChannels}
+        message={errorNotification?.message_template?.source || ""}
+        onChangeChannelId={onChangeChannelId}
+        onChangeMessage={onChangeMessage}
+        getChannels={this.getChannels}
+      />
+    );
+
+    // If we have a destination in the error notification then it's either an older policy or they created through the API
+    if (hasDestination) {
+      content = (
+        <LegacyNotification
+          notificationJsonString={errorNotificationJsonString}
+          onChangeNotificationJsonString={onChangeErrorNotificationJsonString}
+          onSwitchToChannels={onSwitchToChannels}
+        />
+      );
+    }
+
+    return (
+      <ContentPanel
+        bodyStyles={{ padding: "initial" }}
+        title={
+          <EuiFlexGroup gutterSize="xs" alignItems="center">
+            <EuiFlexItem grow={false}>
+              <EuiText>
+                <h3>Error notification</h3>
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiText color="subdued">
+                <i> - optional</i>
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+        titleSize="s"
+        subTitleText={
+          <EuiText size="s" style={{ padding: "5px 0px" }}>
+            <p style={{ color: "grey", fontWeight: 200 }}>
+              You can set up an error notification for when a policy execution fails to notify you.{" "}
+              <EuiLink href={DOCUMENTATION_URL} target="_blank">
+                Learn more <EuiIcon type="popout" size="s" />
+              </EuiLink>
+            </p>
+          </EuiText>
+        }
+      >
+        <div style={{ padding: "10px 0px 0px 10px" }}>{content}</div>
+      </ContentPanel>
+    );
+  }
+}

--- a/public/pages/VisualCreatePolicy/containers/ErrorNotification/__snapshots__/ErrorNotification.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/ErrorNotification/__snapshots__/ErrorNotification.test.tsx.snap
@@ -1,0 +1,225 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ErrorNotification /> spec renders the component 1`] = `
+<div
+  class="euiPanel euiPanel--paddingMedium"
+  style="padding-left: 0px; padding-right: 0px;"
+>
+  <div
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+    style="padding: 0px 10px;"
+  >
+    <div
+      class="euiFlexItem"
+    >
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+      >
+        <div
+          class="euiFlexItem euiFlexItem--flexGrowZero"
+        >
+          <div
+            class="euiText euiText--medium"
+          >
+            <h3>
+              Error notification
+            </h3>
+          </div>
+        </div>
+        <div
+          class="euiFlexItem"
+        >
+          <div
+            class="euiText euiText--medium"
+          >
+            <div
+              class="euiTextColor euiTextColor--subdued"
+            >
+              <i>
+                 - optional
+              </i>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiText euiText--small"
+        style="padding: 5px 0px;"
+      >
+        <p
+          style="color: grey; font-weight: 200;"
+        >
+          You can set up an error notification for when a policy execution fails to notify you.
+           
+          <a
+            class="euiLink euiLink--primary"
+            href="https://opensearch.org/docs/im-plugin/ism/index/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Learn more 
+            EuiIconMock
+          </a>
+        </p>
+      </div>
+    </div>
+  </div>
+  <hr
+    class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+  />
+  <div
+    style="padding: initial;"
+  >
+    <div
+      style="padding: 10px 0px 0px 10px;"
+    >
+      <div
+        class="euiText euiText--medium"
+        style="margin-bottom: 5px;"
+      >
+        <h5
+          style="margin-bottom: 2px;"
+        >
+          Channel ID
+        </h5>
+        <p>
+           
+        </p>
+      </div>
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
+        style="max-width: 600px;"
+      >
+        <div
+          class="euiFlexItem"
+        >
+          <div
+            class="euiFormRow"
+            id="some_html_id-row"
+          >
+            <div
+              class="euiFormRow__fieldWrapper"
+            >
+              <div
+                class="euiFormControlLayout"
+              >
+                <div
+                  class="euiFormControlLayout__childrenWrapper"
+                >
+                  <select
+                    class="euiSelect euiSelect-isLoading"
+                    data-test-subj="create-policy-notification-channel-id"
+                    id="some_html_id"
+                    placeholder="Select channel ID"
+                  >
+                    <option
+                      disabled=""
+                      hidden=""
+                      style="display: none;"
+                      value=""
+                    >
+                       
+                    </option>
+                  </select>
+                  <div
+                    class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                  >
+                    <span
+                      class="euiLoadingSpinner euiLoadingSpinner--medium"
+                    />
+                    <span
+                      class="euiFormControlLayoutCustomIcon"
+                    >
+                      EuiIconMock
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="euiFlexItem euiFlexItem--flexGrowZero"
+        >
+          <button
+            class="euiButton euiButton--primary refresh-button euiButton-isDisabled"
+            data-test-subj="channel-notification-refresh"
+            disabled=""
+            type="button"
+          >
+            <span
+              class="euiButtonContent euiButton__content"
+            >
+              EuiIconMock
+              <span
+                class="euiButton__text"
+              />
+            </span>
+          </button>
+        </div>
+        <div
+          class="euiFlexItem euiFlexItem--flexGrowZero"
+        >
+          <a
+            class="euiButton euiButton--primary"
+            href="notifications-dashboards#/channels"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <span
+              class="euiButtonContent euiButton__content"
+            >
+              EuiIconMock
+              <span
+                class="euiButton__text"
+              >
+                Manage channels
+              </span>
+            </span>
+          </a>
+        </div>
+      </div>
+      <div
+        class="euiSpacer euiSpacer--m"
+      />
+      <div
+        class="euiText euiText--medium"
+        style="margin-bottom: 5px;"
+      >
+        <h5
+          style="margin-bottom: 2px;"
+        >
+          Notification message
+        </h5>
+        <p>
+           
+          <span
+            style="color: grey; font-weight: 200; font-size: 12px;"
+          >
+            Embed variables in your message using Mustache template.
+          </span>
+        </p>
+      </div>
+      <div
+        class="euiFormRow"
+        id="some_html_id-row"
+      >
+        <div
+          class="euiFormRow__fieldWrapper"
+        >
+          <textarea
+            class="euiTextArea euiTextArea--resizeVertical euiTextArea--compressed"
+            data-test-subj="create-policy-notification-message"
+            id="some_html_id"
+            placeholder="The index {{ctx.index}} failed during policy execution."
+            rows="3"
+            style="min-height: 150px;"
+          >
+            some source message
+          </textarea>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/public/pages/VisualCreatePolicy/containers/ErrorNotification/index.ts
+++ b/public/pages/VisualCreatePolicy/containers/ErrorNotification/index.ts
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import ErrorNotification from "./ErrorNotification";
+
+export default ErrorNotification;

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -28,7 +28,7 @@ export const PLUGIN_NAME = "opensearch_index_management_dashboards";
 
 export const DEFAULT_EMPTY_DATA = "-";
 
-export const DOCUMENTATION_URL = "https://docs-beta.opensearch.org/docs/im/ism/";
+export const DOCUMENTATION_URL = "https://opensearch.org/docs/im-plugin/ism/index/";
 
 export const ROUTES = Object.freeze({
   CHANGE_POLICY: "/change-policy",


### PR DESCRIPTION
Signed-off-by: Drew Baugher <46505179+dbbaughe@users.noreply.github.com>

### Description

Adds container for error notification that switches between legacy and channel UIs.

![Screen Shot 2021-08-10 at 3 01 01 PM](https://user-images.githubusercontent.com/46505179/128940812-d5f9ba24-308a-47c9-bc2e-8960df06052f.png)
![Screen Shot 2021-08-10 at 2 59 30 PM](https://user-images.githubusercontent.com/46505179/128940831-9f539b41-0afa-47db-8041-7857b3cd8762.png)

File                                                                                  | % Stmts | % Branch | % Funcs | % Lines |
--------------------------------------------------------------------------------------|---------|----------|---------|---------|
Before recent UI All files                                                                             |   47.84 |    41.09 |   44.05 |   48.38 |
After All files                                                                             |   48.59 |    42.11 |   45.06 |   49.18 |                                                                                                    

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

