### PR TITLE
Fix flaky

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -7,7 +7,9 @@ on:
     branches:
       - main
       - development-*
-
+env:
+  OPENSEARCH_DASHBOARDS_VERSION: '1.x'
+  OPENSEARCH_VERSION: '1.1.0-SNAPSHOT'
 jobs:
   tests:
     name: Run Cypress E2E tests
@@ -42,7 +44,7 @@ jobs:
           ref: 'main'
       - name: Build common-utils
         working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=${{ env.OPENSEARCH_VERSION }}
       # dependencies: job-scheduler
       - name: Checkout job-scheduler
         uses: actions/checkout@v2
@@ -52,8 +54,17 @@ jobs:
           ref: 'main'
       - name: Build job-scheduler
         working-directory: ./job-scheduler
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
-      - name: Checkout
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=${{ env.OPENSEARCH_VERSION }}
+      - name: Checkout alerting
+        uses: actions/checkout@v2
+        with:
+          repository: 'opensearch-project/alerting'
+          path: alerting
+          ref: 'main'
+      - name: Build alerting
+        working-directory: ./alerting
+        run: ./gradlew :alerting-notification:publishToMavenLocal -Dopensearch.version=${{ env.OPENSEARCH_VERSION }}
+      - name: Checkout index management
         uses: actions/checkout@v2
         with:
           path: index-management
@@ -62,7 +73,7 @@ jobs:
       - name: Run opensearch with plugin
         run: |
           cd index-management
-          ./gradlew run -Dopensearch.version=1.1.0-SNAPSHOT &
+          ./gradlew run -Dopensearch.version=${{ env.OPENSEARCH_VERSION }} &
           sleep 300
         # timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do sleep 5; done'
       - name: Checkout Index Management Dashboards plugin
@@ -74,7 +85,7 @@ jobs:
         with:
           repository: opensearch-project/OpenSearch-Dashboards
           path: OpenSearch-Dashboards
-          ref: '1.x'
+          ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
       - name: Get node and yarn versions
         id: versions
         run: |

--- a/cypress/integration/indices_spec.js
+++ b/cypress/integration/indices_spec.js
@@ -167,7 +167,8 @@ describe("Indices", () => {
 
       cy.get(`[data-test-subj="applyPolicyModalEditButton"]`).click({ force: true });
 
-      cy.reload();
+      // Wait some time for apply policy to execute before reload
+      cy.wait(3000).reload();
 
       cy.contains(SAMPLE_INDEX, { timeout: 20000 });
 

--- a/cypress/integration/managed_indices_spec.js
+++ b/cypress/integration/managed_indices_spec.js
@@ -37,7 +37,7 @@ describe("Managed indices", () => {
     // Set welcome screen tracking to false
     localStorage.setItem("home:welcome:show", "false");
 
-    cy.wait(3000).reload();
+    cy.wait(3000);
 
     // Visit ISM OSD
     cy.visit(`${Cypress.env("opensearch_dashboards")}/app/${PLUGIN_NAME}#/managed-indices`);
@@ -70,8 +70,8 @@ describe("Managed indices", () => {
       // Confirm we got a remove policy toaster
       cy.contains("Removed policy from 1 managed indices");
 
-      // Reload the page
-      cy.reload();
+      // Wait some time for remove policy to execute before reload
+      cy.wait(3000).reload();
 
       // Confirm we are back to empty loading state, give 20 seconds as OSD takes a while to load
       cy.contains("There are no existing managed indices.", { timeout: 20000 });

--- a/cypress/integration/managed_indices_spec.js
+++ b/cypress/integration/managed_indices_spec.js
@@ -37,6 +37,8 @@ describe("Managed indices", () => {
     // Set welcome screen tracking to false
     localStorage.setItem("home:welcome:show", "false");
 
+    cy.wait(3000).reload();
+
     // Visit ISM OSD
     cy.visit(`${Cypress.env("opensearch_dashboards")}/app/${PLUGIN_NAME}#/managed-indices`);
 
@@ -198,8 +200,7 @@ describe("Managed indices", () => {
         .type(SAMPLE_INDEX, { parseSpecialCharSequences: false, delay: 1 });
 
       // Click the index option
-      // TODO flaky: Seems sometime click not actually select the option...
-      cy.get(`button[title="${SAMPLE_INDEX}"]`).dblclick().debug();
+      cy.get(`button[title="${SAMPLE_INDEX}"]`).trigger("click", { force: true });
 
       // Get the third combo search input box which should be the policy input
       cy.get(`input[data-test-subj="comboBoxSearchInput"]`).eq(2).focus().type(POLICY_ID_2, { parseSpecialCharSequences: false, delay: 1 });

--- a/cypress/integration/rollups_spec.js
+++ b/cypress/integration/rollups_spec.js
@@ -237,13 +237,13 @@ describe("Rollups", () => {
       cy.contains(`${ROLLUP_ID}`);
 
       // Click Disable button
-      cy.get(`[data-test-subj="disableButton"]`).click({ force: true });
+      cy.get(`[data-test-subj="disableButton"]`).trigger("click", { force: true });
 
       // Confirm we get toaster saying rollup job is disabled
       cy.contains(`${ROLLUP_ID} is disabled`);
 
       // Click Enable button
-      cy.get(`[data-test-subj="enableButton"]`).click({ force: true });
+      cy.get(`[data-test-subj="enableButton"]`).trigger("click", { force: true });
 
       // Confirm we get toaster saying rollup job is enabled
       cy.contains(`${ROLLUP_ID} is enabled`);


### PR DESCRIPTION
Signed-off-by: bowenlan-amzn <bowenlan23@gmail.com>

### Description
Flaky cypress bothered us for some time. This PR helps mitigate 2 kinds of flakiness:
1. cypress original `click()` event not only performed just one native click event, refer to @AvivBenchorin's finding [here](https://github.com/AvivBenchorin/monterey/issues/8). So instead of calling `click()` we should use `trigger('click')`.
2. If we call some backend API, then reload/visit page to expect some new info showing up, consider add a `wait` between them, sometimes backend API call hasn't been able to change the frontend view, we already rendered the frontend page again.

### Issues Resolved
#30 

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

