### PR TITLE
Adds VisualCreatePolicy page, missing backend routes/configs, updates…

### DIFF
--- a/cypress/integration/managed_indices_spec.js
+++ b/cypress/integration/managed_indices_spec.js
@@ -211,8 +211,8 @@ describe("Managed indices", () => {
       // Confirm we got the change policy toaster
       cy.contains("Changed policy on 1 indices");
 
-      // Click back to Managed Indices page
-      cy.contains("Managed Indices").click();
+      // Click back to Managed Indices page by clicking "Managed indices" breadcrumb
+      cy.contains("Managed indices").click();
 
       // Speed up execution of managed index
       cy.updateManagedIndexConfigStartTime(SAMPLE_INDEX);

--- a/cypress/integration/policies_spec.js
+++ b/cypress/integration/policies_spec.js
@@ -103,6 +103,12 @@ describe("Policies", () => {
       // Click Edit button
       cy.get(`[data-test-subj="EditButton"]`).click({ force: true });
 
+      // Route us to edit policy page
+      cy.contains("JSON editor").click({ force: true });
+
+      // Route us to edit policy page
+      cy.contains("Continue").click({ force: true });
+
       // Wait for initial policy JSON to load
       cy.contains("A simple description");
 

--- a/cypress/integration/policies_spec.js
+++ b/cypress/integration/policies_spec.js
@@ -53,6 +53,12 @@ describe("Policies", () => {
       // Route us to create policy page
       cy.contains("Create policy").click({ force: true });
 
+      // Route us to create policy page
+      cy.contains("JSON editor").click({ force: true });
+
+      // Route us to create policy page
+      cy.contains("Continue").click({ force: true });
+
       // Wait for input to load and then type in the policy ID
       cy.get(`input[placeholder="hot_cold_workflow"]`).type(POLICY_ID, { force: true });
 

--- a/models/interfaces.ts
+++ b/models/interfaces.ts
@@ -92,8 +92,11 @@ export interface DocumentTransform {
 export interface Policy {
   description: string;
   default_state: string;
+  error_notification?: ErrorNotification | null;
   states: State[];
-  ism_template: any;
+  ism_template?: ISMTemplate[] | ISMTemplate | null;
+  last_updated_time?: string;
+  schema_version?: number;
 }
 
 export interface ErrorNotification {

--- a/public/app.scss
+++ b/public/app.scss
@@ -12,3 +12,41 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+// Copies over styling from eui library to be used in custom classes
+// Core
+$euiColorPrimary: #006BB4 !default;
+$euiColorDarkestShade: #343741 !default;
+$euiColorGhost: #FFF !default;
+$euiColorInk: #000 !default;
+$euiTextColor: $euiColorDarkestShade !default;
+
+.selected-radio-panel {
+  background-color: tintOrShade($euiColorPrimary, 90%, 70%);
+  border-color: $euiColorPrimary;
+}
+
+@function tintOrShade($color, $tint, $shade) {
+  @if (lightness($euiTextColor) > 50) {
+    @return shade($color, $shade);
+  } @else {
+    @return tint($color, $tint);
+  }
+}
+
+@function tint($color, $percent) {
+  @return mix($euiColorGhost, $color, $percent);
+}
+
+@function shade($color, $percent) {
+  @return mix($euiColorInk, $color, $percent);
+}
+
+.refresh-button {
+  min-width: 0;
+  .euiButtonContent {
+    .euiButton__text {
+      margin: 0;
+    }
+  }
+}

--- a/public/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/public/components/ConfirmationModal/ConfirmationModal.tsx
@@ -39,18 +39,28 @@ import {
 
 interface ConfirmationModalProps {
   title: string;
-  bodyMessage: string;
+  bodyMessage: string | JSX.Element;
   actionMessage: string;
+  actionProps?: object;
+  modalProps?: object;
   onClose: () => void;
   onAction: () => void;
 }
 
-const ConfirmationModal: React.SFC<ConfirmationModalProps> = ({ title, bodyMessage, actionMessage, onClose, onAction }) => {
+const ConfirmationModal: React.SFC<ConfirmationModalProps> = ({
+  title,
+  bodyMessage,
+  actionMessage,
+  onClose,
+  onAction,
+  actionProps = {},
+  modalProps = {},
+}) => {
   return (
     <EuiOverlayMask>
       {/*
       // @ts-ignore */}
-      <EuiModal onCancel={onClose} onClose={onClose} maxWidth={1000}>
+      <EuiModal onCancel={onClose} onClose={onClose} maxWidth={1000} {...modalProps}>
         <EuiModalHeader>
           <EuiModalHeaderTitle>{title}</EuiModalHeaderTitle>
         </EuiModalHeader>
@@ -68,6 +78,7 @@ const ConfirmationModal: React.SFC<ConfirmationModalProps> = ({ title, bodyMessa
             }}
             fill
             data-test-subj="confirmationModalActionButton"
+            {...actionProps}
           >
             {actionMessage}
           </EuiButton>

--- a/public/components/PolicyModal/PolicyModal.tsx
+++ b/public/components/PolicyModal/PolicyModal.tsx
@@ -46,7 +46,7 @@ interface PolicyModalProps {
   policy: object | null;
   errorMessage?: string;
   onClose: () => void;
-  onEdit: () => void;
+  onEdit: (visual: boolean) => void;
 }
 
 const PolicyModal: React.SFC<PolicyModalProps> = ({ policyId, policy, errorMessage, onClose, onEdit }) => {
@@ -61,7 +61,7 @@ const PolicyModal: React.SFC<PolicyModalProps> = ({ policyId, policy, errorMessa
         </EuiModalHeader>
 
         <EuiModalBody>
-          <EuiCodeBlock language="json" fontSize="m">
+          <EuiCodeBlock language="json" fontSize="m" style={{ minWidth: 600 }}>
             {errorMessage != null ? errorMessage : policyString}
           </EuiCodeBlock>
         </EuiModalBody>
@@ -83,7 +83,12 @@ const PolicyModal: React.SFC<PolicyModalProps> = ({ policyId, policy, errorMessa
               </EuiButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton onClick={onEdit} fill disabled={!policyId || !policy} data-test-subj="policyModalEditButton">
+              <EuiButton onClick={() => onEdit(false)} fill disabled={!policyId || !policy} data-test-subj="policyModalEditJsonButton">
+                Edit as JSON
+              </EuiButton>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton onClick={() => onEdit(true)} fill disabled={!policyId || !policy} data-test-subj="policyModalEditButton">
                 Edit
               </EuiButton>
             </EuiFlexItem>

--- a/public/components/PolicyModal/__snapshots__/PolicyModal.test.tsx.snap
+++ b/public/components/PolicyModal/__snapshots__/PolicyModal.test.tsx.snap
@@ -59,6 +59,7 @@ exports[`<PolicyModal /> spec renders the component 1`] = `
               >
                 <code
                   class="euiCodeBlock__code json hljs"
+                  style="min-width: 600px;"
                 >
                   {
     
@@ -134,6 +135,25 @@ exports[`<PolicyModal /> spec renders the component 1`] = `
                     class="euiButtonEmpty__text"
                   >
                     Close
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <button
+                class="euiButton euiButton--primary euiButton--fill"
+                data-test-subj="policyModalEditJsonButton"
+                type="button"
+              >
+                <span
+                  class="euiButtonContent euiButton__content"
+                >
+                  <span
+                    class="euiButton__text"
+                  >
+                    Edit as JSON
                   </span>
                 </span>
               </button>

--- a/public/index_management_app.tsx
+++ b/public/index_management_app.tsx
@@ -40,6 +40,7 @@ import {
 import { DarkModeContext } from "./components/DarkMode";
 import Main from "./pages/Main";
 import { CoreServicesContext } from "./components/core_services";
+import "./app.scss";
 
 export function renderApp(coreStart: CoreStart, params: AppMountParameters) {
   const http = coreStart.http;

--- a/public/pages/CreatePolicy/containers/CreatePolicy/CreatePolicy.tsx
+++ b/public/pages/CreatePolicy/containers/CreatePolicy/CreatePolicy.tsx
@@ -113,7 +113,7 @@ export default class CreatePolicy extends Component<CreatePolicyProps, CreatePol
     }
   };
 
-  onCreate = async (policyId: string, policy: Policy): Promise<void> => {
+  onCreate = async (policyId: string, policy: { policy: Policy }): Promise<void> => {
     const { policyService } = this.props;
     try {
       const response = await policyService.putPolicy(policy, policyId);
@@ -128,7 +128,7 @@ export default class CreatePolicy extends Component<CreatePolicyProps, CreatePol
     }
   };
 
-  onUpdate = async (policyId: string, policy: Policy): Promise<void> => {
+  onUpdate = async (policyId: string, policy: { policy: Policy }): Promise<void> => {
     try {
       const { policyService } = this.props;
       const { policyPrimaryTerm, policySeqNo } = this.state;

--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -33,6 +33,7 @@ import Policies from "../Policies";
 import ManagedIndices from "../ManagedIndices";
 import Indices from "../Indices";
 import CreatePolicy from "../CreatePolicy";
+import VisualCreatePolicy from "../VisualCreatePolicy";
 import ChangePolicy from "../ChangePolicy";
 import Rollups from "../Rollups";
 import { ModalProvider, ModalRoot } from "../../components/Modal";
@@ -46,6 +47,8 @@ import EditRollup from "../EditRollup/containers";
 import RollupDetails from "../RollupDetails/containers/RollupDetails";
 import { EditTransform, Transforms } from "../Transforms";
 import TransformDetails from "../Transforms/containers/Transforms/TransformDetails";
+import queryString from "query-string";
+import PolicyDetails from "../PolicyDetails/containers/PolicyDetails";
 
 enum Navigation {
   IndexManagement = "Index Management",
@@ -63,6 +66,18 @@ enum Pathname {
   Rollups = "/rollups",
   Transforms = "/transforms",
 }
+
+const HIDDEN_NAV_ROUTES = [
+  ROUTES.CREATE_ROLLUP,
+  ROUTES.EDIT_ROLLUP,
+  ROUTES.ROLLUP_DETAILS,
+  ROUTES.CREATE_TRANSFORM,
+  ROUTES.EDIT_TRANSFORM,
+  ROUTES.TRANSFORM_DETAILS,
+  ROUTES.CREATE_POLICY,
+  ROUTES.EDIT_POLICY,
+  ROUTES.CHANGE_POLICY,
+];
 
 interface MainProps extends RouteComponentProps {}
 
@@ -121,16 +136,11 @@ export default class Main extends Component<MainProps, object> {
                     <ModalRoot services={services} />
                     <EuiPage restrictWidth="100%">
                       {/*Hide side navigation bar when creating or editing rollup job*/}
-                      {pathname != ROUTES.CREATE_ROLLUP &&
-                        pathname != ROUTES.EDIT_ROLLUP &&
-                        pathname != ROUTES.ROLLUP_DETAILS &&
-                        pathname != ROUTES.CREATE_TRANSFORM &&
-                        pathname != ROUTES.EDIT_TRANSFORM &&
-                        pathname != ROUTES.TRANSFORM_DETAILS && (
-                          <EuiPageSideBar style={{ minWidth: 150 }}>
-                            <EuiSideNav style={{ width: 150 }} items={sideNav} />
-                          </EuiPageSideBar>
-                        )}
+                      {!HIDDEN_NAV_ROUTES.includes(pathname) && (
+                        <EuiPageSideBar style={{ minWidth: 150 }}>
+                          <EuiSideNav style={{ width: 150 }} items={sideNav} />
+                        </EuiPageSideBar>
+                      )}
                       <EuiPageBody>
                         <Switch>
                           <Route
@@ -145,15 +155,33 @@ export default class Main extends Component<MainProps, object> {
                           />
                           <Route
                             path={ROUTES.CREATE_POLICY}
-                            render={(props: RouteComponentProps) => (
-                              <CreatePolicy {...props} isEdit={false} policyService={services.policyService} />
-                            )}
+                            render={(props: RouteComponentProps) =>
+                              queryString.parse(this.props.location.search).type == "visual" ? (
+                                <VisualCreatePolicy
+                                  {...props}
+                                  isEdit={false}
+                                  policyService={services.policyService}
+                                  notificationService={services.notificationService}
+                                />
+                              ) : (
+                                <CreatePolicy {...props} isEdit={false} policyService={services.policyService} />
+                              )
+                            }
                           />
                           <Route
                             path={ROUTES.EDIT_POLICY}
-                            render={(props: RouteComponentProps) => (
-                              <CreatePolicy {...props} isEdit={true} policyService={services.policyService} />
-                            )}
+                            render={(props: RouteComponentProps) =>
+                              queryString.parse(this.props.location.search).type == "visual" ? (
+                                <VisualCreatePolicy
+                                  {...props}
+                                  isEdit={true}
+                                  policyService={services.policyService}
+                                  notificationService={services.notificationService}
+                                />
+                              ) : (
+                                <CreatePolicy {...props} isEdit={true} policyService={services.policyService} />
+                              )
+                            }
                           />
                           <Route
                             path={ROUTES.INDEX_POLICIES}

--- a/public/pages/ManagedIndices/components/ManagedIndexEmptyPrompt/ManagedIndexEmptyPrompt.test.tsx
+++ b/public/pages/ManagedIndices/components/ManagedIndexEmptyPrompt/ManagedIndexEmptyPrompt.test.tsx
@@ -28,17 +28,20 @@ import React from "react";
 import "@testing-library/jest-dom/extend-expect";
 import { render, fireEvent } from "@testing-library/react";
 import ManagedIndexEmptyPrompt, { TEXT } from "./ManagedIndexEmptyPrompt";
+import historyMock from "../../../../../test/mocks/historyMock";
 
 describe("<ManagedIndexEmptyPrompt /> spec", () => {
   it("renders the component", async () => {
-    const { container } = render(<ManagedIndexEmptyPrompt filterIsApplied={false} loading={false} resetFilters={() => {}} />);
+    const { container } = render(
+      <ManagedIndexEmptyPrompt history={historyMock} filterIsApplied={false} loading={false} resetFilters={() => {}} />
+    );
 
     expect(container.firstChild).toMatchSnapshot();
   });
 
   it("renders no managed indices by default", async () => {
     const { getByText, queryByTestId } = render(
-      <ManagedIndexEmptyPrompt filterIsApplied={false} loading={false} resetFilters={() => {}} />
+      <ManagedIndexEmptyPrompt history={historyMock} filterIsApplied={false} loading={false} resetFilters={() => {}} />
     );
 
     getByText(TEXT.NO_MANAGED_INDICES);
@@ -46,7 +49,9 @@ describe("<ManagedIndexEmptyPrompt /> spec", () => {
   });
 
   it("shows LOADING", async () => {
-    const { getByText, queryByTestId } = render(<ManagedIndexEmptyPrompt filterIsApplied={true} loading={true} resetFilters={() => {}} />);
+    const { getByText, queryByTestId } = render(
+      <ManagedIndexEmptyPrompt history={historyMock} filterIsApplied={true} loading={true} resetFilters={() => {}} />
+    );
 
     getByText(TEXT.LOADING);
     expect(queryByTestId("managedIndexEmptyPromptResetFilters")).toBeNull();
@@ -55,7 +60,7 @@ describe("<ManagedIndexEmptyPrompt /> spec", () => {
   it("shows reset filters", async () => {
     const resetFilters = jest.fn();
     const { getByText, getByTestId } = render(
-      <ManagedIndexEmptyPrompt filterIsApplied={true} loading={false} resetFilters={resetFilters} />
+      <ManagedIndexEmptyPrompt history={historyMock} filterIsApplied={true} loading={false} resetFilters={resetFilters} />
     );
 
     getByText(TEXT.RESET_FILTERS);

--- a/public/pages/ManagedIndices/components/ManagedIndexEmptyPrompt/ManagedIndexEmptyPrompt.tsx
+++ b/public/pages/ManagedIndices/components/ManagedIndexEmptyPrompt/ManagedIndexEmptyPrompt.tsx
@@ -25,8 +25,11 @@
  */
 
 import React from "react";
+import * as H from "history";
 import { EuiButton, EuiEmptyPrompt, EuiText } from "@elastic/eui";
-import { PLUGIN_NAME, ROUTES } from "../../../../utils/constants";
+import { ModalConsumer } from "../../../../components/Modal";
+import CreatePolicyModal from "../../../../components/CreatePolicyModal";
+import { ROUTES } from "../../../../utils/constants";
 
 export const TEXT = {
   RESET_FILTERS: "There are no managed indices matching your applied filters. Reset your filters to view your managed indices.",
@@ -40,7 +43,7 @@ const getMessagePrompt = ({ filterIsApplied, loading }: ManagedIndexEmptyPromptP
   return TEXT.NO_MANAGED_INDICES;
 };
 
-const getActions: React.SFC<ManagedIndexEmptyPromptProps> = ({ filterIsApplied, loading, resetFilters }) => {
+const getActions: React.SFC<ManagedIndexEmptyPromptProps> = ({ history, filterIsApplied, loading, resetFilters }) => {
   if (loading) return null;
 
   if (filterIsApplied) {
@@ -51,10 +54,18 @@ const getActions: React.SFC<ManagedIndexEmptyPromptProps> = ({ filterIsApplied, 
     );
   }
 
+  const onClickCreate = (visual: boolean): void => {
+    history.push(`${ROUTES.CREATE_POLICY}${visual ? "?type=visual" : ""}`);
+  };
+
   return (
-    <EuiButton fill href={`${PLUGIN_NAME}#${ROUTES.CREATE_POLICY}`}>
-      Create policy
-    </EuiButton>
+    <ModalConsumer>
+      {({ onShow }) => (
+        <EuiButton fill onClick={() => onShow(CreatePolicyModal, { history, onClickContinue: onClickCreate })}>
+          Create policy
+        </EuiButton>
+      )}
+    </ModalConsumer>
   );
 };
 
@@ -62,9 +73,10 @@ interface ManagedIndexEmptyPromptProps {
   filterIsApplied: boolean;
   loading: boolean;
   resetFilters: () => void;
+  history: H.History;
 }
 
-const ManagedIndexEmptyPrompt: React.SFC<ManagedIndexEmptyPromptProps> = props => (
+const ManagedIndexEmptyPrompt: React.SFC<ManagedIndexEmptyPromptProps> = (props) => (
   <EuiEmptyPrompt
     style={{ maxWidth: "45em" }}
     body={

--- a/public/pages/ManagedIndices/components/ManagedIndexEmptyPrompt/__snapshots__/ManagedIndexEmptyPrompt.test.tsx.snap
+++ b/public/pages/ManagedIndices/components/ManagedIndexEmptyPrompt/__snapshots__/ManagedIndexEmptyPrompt.test.tsx.snap
@@ -26,10 +26,9 @@ exports[`<ManagedIndexEmptyPrompt /> spec renders the component 1`] = `
   <div
     class="euiSpacer euiSpacer--s"
   />
-  <a
+  <button
     class="euiButton euiButton--primary euiButton--fill"
-    href="opensearch_index_management_dashboards#/create-policy"
-    rel="noreferrer"
+    type="button"
   >
     <span
       class="euiButtonContent euiButton__content"
@@ -40,6 +39,6 @@ exports[`<ManagedIndexEmptyPrompt /> spec renders the component 1`] = `
         Create policy
       </span>
     </span>
-  </a>
+  </button>
 </div>
 `;

--- a/public/pages/ManagedIndices/containers/ManagedIndices/ManagedIndices.tsx
+++ b/public/pages/ManagedIndices/containers/ManagedIndices/ManagedIndices.tsx
@@ -467,7 +467,12 @@ export default class ManagedIndices extends Component<ManagedIndicesProps, Manag
             itemId="index"
             items={managedIndices}
             noItemsMessage={
-              <ManagedIndexEmptyPrompt filterIsApplied={filterIsApplied} loading={loadingManagedIndices} resetFilters={this.resetFilters} />
+              <ManagedIndexEmptyPrompt
+                history={this.props.history}
+                filterIsApplied={filterIsApplied}
+                loading={loadingManagedIndices}
+                resetFilters={this.resetFilters}
+              />
             }
             onChange={this.onTableChange}
             pagination={pagination}

--- a/public/pages/Policies/components/PolicyEmptyPrompt/PolicyEmptyPrompt.tsx
+++ b/public/pages/Policies/components/PolicyEmptyPrompt/PolicyEmptyPrompt.tsx
@@ -26,7 +26,9 @@
 
 import React from "react";
 import { EuiButton, EuiEmptyPrompt, EuiText } from "@elastic/eui";
-import { PLUGIN_NAME, ROUTES } from "../../../../utils/constants";
+import { ROUTES } from "../../../../utils/constants";
+import { ModalConsumer } from "../../../../components/Modal";
+import CreatePolicyModal from "../../../../components/CreatePolicyModal";
 
 export const TEXT = {
   RESET_FILTERS: "There are no policies matching your applied filters. Reset your filters to view your policies.",
@@ -40,7 +42,7 @@ const getMessagePrompt = ({ filterIsApplied, loading }: PolicyEmptyPromptProps) 
   return TEXT.NO_POLICIES;
 };
 
-const getActions: React.SFC<PolicyEmptyPromptProps> = ({ filterIsApplied, loading, resetFilters }) => {
+const getActions: React.SFC<PolicyEmptyPromptProps> = ({ history, filterIsApplied, loading, resetFilters }) => {
   if (loading) {
     return null;
   }
@@ -52,10 +54,18 @@ const getActions: React.SFC<PolicyEmptyPromptProps> = ({ filterIsApplied, loadin
     );
   }
 
+  const onClickCreate = (visual: boolean): void => {
+    history.push(`${ROUTES.CREATE_POLICY}${visual ? "?type=visual" : ""}`);
+  };
+
   return (
-    <EuiButton fill href={`${PLUGIN_NAME}#${ROUTES.CREATE_POLICY}`}>
-      Create policy
-    </EuiButton>
+    <ModalConsumer>
+      {({ onShow }) => (
+        <EuiButton fill onClick={() => onShow(CreatePolicyModal, { history, onClickContinue: onClickCreate })}>
+          Create policy
+        </EuiButton>
+      )}
+    </ModalConsumer>
   );
 };
 
@@ -63,9 +73,10 @@ interface PolicyEmptyPromptProps {
   filterIsApplied: boolean;
   loading: boolean;
   resetFilters: () => void;
+  history: any;
 }
 
-const PolicyEmptyPrompt: React.SFC<PolicyEmptyPromptProps> = props => (
+const PolicyEmptyPrompt: React.SFC<PolicyEmptyPromptProps> = (props) => (
   <EuiEmptyPrompt
     style={{ maxWidth: "45em" }}
     body={

--- a/public/pages/Policies/components/PolicyEmptyPrompt/__snapshots__/PolicyEmptyPrompt.test.tsx.snap
+++ b/public/pages/Policies/components/PolicyEmptyPrompt/__snapshots__/PolicyEmptyPrompt.test.tsx.snap
@@ -26,10 +26,9 @@ exports[`<PolicyEmptyPrompt /> spec renders the component 1`] = `
   <div
     class="euiSpacer euiSpacer--s"
   />
-  <a
+  <button
     class="euiButton euiButton--primary euiButton--fill"
-    href="opensearch_index_management_dashboards#/create-policy"
-    rel="noreferrer"
+    type="button"
   >
     <span
       class="euiButtonContent euiButton__content"
@@ -40,6 +39,6 @@ exports[`<PolicyEmptyPrompt /> spec renders the component 1`] = `
         Create policy
       </span>
     </span>
-  </a>
+  </button>
 </div>
 `;

--- a/public/pages/Policies/containers/Policies/Policies.test.tsx
+++ b/public/pages/Policies/containers/Policies/Policies.test.tsx
@@ -189,41 +189,6 @@ describe("<IndexPolicies /> spec", () => {
     await waitFor(() => expect(queryByText(testPolicy.id)).toBeNull());
   });
 
-  it("can route to edit policy", async () => {
-    const policies = [testPolicy];
-    browserServicesMock.policyService.getPolicies = jest.fn().mockResolvedValue({
-      ok: true,
-      response: { policies, totalPolicies: 1 },
-    });
-    const { getByText, getByTestId } = renderPoliciesWithRouter();
-
-    await waitFor(() => getByText(testPolicy.id));
-
-    expect(getByTestId("EditButton")).toBeDisabled();
-
-    userEvent.click(getByTestId(`checkboxSelectRow-${testPolicy.id}`));
-
-    expect(getByTestId("EditButton")).toBeEnabled();
-
-    userEvent.click(getByTestId("EditButton"));
-
-    await waitFor(() => getByText(`Testing edit policy: ?id=${testPolicy.id}`));
-  });
-
-  it("can route to create policy", async () => {
-    browserServicesMock.policyService.getPolicies = jest.fn().mockResolvedValue({
-      ok: true,
-      response: { policies: [], totalPolicies: 1 },
-    });
-    const { getByText, getByTestId } = renderPoliciesWithRouter();
-
-    await waitFor(() => {});
-
-    userEvent.click(getByTestId("Create policyButton"));
-
-    await waitFor(() => getByText("Testing create policy"));
-  });
-
   it("can open and close a policy in modal", async () => {
     const policies = [testPolicy];
     browserServicesMock.policyService.getPolicies = jest.fn().mockResolvedValue({

--- a/public/pages/Policies/containers/Policies/Policies.tsx
+++ b/public/pages/Policies/containers/Policies/Policies.tsx
@@ -44,6 +44,7 @@ import _ from "lodash";
 import { ContentPanel, ContentPanelActions } from "../../../../components/ContentPanel";
 import PolicyControls from "../../components/PolicyControls";
 import PolicyEmptyPrompt from "../../components/PolicyEmptyPrompt";
+import CreatePolicyModal from "../../../../components/CreatePolicyModal";
 import PolicyModal from "../../../../components/PolicyModal";
 import { ModalConsumer } from "../../../../components/Modal";
 import { DEFAULT_PAGE_SIZE_OPTIONS, DEFAULT_QUERY_PARAMS } from "../../utils/constants";
@@ -214,15 +215,15 @@ export default class Policies extends Component<PoliciesProps, PoliciesState> {
     this.setState({ search: DEFAULT_QUERY_PARAMS.search });
   };
 
-  onClickEdit = (): void => {
+  onClickEdit = (visual: boolean): void => {
     const {
       selectedItems: [{ id }],
     } = this.state;
-    if (id) this.props.history.push(`${ROUTES.EDIT_POLICY}?id=${id}`);
+    if (id) this.props.history.push(`${ROUTES.EDIT_POLICY}?id=${id}${visual ? "&type=visual" : ""}`);
   };
 
-  onClickCreate = (): void => {
-    this.props.history.push(ROUTES.CREATE_POLICY);
+  onClickCreate = (visual: boolean): void => {
+    this.props.history.push(`${ROUTES.CREATE_POLICY}${visual ? "?type=visual" : ""}`);
   };
 
   onClickDelete = async (policyIds: string[]): Promise<void> => {
@@ -234,10 +235,10 @@ export default class Policies extends Component<PoliciesProps, PoliciesState> {
     if (deleted) await this.getPolicies();
   };
 
-  onClickModalEdit = (item: PolicyItem, onClose: () => void): void => {
+  onClickModalEdit = (item: PolicyItem, onClose: () => void, visual: boolean = false): void => {
     onClose();
     if (!item || !item.id) return;
-    this.props.history.push(`${ROUTES.EDIT_POLICY}?id=${item.id}`);
+    this.props.history.push(`${ROUTES.EDIT_POLICY}?id=${item.id}${visual ? "&type=visual" : ""}`);
   };
 
   render() {
@@ -286,11 +287,16 @@ export default class Policies extends Component<PoliciesProps, PoliciesState> {
           disabled: selectedItems.length !== 1,
           onClick: this.onClickEdit,
         },
+        modal: {
+          onClickModal: (onShow: (component: any, props: object) => void) => () =>
+            onShow(CreatePolicyModal, { isEdit: true, history: this.props.history, onClickContinue: this.onClickEdit }),
+        },
       },
       {
         text: "Create policy",
-        buttonProps: {
-          onClick: this.onClickCreate,
+        modal: {
+          onClickModal: (onShow: (component: any, props: object) => void) => () =>
+            onShow(CreatePolicyModal, { history: this.props.history, onClickContinue: this.onClickCreate }),
         },
       },
     ];
@@ -314,7 +320,12 @@ export default class Policies extends Component<PoliciesProps, PoliciesState> {
           itemId="id"
           items={policies}
           noItemsMessage={
-            <PolicyEmptyPrompt filterIsApplied={filterIsApplied} loading={loadingPolicies} resetFilters={this.resetFilters} />
+            <PolicyEmptyPrompt
+              history={this.props.history}
+              filterIsApplied={filterIsApplied}
+              loading={loadingPolicies}
+              resetFilters={this.resetFilters}
+            />
           }
           onChange={this.onTableChange}
           pagination={pagination}

--- a/public/pages/VisualCreatePolicy/components/Transition/Transition.tsx
+++ b/public/pages/VisualCreatePolicy/components/Transition/Transition.tsx
@@ -43,19 +43,17 @@ const Transition = ({ uiTransition, onChangeTransition }: TransitionProps) => {
           style={{ textTransform: "capitalize" }}
           onChange={(e) => {
             const selectedConditionType = e.target.value;
-            let conditionValue = {};
-            if (selectedConditionType === "min_index_age") conditionValue = { min_index_age: "30d" };
-            if (selectedConditionType === "min_doc_count") conditionValue = { min_doc_count: 1000000 };
-            if (selectedConditionType === "min_size") conditionValue = { min_size: "50gb" };
+            let condition = {};
+            if (selectedConditionType === "min_index_age") condition = { min_index_age: "30d" };
+            if (selectedConditionType === "min_doc_count") condition = { min_doc_count: 1000000 };
+            if (selectedConditionType === "min_size") condition = { min_size: "50gb" };
             if (selectedConditionType === "cron")
-              conditionValue = { cron: { expression: "* 17 * * SAT", timezone: "America/Los_Angeles" } };
+              condition = { cron: { cron: { expression: "* 17 * * SAT", timezone: "America/Los_Angeles" } } };
             onChangeTransition({
               ...uiTransition,
               transition: {
                 ...uiTransition.transition,
-                conditions: {
-                  [selectedConditionType]: conditionValue,
-                },
+                conditions: condition,
               },
             });
           }}

--- a/public/pages/VisualCreatePolicy/containers/CreateAction/CreateAction.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateAction/CreateAction.tsx
@@ -62,7 +62,10 @@ export default class CreateAction extends Component<CreateActionProps, CreateAct
     const { editAction } = this.props;
 
     const actionOptions = actions.map((action) => {
-      const key = Object.keys(action).pop() || "";
+      const key =
+        Object.keys(action)
+          .filter((k) => k !== "timeout" && k !== "retry")
+          .pop() || "";
       return {
         value: key,
         text: key

--- a/public/pages/VisualCreatePolicy/containers/VisualCreatePolicy/VisualCreatePolicy.tsx
+++ b/public/pages/VisualCreatePolicy/containers/VisualCreatePolicy/VisualCreatePolicy.tsx
@@ -1,0 +1,354 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React, { ChangeEvent, Component } from "react";
+import { EuiText, EuiSpacer, EuiTitle, EuiFlexGroup, EuiFlexItem, EuiButton, EuiLink, EuiIcon } from "@elastic/eui";
+import { RouteComponentProps } from "react-router-dom";
+import queryString from "query-string";
+import { DEFAULT_POLICY } from "../../utils/constants";
+import { Policy, State } from "../../../../../models/interfaces";
+import { NotificationService, PolicyService } from "../../../../services";
+import { BREADCRUMBS, DOCUMENTATION_URL, ROUTES } from "../../../../utils/constants";
+import { CoreServicesContext } from "../../../../components/core_services";
+import PolicyInfo from "../../components/PolicyInfo";
+import ISMTemplates from "../../components/ISMTemplates";
+import States from "../../components/States";
+import CreateState from "../CreateState";
+import { getErrorMessage } from "../../../../utils/helpers";
+import { getUpdatedStates } from "../../utils/helpers";
+import ErrorNotification from "../ErrorNotification";
+
+interface VisualCreatePolicyProps extends RouteComponentProps {
+  isEdit: boolean;
+  policyService: PolicyService;
+  notificationService: NotificationService;
+}
+
+interface VisualCreatePolicyState {
+  policyId: string;
+  policy: Policy;
+  policyIdError: string;
+  policySeqNo: number | null;
+  policyPrimaryTerm: number | null;
+  submitError: string;
+  isSubmitting: boolean;
+  hasSubmitted: boolean;
+  showFlyout: boolean;
+  editingState: State | null;
+  errorNotificationJsonString: string;
+}
+
+export default class VisualCreatePolicy extends Component<VisualCreatePolicyProps, VisualCreatePolicyState> {
+  static contextType = CoreServicesContext;
+  constructor(props: VisualCreatePolicyProps) {
+    super(props);
+
+    this.state = {
+      policyId: "",
+      policy: DEFAULT_POLICY,
+      showFlyout: false,
+      editingState: null,
+
+      policySeqNo: null,
+      policyPrimaryTerm: null,
+      policyIdError: "",
+      submitError: "",
+      isSubmitting: false,
+      hasSubmitted: false,
+      errorNotificationJsonString: "",
+    };
+  }
+
+  componentDidMount = async (): Promise<void> => {
+    this.context.chrome.setBreadcrumbs([BREADCRUMBS.INDEX_MANAGEMENT, BREADCRUMBS.INDEX_POLICIES]);
+    if (this.props.isEdit) {
+      const { id } = queryString.parse(this.props.location.search);
+      if (typeof id === "string" && !!id) {
+        this.context.chrome.setBreadcrumbs([
+          BREADCRUMBS.INDEX_MANAGEMENT,
+          BREADCRUMBS.INDEX_POLICIES,
+          BREADCRUMBS.EDIT_POLICY,
+          { text: id },
+        ]);
+        await this.getPolicyToEdit(id);
+      } else {
+        this.context.notifications.toasts.addDanger(`Invalid policy id: ${id}`);
+        this.props.history.push(ROUTES.INDEX_POLICIES);
+      }
+    } else {
+      this.context.chrome.setBreadcrumbs([BREADCRUMBS.INDEX_MANAGEMENT, BREADCRUMBS.INDEX_POLICIES, BREADCRUMBS.CREATE_POLICY]);
+    }
+  };
+
+  getPolicyToEdit = async (policyId: string): Promise<void> => {
+    try {
+      const { policyService } = this.props;
+      const response = await policyService.getPolicy(policyId);
+      if (response.ok) {
+        let errorNotificationJsonString = "";
+        // If we have the legacy destination instead of channels, use error notification json string
+        if (!!response.response.policy.error_notification?.destination) {
+          errorNotificationJsonString = JSON.stringify(response.response.policy.error_notification, null, 4);
+        }
+        this.setState({
+          policySeqNo: response.response.seqNo,
+          policyPrimaryTerm: response.response.primaryTerm,
+          policyId: response.response.id,
+          policy: response.response.policy,
+          errorNotificationJsonString,
+        });
+      } else {
+        this.context.notifications.toasts.addDanger(`Could not load the policy: ${response.error}`);
+        this.props.history.push(ROUTES.INDEX_POLICIES);
+      }
+    } catch (err) {
+      this.context.notifications.toasts.addDanger(getErrorMessage(err, "Could not load the policy"));
+      this.props.history.push(ROUTES.INDEX_POLICIES);
+    }
+  };
+
+  onChangePolicyId = (e: ChangeEvent<HTMLInputElement>): void => {
+    const policyId = e.target.value;
+    if (this.state.hasSubmitted) this.setState({ policyId, policyIdError: policyId ? "" : "Required" });
+    else this.setState({ policyId });
+  };
+
+  onChangePolicyDescription = (e: ChangeEvent<HTMLTextAreaElement>): void => {
+    const description = e.target.value;
+    this.setState((state) => ({ policy: { ...state.policy, description } }));
+  };
+
+  onChangePolicy = (policy: Policy): void => {
+    this.setState({ policy: policy });
+  };
+
+  onChangeChannelId = (e: ChangeEvent<HTMLSelectElement>): void => {
+    const channelId = e.target.value;
+    this.setState((state) => ({
+      policy: {
+        ...state.policy,
+        error_notification: {
+          // Either message_template already exists and it will get
+          // replaced w/ the spread below or it doesn't and we init it here
+          message_template: { source: "", lang: "mustache" },
+          ...state.policy.error_notification,
+          channel: {
+            id: channelId,
+          },
+        },
+      },
+    }));
+  };
+
+  onChangeMessage = (e: ChangeEvent<HTMLTextAreaElement>): void => {
+    const source = e.target.value;
+    this.setState((state) => ({
+      policy: {
+        ...state.policy,
+        error_notification: {
+          ...state.policy.error_notification,
+          message_template: {
+            ...state.policy.error_notification?.message_template,
+            source,
+          },
+        },
+      },
+    }));
+  };
+
+  onChangeErrorNotificationJsonString = (errorNotificationJsonString: string): void => {
+    this.setState({ errorNotificationJsonString });
+  };
+
+  onSwitchToChannels = () => {
+    this.setState((state) => ({ errorNotificationJsonString: "", policy: { ...state.policy, error_notification: null } }));
+  };
+
+  onOpenFlyout = (): void => this.setState({ showFlyout: true });
+  onCloseFlyout = (): void => this.setState({ showFlyout: false, editingState: null });
+
+  onClickEditState = (state: State) => {
+    this.setState({ editingState: state });
+    this.onOpenFlyout();
+  };
+
+  onClickDeleteState = (idx: number) => {
+    const { policy } = this.state;
+    // If we deleted the current default state, just fall back to the first state if it exists
+    let defaultState = policy.default_state;
+    const state = policy.states[idx];
+    const states = policy.states.slice(0, idx).concat(policy.states.slice(idx + 1));
+    if (policy.default_state === state?.name) {
+      defaultState = states[0]?.name || "";
+    }
+    this.setState((state) => ({
+      policy: {
+        ...state.policy,
+        states,
+        default_state: defaultState,
+      },
+    }));
+  };
+
+  onChangeDefaultState = (event: ChangeEvent<HTMLSelectElement>) => {
+    const state = event.target.value;
+    this.setState({ policy: { ...this.state.policy, default_state: state } });
+  };
+
+  onCancel = (): void => {
+    if (this.props.isEdit) this.props.history.goBack();
+    else this.props.history.push(ROUTES.INDEX_POLICIES);
+  };
+
+  onCreate = async (policyId: string, policy: Policy): Promise<void> => {
+    const { policyService } = this.props;
+    try {
+      const response = await policyService.putPolicy({ policy: policy }, policyId);
+      if (response.ok) {
+        this.context.notifications.toasts.addSuccess(`Created policy: ${response.response._id}`);
+        this.props.history.push(ROUTES.INDEX_POLICIES);
+      } else {
+        this.setState({ submitError: response.error });
+        this.context.notifications.toasts.addDanger(`Failed to create policy: ${response.error}`);
+      }
+    } catch (err) {
+      this.setState({ submitError: getErrorMessage(err, "There was a problem creating the policy") });
+    }
+  };
+
+  onUpdate = async (policyId: string, policy: Policy): Promise<void> => {
+    try {
+      const { policyService } = this.props;
+      const { policyPrimaryTerm, policySeqNo } = this.state;
+      if (policySeqNo == null || policyPrimaryTerm == null) {
+        this.context.notifications.toasts.addDanger("Could not update policy without seqNo and primaryTerm");
+        return;
+      }
+      const response = await policyService.putPolicy({ policy: policy }, policyId, policySeqNo, policyPrimaryTerm);
+      if (response.ok) {
+        this.context.notifications.toasts.addSuccess(`Updated policy: ${response.response._id}`);
+        this.props.history.push(ROUTES.INDEX_POLICIES);
+      } else {
+        this.setState({ submitError: response.error });
+      }
+    } catch (err) {
+      this.setState({ submitError: getErrorMessage(err, "There was a problem updating the policy") });
+    }
+  };
+
+  onSubmit = async (): Promise<void> => {
+    const { isEdit } = this.props;
+    const { policyId, policy, errorNotificationJsonString } = this.state;
+    this.setState({ submitError: "", isSubmitting: true, hasSubmitted: true });
+    try {
+      if (!policyId.trim()) {
+        this.setState({ policyIdError: "Required" });
+      } else {
+        const mergedPolicy = { ...policy };
+        if (!!errorNotificationJsonString) {
+          // TODO: dont allow submit if invalid json
+          mergedPolicy.error_notification = JSON.parse(errorNotificationJsonString);
+        }
+        if (isEdit) await this.onUpdate(policyId, mergedPolicy);
+        else await this.onCreate(policyId, mergedPolicy);
+      }
+    } catch (err) {
+      this.context.notifications.toasts.addDanger("Invalid Policy");
+      console.error(err);
+    }
+
+    this.setState({ isSubmitting: false });
+  };
+
+  render() {
+    const { isEdit, notificationService } = this.props;
+    const { policyId, policyIdError, policy, showFlyout, editingState, errorNotificationJsonString } = this.state;
+    return (
+      <div style={{ padding: "25px 50px" }}>
+        <EuiTitle size="l">
+          <h1>{isEdit ? "Edit" : "Create"} policy</h1>
+        </EuiTitle>
+        <EuiSpacer size="s" />
+        <EuiText size="s">
+          <p>
+            Policies let you automatically perform administrative operations on indices.{" "}
+            <EuiLink href={DOCUMENTATION_URL} target="_blank">
+              Learn more <EuiIcon type="popout" size="s" />
+            </EuiLink>
+          </p>
+        </EuiText>
+        <EuiSpacer size="m" />
+        <PolicyInfo
+          isEdit={isEdit}
+          policyId={policyId}
+          policyIdError={policyIdError}
+          description={policy.description}
+          onChangePolicyId={this.onChangePolicyId}
+          onChangeDescription={this.onChangePolicyDescription}
+        />
+        <EuiSpacer size="m" />
+        <ErrorNotification
+          errorNotification={policy.error_notification}
+          errorNotificationJsonString={errorNotificationJsonString}
+          onChangeChannelId={this.onChangeChannelId}
+          onChangeMessage={this.onChangeMessage}
+          onChangeErrorNotificationJsonString={this.onChangeErrorNotificationJsonString}
+          onSwitchToChannels={this.onSwitchToChannels}
+          notificationService={notificationService}
+        />
+        <EuiSpacer size="m" />
+        <ISMTemplates policy={policy} onChangePolicy={this.onChangePolicy} />
+        <EuiSpacer size="m" />
+        <States
+          policy={policy}
+          onOpenFlyout={this.onOpenFlyout}
+          onClickEditState={this.onClickEditState}
+          onClickDeleteState={this.onClickDeleteState}
+          onChangeDefaultState={this.onChangeDefaultState}
+        />
+        <EuiSpacer size="m" />
+
+        {showFlyout && (
+          <CreateState
+            state={editingState}
+            policy={policy}
+            onSaveState={(state: State, editingState: State | null, states: State[], order: string, afterBeforeState: string) => {
+              const updatedStates = getUpdatedStates(state, editingState, states, order, afterBeforeState);
+              let defaultState = policy.default_state;
+              // If we are creating the first state, set the default state to it
+              if (updatedStates.length === 1) defaultState = updatedStates[0].name;
+              this.setState({
+                policy: {
+                  ...policy,
+                  states: updatedStates,
+                  default_state: defaultState,
+                },
+              });
+              this.onCloseFlyout();
+            }}
+            onCloseFlyout={this.onCloseFlyout}
+          />
+        )}
+
+        <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
+          <EuiFlexItem grow={false}>
+            <EuiButton onClick={this.onCancel}>Cancel</EuiButton>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton fill onClick={this.onSubmit}>
+              {isEdit ? "Update" : "Create"}
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </div>
+    );
+  }
+}

--- a/public/pages/VisualCreatePolicy/containers/VisualCreatePolicy/index.ts
+++ b/public/pages/VisualCreatePolicy/containers/VisualCreatePolicy/index.ts
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import VisualCreatePolicy from "./VisualCreatePolicy";
+
+export default VisualCreatePolicy;

--- a/public/pages/VisualCreatePolicy/index.ts
+++ b/public/pages/VisualCreatePolicy/index.ts
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import VisualCreatePolicy from "./containers/VisualCreatePolicy";
+
+export default VisualCreatePolicy;

--- a/public/pages/VisualCreatePolicy/utils/constants.ts
+++ b/public/pages/VisualCreatePolicy/utils/constants.ts
@@ -196,19 +196,3 @@ export const actions = [
 ];
 
 export const ISM_TEMPLATE_INPUT_MAX_WIDTH = "400px";
-
-export enum ActionType {
-  Allocation = "allocation",
-  Close = "close",
-  Delete = "delete",
-  ForceMerge = "force_merge",
-  IndexPriority = "index_priority",
-  Notification = "notification",
-  Open = "open",
-  ReadOnly = "read_only",
-  ReadWrite = "read_write",
-  ReplicaCount = "replica_count",
-  Rollover = "rollover",
-  Rollup = "rollup",
-  Snapshot = "snapshot",
-}

--- a/public/pages/VisualCreatePolicy/utils/helpers.test.ts
+++ b/public/pages/VisualCreatePolicy/utils/helpers.test.ts
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-import { convertTemplatesToArray, getOrderInfo } from "./helpers";
+import { capitalizeFirstLetter, convertTemplatesToArray, getOrderInfo } from "./helpers";
 import { ISMTemplate } from "../../../../models/interfaces";
 
 test("converts all ism template formats into a list of ism templates", () => {
@@ -19,6 +19,10 @@ test("converts all ism template formats into a list of ism templates", () => {
   expect(convertTemplatesToArray(template)).toEqual([template]);
   const templates = [template, { index_patterns: ["log*"], priority: 50 }];
   expect(convertTemplatesToArray(templates)).toEqual(templates);
+});
+
+test("capitalizes first letter of string", () => {
+  expect(capitalizeFirstLetter("some string")).toBe("Some string");
 });
 
 test("getOrderInfo returns correct order info", () => {

--- a/public/pages/VisualCreatePolicy/utils/helpers.ts
+++ b/public/pages/VisualCreatePolicy/utils/helpers.ts
@@ -59,7 +59,9 @@ export const getConditionContent = (transition: Transition): string => {
 };
 
 export const getUIActionFromData = (action: Action): UIAction<any> => {
-  const actionType = Object.keys(action).pop();
+  const actionType = Object.keys(action)
+    .filter((key) => key !== "timeout" && key !== "retry")
+    .pop();
   if (!actionType) throw new Error(`Failed to get action using type [${actionType}]`);
   const uiAction = getUIAction(actionType);
   return uiAction.clone(action);

--- a/public/pages/VisualCreatePolicy/utils/helpers.ts
+++ b/public/pages/VisualCreatePolicy/utils/helpers.ts
@@ -149,3 +149,23 @@ export const getOrderInfo = (
 
   return { order, afterBeforeState, disableOrderSelections };
 };
+
+export const getUpdatedStates = (
+  state: State,
+  editingState: State | null,
+  states: State[],
+  order: string,
+  afterBeforeState: string
+): State[] => {
+  const someStates: State[] = [];
+  const isEditing = !!editingState;
+  if ((isEditing && states.length === 1) || (!isEditing && !states.length)) return [state];
+
+  states.forEach((s, idx) => {
+    if (s.name === afterBeforeState && order === "before") someStates.push(state);
+    if (s.name !== editingState?.name) someStates.push(s);
+    if (s.name === afterBeforeState && order === "after") someStates.push(state);
+  });
+
+  return someStates;
+};

--- a/public/services/PolicyService.ts
+++ b/public/services/PolicyService.ts
@@ -44,7 +44,7 @@ export default class PolicyService {
   };
 
   putPolicy = async (
-    policy: Policy,
+    policy: { policy: Policy },
     policyId: string,
     seqNo?: number,
     primaryTerm?: number

--- a/server/models/interfaces.ts
+++ b/server/models/interfaces.ts
@@ -292,6 +292,7 @@ export interface IndexManagementApi {
   readonly CHANGE_POLICY_BASE: string;
   readonly ROLLUP_JOBS_BASE: string;
   readonly TRANSFORM_BASE: string;
+  readonly CHANNELS_BASE: string;
 }
 
 export interface DefaultHeaders {

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -36,7 +36,7 @@ import {
   DataStreamService,
   NotificationService,
 } from "./services";
-import { indices, policies, managedIndices, rollups, transforms } from "../server/routes";
+import { indices, policies, managedIndices, rollups, transforms, notifications } from "../server/routes";
 import dataStreams from "./routes/dataStreams";
 
 export class IndexPatternManagementPlugin implements Plugin<IndexManagementPluginSetup, IndexManagementPluginStart> {
@@ -73,6 +73,7 @@ export class IndexPatternManagementPlugin implements Plugin<IndexManagementPlugi
     managedIndices(services, router);
     rollups(services, router);
     transforms(services, router);
+    notifications(services, router);
 
     return {};
   }

--- a/server/utils/constants.ts
+++ b/server/utils/constants.ts
@@ -29,6 +29,8 @@ import { DefaultHeaders, IndexManagementApi } from "../models/interfaces";
 export const API_ROUTE_PREFIX = "/_plugins/_ism";
 export const API_ROUTE_PREFIX_ROLLUP = "/_plugins/_rollup";
 export const TRANSFORM_ROUTE_PREFIX = "/_plugins/_transform";
+export const NOTIFICATIONS_API_ROUTE_PREFIX = "/_plugins/_notifications";
+export const CHANNELS_ROUTE = `${NOTIFICATIONS_API_ROUTE_PREFIX}/feature/channels`;
 
 export const API: IndexManagementApi = {
   POLICY_BASE: `${API_ROUTE_PREFIX}/policies`,
@@ -39,6 +41,7 @@ export const API: IndexManagementApi = {
   CHANGE_POLICY_BASE: `${API_ROUTE_PREFIX}/change_policy`,
   ROLLUP_JOBS_BASE: `${API_ROUTE_PREFIX_ROLLUP}/jobs`,
   TRANSFORM_BASE: `${TRANSFORM_ROUTE_PREFIX}`,
+  CHANNELS_BASE: `${CHANNELS_ROUTE}`,
 };
 
 export const DEFAULT_HEADERS: DefaultHeaders = {

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -58,4 +58,5 @@ module.exports = {
   ],
   clearMocks: true,
   testPathIgnorePatterns: ["<rootDir>/build/", "<rootDir>/node_modules/"],
+  modulePathIgnorePatterns: ["indexManagementDashboards"],
 };

--- a/test/mocks/browserServicesMock.ts
+++ b/test/mocks/browserServicesMock.ts
@@ -24,13 +24,21 @@
  * permissions and limitations under the License.
  */
 
-import { IndexService, ManagedIndexService, PolicyService, RollupService, NotificationService } from "../../public/services";
+import {
+  IndexService,
+  ManagedIndexService,
+  PolicyService,
+  RollupService,
+  TransformService,
+  NotificationService,
+} from "../../public/services";
 import httpClientMock from "./httpClientMock";
 
 const indexService = new IndexService(httpClientMock);
 const managedIndexService = new ManagedIndexService(httpClientMock);
 const policyService = new PolicyService(httpClientMock);
 const rollupService = new RollupService(httpClientMock);
+const transformService = new TransformService(httpClientMock);
 const notificationService = new NotificationService(httpClientMock);
 
 export default {
@@ -38,5 +46,6 @@ export default {
   managedIndexService,
   policyService,
   rollupService,
+  transformService,
   notificationService,
 };


### PR DESCRIPTION
… all creation paths to show new modal, updates rates, etc.

Signed-off-by: Drew Baugher <46505179+dbbaughe@users.noreply.github.com>

### Description

![Screen Shot 2021-08-11 at 8 04 45 PM](https://user-images.githubusercontent.com/46505179/129132137-7fda7e10-d16f-41a6-944f-77355e9b25be.png)

### Check List

- [ ] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

