### PR TITLE
Added PolicySettings and DeleteModal components for PolicyDetails UI

### DIFF
--- a/models/interfaces.ts
+++ b/models/interfaces.ts
@@ -104,37 +104,6 @@ export interface ErrorNotification {
 }
 
 export interface Channel {
-  channel_id: string;
-}
-
-export interface Destination {
-  chime?: {
-    url: string;
-  };
-  slack?: {
-    url: string;
-  };
-  custom_webhook?: {
-    url: string;
-  };
-}
-
-export interface MessageTemplate {
-  source: string;
-}
-
-export interface ISMTemplate {
-  index_patterns: string[];
-  priority: number;
-}
-
-export interface ErrorNotification {
-  destination?: Destination;
-  channel?: Channel;
-  message_template: MessageTemplate;
-}
-
-export interface Channel {
   id: string;
 }
 

--- a/models/interfaces.ts
+++ b/models/interfaces.ts
@@ -92,8 +92,40 @@ export interface DocumentTransform {
 export interface Policy {
   description: string;
   default_state: string;
+  error_notification?: ErrorNotification;
   states: State[];
-  ism_template: any;
+  ism_template?: ISMTemplate[] | ISMTemplate | null;
+}
+
+export interface ErrorNotification {
+  destination?: Destination;
+  channel?: Channel;
+  message_template: MessageTemplate;
+}
+
+export interface Channel {
+  channel_id: string;
+}
+
+export interface Destination {
+  chime?: {
+    url: string;
+  };
+  slack?: {
+    url: string;
+  };
+  custom_webhook?: {
+    url: string;
+  };
+}
+
+export interface MessageTemplate {
+  source: string;
+}
+
+export interface ISMTemplate {
+  index_patterns: string[];
+  priority: number;
 }
 
 export interface ErrorNotification {

--- a/public/pages/PolicyDetails/components/DeleteModal/DeleteModal.test.tsx
+++ b/public/pages/PolicyDetails/components/DeleteModal/DeleteModal.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render } from "@testing-library/react";
+import DeleteModal from "./DeleteModal";
+import { fireEvent } from "@testing-library/dom";
+import userEvent from "@testing-library/user-event/dist";
+
+describe("<DeleteModal /> spec", () => {
+  it("renders the component", () => {
+    const { container } = render(
+      <DeleteModal
+        policyId="some_id"
+        closeDeleteModal={() => {}}
+        onClickDelete={() => {}}
+      />
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("calls closeDeleteModal when cancel button is clicked", () => {
+    const closeDeleteModal = jest.fn();
+    const { getByTestId } = render(
+      <DeleteModal
+        policyId="some_id"
+        closeDeleteModal={closeDeleteModal}
+        onClickDelete={() => {}}
+      />
+    );
+
+    userEvent.click(getByTestId("confirmModalCancelButton"));
+    expect(closeDeleteModal).toHaveBeenCalled();
+  });
+
+  it("calls onClickDelete when delete button is clicked", () => {
+    const onClickDelete = jest.fn();
+    const { getByTestId } = render(
+      <DeleteModal
+        policyId="some_id"
+        closeDeleteModal={() => {}}
+        onClickDelete={onClickDelete}
+      />
+    );
+
+    fireEvent.focus(getByTestId("deleteTextField"));
+    userEvent.type(getByTestId("deleteTextField"), `delete`);
+    userEvent.click(getByTestId("confirmModalConfirmButton"));
+
+    expect(onClickDelete).toHaveBeenCalled();
+  });
+});

--- a/public/pages/PolicyDetails/components/DeleteModal/DeleteModal.test.tsx
+++ b/public/pages/PolicyDetails/components/DeleteModal/DeleteModal.test.tsx
@@ -11,21 +11,21 @@
 
 import React from "react";
 import "@testing-library/jest-dom/extend-expect";
-import { render } from "@testing-library/react";
+import { screen, render } from "@testing-library/react";
 import DeleteModal from "./DeleteModal";
 import { fireEvent } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event/dist";
 
 describe("<DeleteModal /> spec", () => {
   it("renders the component", () => {
-    const { container } = render(
+    const { baseElement } = render(
       <DeleteModal
         policyId="some_id"
         closeDeleteModal={() => {}}
         onClickDelete={() => {}}
       />
     );
-    expect(container.firstChild).toMatchSnapshot();
+    expect(baseElement).toMatchSnapshot();
   });
 
   it("calls closeDeleteModal when cancel button is clicked", () => {

--- a/public/pages/PolicyDetails/components/DeleteModal/DeleteModal.tsx
+++ b/public/pages/PolicyDetails/components/DeleteModal/DeleteModal.tsx
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React, { ChangeEvent, Component, Fragment } from "react";
+import { EuiConfirmModal, EuiForm, EuiFormRow, EuiFieldText, EuiOverlayMask, EuiSpacer } from "@elastic/eui";
+
+interface DeleteModalProps {
+ policyId: string;
+ closeDeleteModal: (event?: any) => void;
+ onClickDelete: (event?: any) => void;
+}
+
+interface DeleteModalState {
+ confirmDeleteText: string;
+}
+
+export default class DeleteModal extends Component<DeleteModalProps, DeleteModalState> {
+ state = { confirmDeleteText: "" };
+
+ onChange = (e: ChangeEvent<HTMLInputElement>): void => {
+   this.setState({ confirmDeleteText: e.target.value });
+ };
+
+ render() {
+   const { policyId, closeDeleteModal, onClickDelete } = this.props;
+   const { confirmDeleteText } = this.state;
+
+   return (
+     <EuiOverlayMask>
+       <EuiConfirmModal
+         title="Delete policy"
+         onCancel={closeDeleteModal}
+         onConfirm={onClickDelete}
+         cancelButtonText="Cancel"
+         confirmButtonText="Delete policy"
+         buttonColor="danger"
+         defaultFocusedButton="confirm"
+         confirmButtonDisabled={confirmDeleteText != "delete"}
+       >
+         <EuiForm>
+           <Fragment>
+             Delete "<strong>{policyId}</strong>" permanently? Indices will no
+             longer be managed using this policy
+           </Fragment>
+           <EuiSpacer size="s" />
+           <EuiFormRow helpText="To confirm deletion, type delete">
+             <EuiFieldText value={confirmDeleteText} placeholder="delete" onChange={this.onChange} data-test-subj="deleteTextField" />
+           </EuiFormRow>
+         </EuiForm>
+       </EuiConfirmModal>
+     </EuiOverlayMask>
+   );
+ }
+}

--- a/public/pages/PolicyDetails/components/DeleteModal/__snapshots__/DeleteModal.test.tsx.snap
+++ b/public/pages/PolicyDetails/components/DeleteModal/__snapshots__/DeleteModal.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<DeleteModal /> spec renders the component 1`] = `null`;

--- a/public/pages/PolicyDetails/components/DeleteModal/__snapshots__/DeleteModal.test.tsx.snap
+++ b/public/pages/PolicyDetails/components/DeleteModal/__snapshots__/DeleteModal.test.tsx.snap
@@ -1,3 +1,159 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<DeleteModal /> spec renders the component 1`] = `null`;
+exports[`<DeleteModal /> spec renders the component 1`] = `
+<body
+  class="euiBody-hasOverlayMask"
+>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  />
+  <div
+    class="euiOverlayMask euiOverlayMask--aboveHeader"
+  >
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="1"
+    />
+    <div
+      data-focus-lock-disabled="false"
+    >
+      <div
+        class="euiModal euiModal--maxWidth-default euiModal--confirmation"
+        tabindex="0"
+      >
+        <button
+          aria-label="Closes this modal window"
+          class="euiButtonIcon euiButtonIcon--text euiModal__closeIcon"
+          type="button"
+        >
+          EuiIconMock
+        </button>
+        <div
+          class="euiModal__flex"
+        >
+          <div
+            class="euiModalHeader"
+          >
+            <div
+              class="euiModalHeader__title"
+              data-test-subj="confirmModalTitleText"
+            >
+              Delete policy
+            </div>
+          </div>
+          <div
+            class="euiModalBody"
+          >
+            <div
+              class="euiModalBody__overflow"
+            >
+              <div
+                class="euiText euiText--medium"
+                data-test-subj="confirmModalBodyText"
+              >
+                <div
+                  class="euiForm"
+                >
+                  Delete "
+                  <strong>
+                    some_id
+                  </strong>
+                  " permanently? Indices will no longer be managed using this policy
+                  <div
+                    class="euiSpacer euiSpacer--s"
+                  />
+                  <div
+                    class="euiFormRow"
+                    id="some_html_id-row"
+                  >
+                    <div
+                      class="euiFormRow__fieldWrapper"
+                    >
+                      <div
+                        class="euiFormControlLayout"
+                      >
+                        <div
+                          class="euiFormControlLayout__childrenWrapper"
+                        >
+                          <input
+                            aria-describedby="some_html_id-help"
+                            class="euiFieldText"
+                            data-test-subj="deleteTextField"
+                            id="some_html_id"
+                            placeholder="delete"
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="euiFormHelpText euiFormRow__text"
+                        id="some_html_id-help"
+                      >
+                        To confirm deletion, type delete
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="euiModalFooter"
+          >
+            <button
+              class="euiButtonEmpty euiButtonEmpty--primary"
+              data-test-subj="confirmModalCancelButton"
+              type="button"
+            >
+              <span
+                class="euiButtonContent euiButtonEmpty__content"
+              >
+                <span
+                  class="euiButtonEmpty__text"
+                >
+                  Cancel
+                </span>
+              </span>
+            </button>
+            <button
+              class="euiButton euiButton--danger euiButton--fill euiButton-isDisabled"
+              data-test-subj="confirmModalConfirmButton"
+              disabled=""
+              type="button"
+            >
+              <span
+                class="euiButtonContent euiButton__content"
+              >
+                <span
+                  class="euiButton__text"
+                >
+                  Delete policy
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;

--- a/public/pages/PolicyDetails/components/DeleteModal/index.ts
+++ b/public/pages/PolicyDetails/components/DeleteModal/index.ts
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import DeleteModal from "./DeleteModal";
+
+export default DeleteModal;

--- a/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.test.tsx
+++ b/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.test.tsx
@@ -15,13 +15,22 @@ import { render } from "@testing-library/react";
 import PolicySettings from "./PolicySettings";
 
 describe("<PolicySettings /> spec", () => {
+  beforeAll(() => {
+    jest.useFakeTimers('modern');
+    jest.setSystemTime(new Date(2021, 7, 1));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   it("renders the component", () => {
     const { container } = render(
       <PolicySettings
         policyId={"some_id"}
         channelId={"some_channel_id"}
         primaryTerm={1}
-        lastUpdated={"2021-08-11T23:17:01.054Z"}
+        lastUpdated={new Date().toString()}
         description={"some description"}
         sequenceNumber={2}
         schemaVersion={3}

--- a/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.test.tsx
+++ b/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.test.tsx
@@ -16,13 +16,12 @@ import PolicySettings from "./PolicySettings";
 
 describe("<PolicySettings /> spec", () => {
   it("renders the component", () => {
-    const dateTime = new Date();
     const { container } = render(
       <PolicySettings
         policyId={"some_id"}
         channelId={"some_channel_id"}
         primaryTerm={1}
-        lastUpdated={dateTime.toString()}
+        lastUpdated={"2021-08-11T23:17:01.054Z"}
         description={"some description"}
         sequenceNumber={2}
         schemaVersion={3}

--- a/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.test.tsx
+++ b/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.test.tsx
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render } from "@testing-library/react";
+import PolicySettings from "./PolicySettings";
+
+describe("<PolicySettings /> spec", () => {
+  it("renders the component", () => {
+    const dateTime = new Date();
+    const { container } = render(
+      <PolicySettings
+        policyId={"some_id"}
+        channelId={"some_channel_id"}
+        primaryTerm={1}
+        lastUpdated={dateTime.toString()}
+        description={"some description"}
+        sequenceNumber={2}
+        schemaVersion={3}
+        ismTemplates={[]}
+      />
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.tsx
+++ b/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.tsx
@@ -43,14 +43,6 @@ export default class PolicySettings extends Component<PolicySettingsProps, Polic
     }
   }
 
-  getTemplates = (ismTemplates: ISMTemplate[]): ISMTemplate[] => {
-    const templateArray = ismTemplates.map(ismTemplate => ({
-      index_patterns: ismTemplate.index_patterns,
-      priority: ismTemplate.priority,
-    }));
-    return templateArray;
-  }
-
   onTableChange = ({ page = {} }) => {
     const { index: pageIndex, size: pageSize } = page;
 
@@ -79,7 +71,7 @@ export default class PolicySettings extends Component<PolicySettingsProps, Polic
 
     const columns = [
       {
-        field: 'indexPatterns',
+        field: 'index_patterns',
         name: 'Index patterns',
         truncateText: false
       },
@@ -89,7 +81,6 @@ export default class PolicySettings extends Component<PolicySettingsProps, Polic
         truncateText: false
       }
     ]
-    const items = this.getTemplates(ismTemplates);
 
     const infoItems = [
       { term: "Policy name", value: policyId },
@@ -152,7 +143,7 @@ export default class PolicySettings extends Component<PolicySettingsProps, Polic
             titleSize="s"
           >
             <EuiBasicTable
-              items={items}
+              items={ismTemplates}
               columns={columns}
               pagination={pagination}
               onChange={this.onTableChange}

--- a/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.tsx
+++ b/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.tsx
@@ -43,23 +43,18 @@ export default class PolicySettings extends Component<PolicySettingsProps, Polic
     }
   }
 
-  // TODO: Needs to be updated to handle template array
   getTemplates = (ismTemplates: ISMTemplate[]): ISMTemplate[] => {
-    const templateArray = [];
-    ismTemplates.map((ismTemplate)=> {
-      templateArray.push({
-        indexPatterns: ismTemplate.index_patterns,
-        priority: ismTemplate.priority,
-      })
-    })
+    const templateArray = ismTemplates.map(ismTemplate => ({
+      index_patterns: ismTemplate.index_patterns,
+      priority: ismTemplate.priority,
+    }));
     return templateArray;
   }
 
   onTableChange = ({ page = {} }) => {
     const { index: pageIndex, size: pageSize } = page;
 
-    this.setState({pageIndex: pageIndex});
-    this.setState({pageSize: pageSize});
+    this.setState({pageIndex, pageSize});
   };
 
   render() {

--- a/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.tsx
+++ b/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.tsx
@@ -44,7 +44,7 @@ export default class PolicySettings extends Component<PolicySettingsProps, Polic
   }
 
   // TODO: Needs to be updated to handle template array
-  getTemplates = (ismTemplates: ISMTemplate[]): any[] => {
+  getTemplates = (ismTemplates: ISMTemplate[]): ISMTemplate[] => {
     const templateArray = [];
     ismTemplates.map((ismTemplate)=> {
       templateArray.push({

--- a/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.tsx
+++ b/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.tsx
@@ -139,7 +139,7 @@ export default class PolicySettings extends Component<PolicySettingsProps, Polic
           <ContentPanel
             panelStyles={{ padding: "20px 20px" }}
             bodyStyles={{ padding: "10px" }}
-            title="ISM Templates"
+            title={`ISM Templates (${ismTemplates.length})`}
             titleSize="s"
           >
             <EuiBasicTable

--- a/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.tsx
+++ b/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.tsx
@@ -124,7 +124,7 @@ export default class PolicySettings extends Component<PolicySettingsProps, Polic
                   {
                     text: "Edit",
                     buttonProps: {
-                      onClick: {},
+                      onClick: () => {},
                     },
                   },
                 ]}

--- a/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.tsx
+++ b/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.tsx
@@ -1,0 +1,170 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React, { Component } from "react";
+import { EuiFlexGrid, EuiSpacer, EuiFlexItem, EuiText, EuiBasicTable } from "@elastic/eui";
+import { ContentPanel, ContentPanelActions } from "../../../../components/ContentPanel";
+import { ModalConsumer } from "../../../../components/Modal";
+import { ISMTemplate } from "../../../../../models/interfaces";
+
+interface PolicySettingsProps {
+  policyId: string;
+  channelId: string;
+  primaryTerm: number;
+  lastUpdated: string;
+  description: string;
+  sequenceNumber: number;
+  schemaVersion: number;
+  ismTemplates: ISMTemplate[];
+}
+
+interface PolicySettingsState {
+  pageIndex: number;
+  pageSize: number;
+  showPerPageOptions: boolean;
+}
+
+export default class PolicySettings extends Component<PolicySettingsProps, PolicySettingsState> {
+  constructor(props: PolicySettingsProps) {
+    super(props);
+
+    this.state = {
+      pageIndex: 0,
+      pageSize: 10,
+      showPerPageOptions: true,
+    }
+  }
+
+  // TODO: Needs to be updated to handle template array
+  getTemplates = (ismTemplates: ISMTemplate[]): any[] => {
+    const templateArray = [];
+    ismTemplates.map((ismTemplate)=> {
+      templateArray.push({
+        indexPatterns: ismTemplate.index_patterns,
+        priority: ismTemplate.priority,
+      })
+    })
+    return templateArray;
+  }
+
+  onTableChange = ({ page = {} }) => {
+    const { index: pageIndex, size: pageSize } = page;
+
+    this.setState({pageIndex: pageIndex});
+    this.setState({pageSize: pageSize});
+  };
+
+  render() {
+    const {
+      policyId,
+      channelId,
+      primaryTerm,
+      lastUpdated,
+      description,
+      sequenceNumber,
+      schemaVersion,
+      ismTemplates,
+    } = this.props;
+
+    const {
+      pageIndex,
+      pageSize,
+      showPerPageOptions,
+    } = this.state;
+
+    const updatedDate = new Date(lastUpdated);
+
+    const columns = [
+      {
+        field: 'indexPatterns',
+        name: 'Index patterns',
+        truncateText: false
+      },
+      {
+        field: 'priority',
+        name: "Priority",
+        truncateText: false
+      }
+    ]
+    const items = this.getTemplates(ismTemplates);
+
+    const infoItems = [
+      { term: "Policy name", value: policyId },
+      { term: "channel ID", value: channelId || "-" },
+      { term: "Primary term", value: primaryTerm },
+      { term: "Last updated", value: updatedDate.toLocaleString() },
+      { term: "Policy description", value: description || "-" },
+      { term: "Sequence number", value: sequenceNumber },
+      { term: "Schema version", value: schemaVersion },
+    ];
+
+    const pagination = {
+      pageIndex: pageIndex,
+      pageSize,
+      totalItemCount: ismTemplates.length,
+      pageSizeOptions: [10, 20, 50],
+      hidePerPageOptions: !showPerPageOptions,
+    };
+
+    return(
+      <ContentPanel
+        actions={
+          <ModalConsumer>
+            {() => (
+              <ContentPanelActions
+                actions={[
+                  {
+                    text: "Edit",
+                    buttonProps: {
+                      onClick: {},
+                    },
+                  },
+                ]}
+              />
+            )}
+          </ModalConsumer>
+        }
+        panelStyles={{ padding: "20px 20px" }}
+        bodyStyles={{ padding: "10px" }}
+        title="Policy settings"
+        titleSize="s"
+      >
+        <div style={{ paddingLeft: "10px" }}>
+          <EuiSpacer size="s" />
+          <EuiFlexGrid columns={4}>
+            {infoItems.map((item) => (
+              <EuiFlexItem key={`${item.term}#${item.value}`}>
+                <EuiText size="xs">
+                  <dt>{item.term}</dt>
+                  <dd>{item.value}</dd>
+                </EuiText>
+              </EuiFlexItem>
+            ))}
+          </EuiFlexGrid>
+          <EuiSpacer size="s" />
+          <ContentPanel
+            panelStyles={{ padding: "20px 20px" }}
+            bodyStyles={{ padding: "10px" }}
+            title="ISM Templates"
+            titleSize="s"
+          >
+            <EuiBasicTable
+              items={items}
+              columns={columns}
+              pagination={pagination}
+              onChange={this.onTableChange}
+            />
+          </ContentPanel>
+        </div>
+      </ContentPanel>
+    );
+  }
+}

--- a/public/pages/PolicyDetails/components/PolicySettings/__snapshots__/PolicySettings.test.tsx.snap
+++ b/public/pages/PolicyDetails/components/PolicySettings/__snapshots__/PolicySettings.test.tsx.snap
@@ -1,0 +1,290 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<PolicySettings /> spec renders the component 1`] = `
+<div
+  class="euiPanel euiPanel--paddingMedium"
+  style="padding: 20px 20px;"
+>
+  <div
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+    style="padding: 0px 10px;"
+  >
+    <div
+      class="euiFlexItem"
+    >
+      <h3
+        class="euiTitle euiTitle--small"
+      >
+        Policy settings
+      </h3>
+    </div>
+    <div
+      class="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+      >
+        <div
+          class="euiFlexItem"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          >
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <button
+                class="euiButton euiButton--primary"
+                data-test-subj="EditButton"
+                type="button"
+              >
+                <span
+                  class="euiButtonContent euiButton__content"
+                >
+                  <span
+                    class="euiButton__text"
+                  >
+                    Edit
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <hr
+    class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+  />
+  <div
+    style="padding: 10px;"
+  >
+    <div
+      style="padding-left: 10px;"
+    >
+      <div
+        class="euiSpacer euiSpacer--s"
+      />
+      <div
+        class="euiFlexGrid euiFlexGrid--gutterLarge euiFlexGrid--fourths euiFlexGrid--responsive"
+      >
+        <div
+          class="euiFlexItem"
+        >
+          <div
+            class="euiText euiText--extraSmall"
+          >
+            <dt>
+              Policy name
+            </dt>
+            <dd>
+              some_id
+            </dd>
+          </div>
+        </div>
+        <div
+          class="euiFlexItem"
+        >
+          <div
+            class="euiText euiText--extraSmall"
+          >
+            <dt>
+              channel ID
+            </dt>
+            <dd>
+              some_channel_id
+            </dd>
+          </div>
+        </div>
+        <div
+          class="euiFlexItem"
+        >
+          <div
+            class="euiText euiText--extraSmall"
+          >
+            <dt>
+              Primary term
+            </dt>
+            <dd>
+              1
+            </dd>
+          </div>
+        </div>
+        <div
+          class="euiFlexItem"
+        >
+          <div
+            class="euiText euiText--extraSmall"
+          >
+            <dt>
+              Last updated
+            </dt>
+            <dd>
+              8/10/2021, 6:39:14 PM
+            </dd>
+          </div>
+        </div>
+        <div
+          class="euiFlexItem"
+        >
+          <div
+            class="euiText euiText--extraSmall"
+          >
+            <dt>
+              Policy description
+            </dt>
+            <dd>
+              some description
+            </dd>
+          </div>
+        </div>
+        <div
+          class="euiFlexItem"
+        >
+          <div
+            class="euiText euiText--extraSmall"
+          >
+            <dt>
+              Sequence number
+            </dt>
+            <dd>
+              2
+            </dd>
+          </div>
+        </div>
+        <div
+          class="euiFlexItem"
+        >
+          <div
+            class="euiText euiText--extraSmall"
+          >
+            <dt>
+              Schema version
+            </dt>
+            <dd>
+              3
+            </dd>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiSpacer euiSpacer--s"
+      />
+      <div
+        class="euiPanel euiPanel--paddingMedium"
+        style="padding: 20px 20px;"
+      >
+        <div
+          class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          style="padding: 0px 10px;"
+        >
+          <div
+            class="euiFlexItem"
+          >
+            <h3
+              class="euiTitle euiTitle--small"
+            >
+              ISM Templates
+            </h3>
+          </div>
+        </div>
+        <hr
+          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+        />
+        <div
+          style="padding: 10px;"
+        >
+          <div
+            class="euiBasicTable"
+          >
+            <div>
+              <div
+                class="euiTableHeaderMobile"
+              >
+                <div
+                  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                >
+                  <div
+                    class="euiFlexItem euiFlexItem--flexGrowZero"
+                  />
+                  <div
+                    class="euiFlexItem euiFlexItem--flexGrowZero"
+                  />
+                </div>
+              </div>
+              <table
+                class="euiTable euiTable--responsive"
+                id="some_html_id"
+                tabindex="-1"
+              >
+                <caption
+                  class="euiScreenReaderOnly euiTableCaption"
+                />
+                <thead>
+                  <tr>
+                    <th
+                      class="euiTableHeaderCell"
+                      data-test-subj="tableHeaderCell_indexPatterns_0"
+                      role="columnheader"
+                      scope="col"
+                    >
+                      <div
+                        class="euiTableCellContent"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                          title="Index patterns"
+                        >
+                          Index patterns
+                        </span>
+                      </div>
+                    </th>
+                    <th
+                      class="euiTableHeaderCell"
+                      data-test-subj="tableHeaderCell_priority_1"
+                      role="columnheader"
+                      scope="col"
+                    >
+                      <div
+                        class="euiTableCellContent"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                          title="Priority"
+                        >
+                          Priority
+                        </span>
+                      </div>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr
+                    class="euiTableRow"
+                  >
+                    <td
+                      class="euiTableRowCell euiTableRowCell--isMobileFullWidth"
+                      colspan="2"
+                    >
+                      <div
+                        class="euiTableCellContent euiTableCellContent--alignCenter"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          No items found
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/public/pages/PolicyDetails/components/PolicySettings/__snapshots__/PolicySettings.test.tsx.snap
+++ b/public/pages/PolicyDetails/components/PolicySettings/__snapshots__/PolicySettings.test.tsx.snap
@@ -225,7 +225,7 @@ exports[`<PolicySettings /> spec renders the component 1`] = `
                   <tr>
                     <th
                       class="euiTableHeaderCell"
-                      data-test-subj="tableHeaderCell_indexPatterns_0"
+                      data-test-subj="tableHeaderCell_index_patterns_0"
                       role="columnheader"
                       scope="col"
                     >

--- a/public/pages/PolicyDetails/components/PolicySettings/__snapshots__/PolicySettings.test.tsx.snap
+++ b/public/pages/PolicyDetails/components/PolicySettings/__snapshots__/PolicySettings.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`<PolicySettings /> spec renders the component 1`] = `
               Last updated
             </dt>
             <dd>
-              8/11/2021, 4:17:01 PM
+              8/1/2021, 12:00:00 AM
             </dd>
           </div>
         </div>

--- a/public/pages/PolicyDetails/components/PolicySettings/__snapshots__/PolicySettings.test.tsx.snap
+++ b/public/pages/PolicyDetails/components/PolicySettings/__snapshots__/PolicySettings.test.tsx.snap
@@ -185,7 +185,7 @@ exports[`<PolicySettings /> spec renders the component 1`] = `
             <h3
               class="euiTitle euiTitle--small"
             >
-              ISM Templates
+              ISM Templates (0)
             </h3>
           </div>
         </div>

--- a/public/pages/PolicyDetails/components/PolicySettings/__snapshots__/PolicySettings.test.tsx.snap
+++ b/public/pages/PolicyDetails/components/PolicySettings/__snapshots__/PolicySettings.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`<PolicySettings /> spec renders the component 1`] = `
               Last updated
             </dt>
             <dd>
-              8/10/2021, 6:39:14 PM
+              8/11/2021, 4:17:01 PM
             </dd>
           </div>
         </div>

--- a/public/pages/PolicyDetails/components/PolicySettings/index.ts
+++ b/public/pages/PolicyDetails/components/PolicySettings/index.ts
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+ import PolicySettings from "./PolicySettings";
+
+ export default PolicySettings;


### PR DESCRIPTION
Signed-off-by: Eric Lobdell <lobdelle@amazon.com>

### Description

Adds PolicySettings and DeleteModal components used by the PolicyDetails UI. PolicySettings is the upper render box that shows basic details of the given policy, excluding States display. DeleteModal is responsible for confirming that the user wants to delete the policy.

![Screen Shot 2021-08-11 at 5 54 37 PM](https://user-images.githubusercontent.com/78931475/129122269-9e66b230-2956-4862-9bc1-8acada1dbe02.png)

![Screen Shot 2021-08-11 at 5 23 17 PM](https://user-images.githubusercontent.com/78931475/129120172-5ca9b196-8997-4f86-a5cd-b76cfd39d067.png)



### Known Issues
- interfaces.ts file includes too many changes and may need to be reduced to just relevant changes. 

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
