### PR TITLE
Adds create state container and removes unused props from modal and c…

### DIFF
--- a/public/components/CreatePolicyModal/CreatePolicyModal.test.tsx
+++ b/public/components/CreatePolicyModal/CreatePolicyModal.test.tsx
@@ -13,11 +13,10 @@ import React from "react";
 import "@testing-library/jest-dom/extend-expect";
 import { render, fireEvent } from "@testing-library/react";
 import CreatePolicyModal from "./CreatePolicyModal";
-import { historyMock } from "../../../test/mocks";
 
 describe("<CreatePolicyModal /> spec", () => {
   it("renders the component", () => {
-    render(<CreatePolicyModal isEdit={false} history={historyMock} onClose={() => {}} onClickContinue={() => {}} />);
+    render(<CreatePolicyModal isEdit={false} onClose={() => {}} onClickContinue={() => {}} />);
     // EuiOverlayMask appends an element to the body so we should have two, an empty div from react-test-library
     // and our EuiOverlayMask element
     expect(document.body.children).toHaveLength(2);
@@ -25,7 +24,7 @@ describe("<CreatePolicyModal /> spec", () => {
   });
 
   it("renders the component w/ edit", () => {
-    render(<CreatePolicyModal isEdit={true} history={historyMock} onClose={() => {}} onClickContinue={() => {}} />);
+    render(<CreatePolicyModal isEdit={true} onClose={() => {}} onClickContinue={() => {}} />);
     // EuiOverlayMask appends an element to the body so we should have two, an empty div from react-test-library
     // and our EuiOverlayMask element
     expect(document.body.children).toHaveLength(2);
@@ -35,9 +34,7 @@ describe("<CreatePolicyModal /> spec", () => {
   it("calls onAction and onCLose when action button clicked", () => {
     const onContinue = jest.fn();
     const onClose = jest.fn();
-    const { getByTestId } = render(
-      <CreatePolicyModal isEdit={false} history={historyMock} onClose={onClose} onClickContinue={onContinue} />
-    );
+    const { getByTestId } = render(<CreatePolicyModal isEdit={false} onClose={onClose} onClickContinue={onContinue} />);
 
     fireEvent.click(getByTestId("createPolicyModalContinueButton"));
     expect(onContinue).toHaveBeenCalled();
@@ -46,7 +43,7 @@ describe("<CreatePolicyModal /> spec", () => {
 
   it("calls close when close button clicked", () => {
     const onClose = jest.fn();
-    const { getByTestId } = render(<CreatePolicyModal isEdit={false} history={historyMock} onClose={onClose} onClickContinue={() => {}} />);
+    const { getByTestId } = render(<CreatePolicyModal isEdit={false} onClose={onClose} onClickContinue={() => {}} />);
 
     fireEvent.click(getByTestId("createPolicyModalCancelButton"));
     expect(onClose).toHaveBeenCalled();

--- a/public/components/CreatePolicyModal/CreatePolicyModal.tsx
+++ b/public/components/CreatePolicyModal/CreatePolicyModal.tsx
@@ -26,16 +26,14 @@ import {
   EuiRadio,
   EuiPanel,
 } from "@elastic/eui";
-import * as H from "history";
 
 interface CreatePolicyModalProps {
   isEdit?: boolean;
-  history: H.History;
   onClose: () => void;
   onClickContinue: (visual: boolean) => void;
 }
 
-const CreatePolicyModal: React.SFC<CreatePolicyModalProps> = ({ isEdit = false, onClose, history, onClickContinue }) => {
+const CreatePolicyModal: React.SFC<CreatePolicyModalProps> = ({ isEdit = false, onClose, onClickContinue }) => {
   const [visual, setVisual] = useState(true);
   return (
     <EuiOverlayMask>

--- a/public/pages/VisualCreatePolicy/containers/CreateState/Actions.test.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/Actions.test.tsx
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render } from "@testing-library/react";
+import Actions from "./Actions";
+import { UIAction } from "../../../../../models/interfaces";
+import { CloseUIAction, RolloverUIAction } from "../../components/UIActions";
+import { DEFAULT_CLOSE, DEFAULT_ROLLOVER } from "../../utils/constants";
+
+describe("<Actions /> spec", () => {
+  it("renders the component", () => {
+    const actions: UIAction<any>[] = [new RolloverUIAction(DEFAULT_ROLLOVER, "some_id_1"), new CloseUIAction(DEFAULT_CLOSE, "some_id_2")];
+    const { container } = render(
+      <Actions
+        actions={actions}
+        onClickDeleteAction={() => {}}
+        onClickEditAction={() => {}}
+        onDragEndActions={() => {}}
+        onClickAddAction={() => {}}
+      />
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/public/pages/VisualCreatePolicy/containers/CreateState/Actions.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/Actions.tsx
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from "react";
+import { EuiButton, EuiFormRow, EuiDragDropContext, EuiDroppable, EuiSpacer, EuiText, DropResult } from "@elastic/eui";
+import DraggableItem from "../../components/DraggableItem";
+import EuiFormCustomLabel from "../../components/EuiFormCustomLabel";
+import { Action, UIAction } from "../../../../../models/interfaces";
+
+interface ActionsProps {
+  actions: UIAction<Action>[];
+  onClickDeleteAction: (idx: number) => void;
+  onClickEditAction: (action: UIAction<Action>) => void;
+  onDragEndActions: (dropResult: DropResult) => void;
+  onClickAddAction: () => void;
+}
+
+const Actions = ({ actions, onClickDeleteAction, onClickEditAction, onDragEndActions, onClickAddAction }: ActionsProps) => {
+  return (
+    <>
+      <EuiFormCustomLabel title="Actions" helpText="Actions are the operations ISM performs when an index is in a certain state." />
+
+      {!!actions.length && (
+        <EuiFormRow fullWidth isInvalid={false} error={null}>
+          <EuiDragDropContext onDragEnd={onDragEndActions}>
+            <EuiDroppable droppableId="STATE_ACTIONS_DROPPABLE_AREA">
+              {actions.map((action, idx) => (
+                <DraggableItem
+                  key={action.id}
+                  content={action.content()}
+                  id={action.id}
+                  idx={idx}
+                  isLast={actions.length - 1 === idx}
+                  onClickDelete={() => onClickDeleteAction(idx)}
+                  onClickEdit={() => onClickEditAction(action)}
+                />
+              ))}
+            </EuiDroppable>
+          </EuiDragDropContext>
+        </EuiFormRow>
+      )}
+
+      <EuiSpacer size="s" />
+
+      {!actions.length && (
+        <EuiText>
+          <p style={{ backgroundColor: "#F5F7FA", padding: "5px" }}>
+            <span style={{ color: "grey", fontWeight: 200, fontSize: "15px" }}>No actions have been added.</span>
+          </p>
+        </EuiText>
+      )}
+
+      <EuiSpacer />
+
+      <EuiButton onClick={onClickAddAction}>+ Add action</EuiButton>
+    </>
+  );
+};
+
+export default Actions;

--- a/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.test.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.test.tsx
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render } from "@testing-library/react";
+import CreateState from "./CreateState";
+import { DEFAULT_POLICY } from "../../utils/constants";
+
+describe("<CreateState /> spec", () => {
+  it("renders the component", () => {
+    const { container } = render(<CreateState policy={DEFAULT_POLICY} onSaveState={() => {}} onCloseFlyout={() => {}} state={null} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
@@ -1,0 +1,337 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React, { Component, ChangeEvent } from "react";
+import {
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiTitle,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiButtonEmpty,
+  EuiButton,
+  EuiFormRow,
+  EuiFieldText,
+  EuiHorizontalRule,
+  euiDragDropReorder,
+  DropResult,
+  EuiSelect,
+  EuiSpacer,
+  EuiText,
+  EuiPortal,
+} from "@elastic/eui";
+import { UIAction, Policy, State, Action, UITransition } from "../../../../../models/interfaces";
+import CreateTransition from "../CreateTransition";
+import CreateAction from "../CreateAction";
+import Actions from "./Actions";
+import Transitions from "./Transitions";
+import { getOrderInfo, getUIActionFromData } from "../../utils/helpers";
+import { makeId } from "../../../../utils/helpers";
+
+interface CreateStateProps {
+  policy: Policy;
+  onSaveState: (state: State, editingState: State | null, states: State[], order: string, afterBeforeState: string) => void;
+  onCloseFlyout: () => void;
+  state: State | null;
+}
+
+interface CreateStateState {
+  name: string;
+  createAction: boolean;
+  editAction: UIAction<Action> | null;
+  createTransition: boolean;
+  editTransition: UITransition | null;
+  actions: UIAction<Action>[];
+  transitions: UITransition[];
+  afterBeforeState: string;
+  order: string;
+  disableOrderSelections: boolean;
+}
+
+export default class CreateState extends Component<CreateStateProps, CreateStateState> {
+  constructor(props: CreateStateProps) {
+    super(props);
+
+    const { afterBeforeState, order, disableOrderSelections } = getOrderInfo(props.state, props.policy.states);
+    this.state = {
+      name: props.state?.name || "",
+      createAction: false,
+      editAction: null,
+      createTransition: false,
+      editTransition: null,
+      actions: props.state?.actions?.map((action) => getUIActionFromData(action)) || [],
+      transitions: props.state?.transitions?.map((transition) => ({ id: makeId(), transition })) || [],
+      afterBeforeState,
+      order,
+      disableOrderSelections,
+    };
+  }
+
+  onChangeStateName = (event: ChangeEvent<HTMLInputElement>) => {
+    const name = event.target.value;
+    this.setState((state) => ({ name }));
+  };
+
+  onDragEndActions = ({ source, destination }: DropResult) => {
+    if (source && destination) {
+      const items = euiDragDropReorder(this.state.actions, source.index, destination.index);
+      this.setState({ actions: items });
+    }
+  };
+
+  onDragEndTransitions = ({ source, destination }: DropResult) => {
+    if (source && destination) {
+      const items = euiDragDropReorder(this.state.transitions, source.index, destination.index);
+      this.setState({ transitions: items });
+    }
+  };
+
+  onClickDeleteAction = (idx: number) => {
+    const { actions } = this.state;
+    this.setState({ actions: actions.slice(0, idx).concat(actions.slice(idx + 1)) });
+  };
+
+  onClickEditAction = (action: UIAction<Action>) => this.setState({ editAction: action });
+
+  onClickAddAction = () => this.setState({ createAction: true });
+
+  onClickDeleteTransition = (idx: number) => {
+    const { transitions } = this.state;
+    this.setState({ transitions: transitions.slice(0, idx).concat(transitions.slice(idx + 1)) });
+  };
+
+  onClickEditTransition = (transition: UITransition) => this.setState({ editTransition: transition });
+
+  onClickAddTransition = () => {
+    this.setState({
+      createTransition: true,
+    });
+  };
+
+  onClickSaveTransition = (transition: UITransition) => {
+    const { editTransition, transitions } = this.state;
+    let newTransitions = [...transitions, transition];
+    if (!!editTransition) {
+      const foundTransitionIdx = transitions.findIndex(({ id }) => {
+        return transition.id === id;
+      });
+
+      if (foundTransitionIdx >= 0) {
+        newTransitions = transitions
+          .slice(0, foundTransitionIdx)
+          .concat(transition)
+          .concat(transitions.slice(foundTransitionIdx + 1));
+      }
+    }
+    this.setState((state) => ({
+      transitions: newTransitions,
+      createTransition: false,
+      editTransition: null,
+    }));
+  };
+
+  onClickSaveAction = (action: UIAction<Action>) => {
+    const { editAction, actions } = this.state;
+    if (action?.action) {
+      let newActions = [...actions, action];
+      if (!!editAction) {
+        const foundActionIdx = actions.findIndex(({ id }) => action.id === id);
+        if (foundActionIdx >= 0) {
+          newActions = actions
+            .slice(0, foundActionIdx)
+            .concat(action)
+            .concat(actions.slice(foundActionIdx + 1));
+        }
+      }
+      this.setState({
+        actions: newActions,
+        editAction: null,
+        createAction: false,
+      });
+    }
+  };
+
+  onClickCancelAction = () => {
+    this.setState({ createAction: false, editAction: null });
+  };
+
+  onClickSaveState = () => {
+    const { order, afterBeforeState } = this.state;
+    const { onSaveState, state, policy } = this.props;
+    onSaveState(
+      {
+        name: this.state.name,
+        actions: this.state.actions.map((action) => action.toAction()),
+        transitions: this.state.transitions.map((transition) => transition.transition),
+      },
+      state,
+      policy.states,
+      order,
+      afterBeforeState
+    );
+  };
+
+  renderDefault = () => {
+    const { policy, state } = this.props;
+    const { actions, name, afterBeforeState, order, disableOrderSelections } = this.state;
+    // If we are editing a state filter it out from the selectable options
+    const stateOptions = policy.states.map((state) => ({ value: state.name, text: state.name })).filter((s) => s.value !== state?.name);
+    return (
+      <>
+        <EuiText>
+          <h5>State name</h5>
+          <span /> {/* Dummy span to get rid of last child styling on h5 */}
+        </EuiText>
+
+        <EuiFormRow fullWidth isInvalid={false} error={null}>
+          <EuiFieldText
+            fullWidth
+            isInvalid={false}
+            placeholder="sample_hot_state"
+            readOnly={false}
+            value={name}
+            onChange={this.onChangeStateName}
+            data-test-subj="create-state-state-name"
+          />
+        </EuiFormRow>
+
+        <EuiSpacer />
+
+        <EuiText>
+          <h5>Order</h5>
+          <span /> {/* Dummy span to get rid of last child styling on h5 */}
+        </EuiText>
+
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            <EuiFormRow>
+              <EuiSelect
+                disabled={disableOrderSelections}
+                options={[
+                  { value: "after", text: "Add after" },
+                  { value: "before", text: "Add before" },
+                ]}
+                value={order}
+                onChange={(e) => this.setState({ order: e.target.value })}
+                aria-label="Retry failed policy from"
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiFormRow>
+              <EuiSelect
+                disabled={disableOrderSelections}
+                options={stateOptions}
+                value={afterBeforeState}
+                onChange={(e) => this.setState({ afterBeforeState: e.target.value })}
+                aria-label="Retry failed policy from"
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+
+        <EuiHorizontalRule />
+
+        <Actions
+          actions={actions}
+          onClickDeleteAction={this.onClickDeleteAction}
+          onClickEditAction={this.onClickEditAction}
+          onDragEndActions={this.onDragEndActions}
+          onClickAddAction={this.onClickAddAction}
+        />
+
+        <EuiHorizontalRule />
+
+        <Transitions
+          transitions={this.state.transitions}
+          onDragEndTransitions={this.onDragEndTransitions}
+          onClickDeleteTransition={this.onClickDeleteTransition}
+          onClickEditTransition={this.onClickEditTransition}
+          onClickAddTransition={this.onClickAddTransition}
+        />
+      </>
+    );
+  };
+
+  renderDefaultFooter = () => {
+    const { onCloseFlyout, state } = this.props;
+    const { name } = this.state;
+    const isEditing = !!state;
+    return (
+      <EuiFlexGroup justifyContent="spaceBetween">
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty iconType="cross" onClick={onCloseFlyout} flush="left">
+            Close
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButton fill disabled={!name.trim().length} onClick={this.onClickSaveState}>
+            {isEditing ? "Update state" : "Save state"}
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  };
+
+  render() {
+    const { onCloseFlyout, policy, state } = this.props;
+    const { name, createAction, editAction, createTransition, editTransition, actions } = this.state;
+    const isEditing = !!state;
+
+    let title = `${isEditing ? "Edit" : "Create"} state: ${name}`;
+    if (createTransition || createAction || !!editTransition || !!editAction) title = `State: ${name}`;
+
+    // Filter out the current editing state if we are editing
+    const stateOptions = policy.states.map((s) => s.name);
+
+    let flyoutContent;
+    if (createAction || !!editAction)
+      flyoutContent = () => (
+        <CreateAction
+          actions={actions}
+          editAction={editAction}
+          stateName={name}
+          onClickCancelAction={this.onClickCancelAction}
+          onClickSaveAction={this.onClickSaveAction}
+        />
+      );
+    if (createTransition || editTransition)
+      flyoutContent = () => (
+        <CreateTransition
+          stateOptions={stateOptions}
+          editTransition={editTransition}
+          onCloseCreateTransition={() => this.setState({ createTransition: false, editTransition: null })}
+          onClickSaveTransition={this.onClickSaveTransition}
+        />
+      );
+    if (!flyoutContent)
+      flyoutContent = () => (
+        <>
+          <EuiFlyoutBody>{this.renderDefault()}</EuiFlyoutBody>
+          <EuiFlyoutFooter>{this.renderDefaultFooter()}</EuiFlyoutFooter>
+        </>
+      );
+    return (
+      <EuiPortal>
+        <EuiFlyout ownFocus onClose={onCloseFlyout} maxWidth={600} size="m" aria-labelledby="flyoutTitle">
+          <EuiFlyoutHeader hasBorder>
+            <EuiTitle size="m">
+              <h2 id="flyoutTitle">{title}</h2>
+            </EuiTitle>
+          </EuiFlyoutHeader>
+          {flyoutContent()}
+        </EuiFlyout>
+      </EuiPortal>
+    );
+  }
+}

--- a/public/pages/VisualCreatePolicy/containers/CreateState/Transitions.test.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/Transitions.test.tsx
@@ -12,18 +12,22 @@
 import React from "react";
 import "@testing-library/jest-dom/extend-expect";
 import { render } from "@testing-library/react";
-import CreateTransition from "./CreateTransition";
+import Transitions from "./Transitions";
 import { UITransition } from "../../../../../models/interfaces";
 
-describe("<CreateTransition /> spec", () => {
+describe("<Transitions /> spec", () => {
   it("renders the component", () => {
-    const transition: UITransition = { id: "some_id", transition: { state_name: "hot", conditions: { min_index_age: "30d" } } };
+    const transitions: UITransition[] = [
+      { id: "some_id_1", transition: { state_name: "some_state", conditions: { min_index_age: "30d" } } },
+      { id: "some_id_2", transition: { state_name: "some_state", conditions: { min_size: "50gb" } } },
+    ];
     const { container } = render(
-      <CreateTransition
-        editTransition={transition}
-        onCloseCreateTransition={() => {}}
-        onClickSaveTransition={() => {}}
-        stateOptions={["hot", "warm", "cold"]}
+      <Transitions
+        transitions={transitions}
+        onClickDeleteTransition={() => {}}
+        onClickEditTransition={() => {}}
+        onDragEndTransitions={() => {}}
+        onClickAddTransition={() => {}}
       />
     );
     expect(container.firstChild).toMatchSnapshot();

--- a/public/pages/VisualCreatePolicy/containers/CreateState/Transitions.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/Transitions.tsx
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from "react";
+import { EuiButton, EuiFormRow, EuiDragDropContext, EuiDroppable, EuiSpacer, EuiText, DropResult } from "@elastic/eui";
+import EuiFormCustomLabel from "../../components/EuiFormCustomLabel";
+import DraggableItem from "../../components/DraggableItem";
+import { UITransition } from "../../../../../models/interfaces";
+import { getConditionContent } from "../../utils/helpers";
+
+interface TransitionsProps {
+  transitions: UITransition[];
+  onClickDeleteTransition: (idx: number) => void;
+  onClickEditTransition: (transition: UITransition) => void;
+  onDragEndTransitions: (dropResult: DropResult) => void;
+  onClickAddTransition: () => void;
+}
+
+const Transitions = ({
+  transitions,
+  onClickDeleteTransition,
+  onClickEditTransition,
+  onDragEndTransitions,
+  onClickAddTransition,
+}: TransitionsProps) => {
+  return (
+    <>
+      <EuiFormCustomLabel
+        title="Transitions"
+        helpText="Transitions define the conditions that need to be met for a state to change. After all actions in the current state are completed, the policy starts checking the conditions for transitions."
+      />
+      {!!transitions.length && (
+        <EuiFormRow fullWidth isInvalid={false} error={null}>
+          <EuiDragDropContext onDragEnd={onDragEndTransitions}>
+            <EuiDroppable droppableId="STATE_TRANSITIONS_DROPPABLE_AREA">
+              {transitions.map((transition, idx) => (
+                <DraggableItem
+                  key={transition.id}
+                  id={transition.id}
+                  content={getConditionContent(transition.transition)}
+                  idx={idx}
+                  isLast={transitions.length - 1 === idx}
+                  onClickDelete={() => onClickDeleteTransition(idx)}
+                  onClickEdit={() => onClickEditTransition(transition)}
+                />
+              ))}
+            </EuiDroppable>
+          </EuiDragDropContext>
+        </EuiFormRow>
+      )}
+
+      <EuiSpacer size="s" />
+
+      {!transitions.length && (
+        <EuiText>
+          <p style={{ backgroundColor: "#F5F7FA", padding: "5px" }}>
+            <span style={{ color: "grey", fontWeight: 200, fontSize: "15px" }}>No transitions have been added.</span>
+          </p>
+        </EuiText>
+      )}
+
+      <EuiSpacer />
+
+      <EuiButton onClick={onClickAddTransition}>+ Add Transition</EuiButton>
+    </>
+  );
+};
+
+export default Transitions;

--- a/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/Actions.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/Actions.test.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Actions /> spec renders the component 1`] = `
+<div
+  class="euiText euiText--medium"
+  style="margin-bottom: 5px;"
+>
+  <h5
+    style="margin-bottom: 2px;"
+  >
+    Actions
+  </h5>
+  <p>
+     
+    <span
+      style="color: grey; font-weight: 200; font-size: 12px;"
+    >
+      Actions are the operations ISM performs when an index is in a certain state.
+    </span>
+  </p>
+</div>
+`;

--- a/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/CreateState.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/CreateState.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<CreateState /> spec renders the component 1`] = `null`;

--- a/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/Transitions.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/Transitions.test.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Transitions /> spec renders the component 1`] = `
+<div
+  class="euiText euiText--medium"
+  style="margin-bottom: 5px;"
+>
+  <h5
+    style="margin-bottom: 2px;"
+  >
+    Transitions
+  </h5>
+  <p>
+     
+    <span
+      style="color: grey; font-weight: 200; font-size: 12px;"
+    >
+      Transitions define the conditions that need to be met for a state to change. After all actions in the current state are completed, the policy starts checking the conditions for transitions.
+    </span>
+  </p>
+</div>
+`;

--- a/public/pages/VisualCreatePolicy/containers/CreateState/index.ts
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/index.ts
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import CreateState from "./CreateState";
+
+export default CreateState;

--- a/public/pages/VisualCreatePolicy/containers/CreateTransition/CreateTransition.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateTransition/CreateTransition.tsx
@@ -19,7 +19,6 @@ import Transition from "../../components/Transition";
 
 interface CreateTransitionProps {
   editTransition: UITransition | null;
-  transitions: UITransition[];
   onCloseCreateTransition: () => void;
   onClickSaveTransition: (uiTransition: UITransition) => void;
   stateOptions: string[];

--- a/public/pages/VisualCreatePolicy/utils/helpers.test.ts
+++ b/public/pages/VisualCreatePolicy/utils/helpers.test.ts
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-import { convertTemplatesToArray } from "./helpers";
+import { convertTemplatesToArray, getOrderInfo } from "./helpers";
 import { ISMTemplate } from "../../../../models/interfaces";
 
 test("converts all ism template formats into a list of ism templates", () => {
@@ -19,4 +19,28 @@ test("converts all ism template formats into a list of ism templates", () => {
   expect(convertTemplatesToArray(template)).toEqual([template]);
   const templates = [template, { index_patterns: ["log*"], priority: 50 }];
   expect(convertTemplatesToArray(templates)).toEqual(templates);
+});
+
+test("getOrderInfo returns correct order info", () => {
+  const state = { name: "some_name" };
+  const state2 = { name: "some_name2" };
+  const state3 = { name: "some_name3" };
+  expect(getOrderInfo(state, [state]).disableOrderSelections).toBe(true);
+  expect(getOrderInfo(state, [state]).order).toBe("after");
+  expect(getOrderInfo(state, [state]).afterBeforeState).toBe("");
+  expect(getOrderInfo(state, [state, state2]).disableOrderSelections).toBe(false);
+
+  expect(getOrderInfo(state, [state, state2, state3]).disableOrderSelections).toBe(false);
+  expect(getOrderInfo(state, [state, state2, state3]).order).toBe("before");
+  expect(getOrderInfo(state, [state, state2, state3]).afterBeforeState).toBe(state2.name);
+
+  expect(getOrderInfo(state2, [state, state2, state3]).order).toBe("after");
+  expect(getOrderInfo(state2, [state, state2, state3]).afterBeforeState).toBe(state.name);
+
+  expect(getOrderInfo(null, []).disableOrderSelections).toBe(true);
+  expect(getOrderInfo(null, []).afterBeforeState).toBe("");
+
+  expect(getOrderInfo(null, [state]).disableOrderSelections).toBe(false);
+  expect(getOrderInfo(null, [state]).order).toBe("after");
+  expect(getOrderInfo(null, [state]).afterBeforeState).toBe(state.name);
 });

--- a/public/pages/VisualCreatePolicy/utils/helpers.ts
+++ b/public/pages/VisualCreatePolicy/utils/helpers.ts
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-import { UIAction, Action, Transition, ISMTemplate } from "../../../../models/interfaces";
+import { UIAction, Action, Transition, ISMTemplate, State } from "../../../../models/interfaces";
 import {
   ActionType,
   DEFAULT_ALLOCATION,
@@ -112,3 +112,40 @@ export const convertTemplatesToArray = (ismTemplates: ISMTemplate[] | ISMTemplat
 
 export const capitalizeFirstLetter = ([first, ...rest]: string, locale = navigator.language) =>
   first.toLocaleUpperCase(locale) + rest.join("");
+
+export const getOrderInfo = (
+  state: State | null,
+  states: State[]
+): { order: string; afterBeforeState: string; disableOrderSelections: boolean } => {
+  const isEditing = !!state;
+  const editingStateIdx = states.findIndex((s) => s === state);
+  let afterBeforeState = "";
+  let order = "after";
+  let disableOrderSelections = false;
+  if (isEditing) {
+    // If there is only one existing state then we are editing the only state and there is nothing to order after/before
+    if (states.length === 1) {
+      disableOrderSelections = true;
+    } else {
+      // If the editing state is the first state then we are "Add before $secondState"
+      if (editingStateIdx === 0) {
+        afterBeforeState = states[editingStateIdx + 1]?.name;
+        order = "before";
+      } else {
+        // otherwise we are "Add after $previousState"
+        afterBeforeState = states[editingStateIdx - 1]?.name;
+      }
+    }
+  } else {
+    // when creating a new state
+    // If there are no existing states then there is nothing to order after/before
+    if (!states.length) {
+      disableOrderSelections = true;
+    } else {
+      // Else always order it after the last state
+      afterBeforeState = states[states.length - 1]?.name;
+    }
+  }
+
+  return { order, afterBeforeState, disableOrderSelections };
+};


### PR DESCRIPTION
…reate transitions

Signed-off-by: Drew Baugher <46505179+dbbaughe@users.noreply.github.com>

### Description

![Screen Shot 2021-08-11 at 5 42 33 PM](https://user-images.githubusercontent.com/46505179/129121266-a7cbb153-f2a8-4552-854f-4aac7f18a4db.png)

Missing a lot of tests for these, will add in follow up PRs.

### Check List

- [ ] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

