### PR TITLE
Fixes policy details page

### DIFF
--- a/models/interfaces.ts
+++ b/models/interfaces.ts
@@ -95,7 +95,7 @@ export interface Policy {
   error_notification?: ErrorNotification | null;
   states: State[];
   ism_template?: ISMTemplate[] | ISMTemplate | null;
-  last_updated_time?: string;
+  last_updated_time?: number;
   schema_version?: number;
 }
 

--- a/public/components/JSONModal/JSONModal.test.tsx
+++ b/public/components/JSONModal/JSONModal.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render, fireEvent } from "@testing-library/react";
+import JSONModal from "./JSONModal";
+import { DEFAULT_LEGACY_ERROR_NOTIFICATION } from "../../pages/VisualCreatePolicy/utils/constants";
+
+describe("<JSONModal /> spec", () => {
+  it("renders the component", () => {
+    render(
+      <JSONModal
+        title="Some modal title"
+        json={DEFAULT_LEGACY_ERROR_NOTIFICATION} // just some random json
+        onClose={() => {}}
+      />
+    );
+    // EuiOverlayMask appends an element to the body so we should have two, an empty div from react-test-library
+    // and our EuiOverlayMask element
+    expect(document.body.children).toHaveLength(2);
+    expect(document.body.children[1]).toMatchSnapshot();
+  });
+
+  it("calls close when close button clicked", () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(
+      <JSONModal
+        title="Some modal title"
+        json={DEFAULT_LEGACY_ERROR_NOTIFICATION} // just some random json
+        onClose={onClose}
+      />
+    );
+
+    fireEvent.click(getByTestId("jsonModalCloseButton"));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/public/components/JSONModal/JSONModal.tsx
+++ b/public/components/JSONModal/JSONModal.tsx
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from "react";
+import {
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiOverlayMask,
+  EuiCodeBlock,
+  EuiButtonEmpty,
+} from "@elastic/eui";
+
+interface JSONModalProps {
+  title: string;
+  json: object;
+  onClose: () => void;
+}
+
+const JSONModal: React.SFC<JSONModalProps> = ({ title, json, onClose }) => {
+  return (
+    <EuiOverlayMask>
+      <EuiModal onClose={onClose} style={{ padding: "5px 30px" }}>
+        <EuiModalHeader>
+          <EuiModalHeaderTitle>{title}</EuiModalHeaderTitle>
+        </EuiModalHeader>
+
+        <EuiModalBody>
+          <EuiCodeBlock language="json" fontSize="m" paddingSize="m" overflowHeight={600} inline={false} isCopyable>
+            {JSON.stringify(json, null, 4)}
+          </EuiCodeBlock>
+        </EuiModalBody>
+
+        <EuiModalFooter>
+          <EuiButtonEmpty onClick={onClose} data-test-subj="jsonModalCloseButton">
+            Close
+          </EuiButtonEmpty>
+        </EuiModalFooter>
+      </EuiModal>
+    </EuiOverlayMask>
+  );
+};
+
+export default JSONModal;

--- a/public/components/JSONModal/__snapshots__/JSONModal.test.tsx.snap
+++ b/public/components/JSONModal/__snapshots__/JSONModal.test.tsx.snap
@@ -1,0 +1,178 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<JSONModal /> spec renders the component 1`] = `
+<div
+  class="euiOverlayMask euiOverlayMask--aboveHeader"
+>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="1"
+  />
+  <div
+    data-focus-lock-disabled="false"
+  >
+    <div
+      class="euiModal euiModal--maxWidth-default"
+      style="padding: 5px 30px;"
+      tabindex="0"
+    >
+      <button
+        aria-label="Closes this modal window"
+        class="euiButtonIcon euiButtonIcon--text euiModal__closeIcon"
+        type="button"
+      >
+        EuiIconMock
+      </button>
+      <div
+        class="euiModal__flex"
+      >
+        <div
+          class="euiModalHeader"
+        >
+          <div
+            class="euiModalHeader__title"
+          >
+            Some modal title
+          </div>
+        </div>
+        <div
+          class="euiModalBody"
+        >
+          <div
+            class="euiModalBody__overflow"
+          >
+            <div
+              class="euiCodeBlock euiCodeBlock--fontMedium euiCodeBlock--paddingMedium euiCodeBlock--hasControls"
+              style="max-height: 600px;"
+            >
+              <pre
+                class="euiCodeBlock__pre euiCodeBlock__pre--whiteSpacePreWrap"
+                style="max-height: 600px;"
+              >
+                <code
+                  class="euiCodeBlock__code json hljs"
+                >
+                  {
+    
+                  <span
+                    class="hljs-attr"
+                  >
+                    "destination"
+                  </span>
+                  : {
+        
+                  <span
+                    class="hljs-attr"
+                  >
+                    "slack"
+                  </span>
+                  : {
+            
+                  <span
+                    class="hljs-attr"
+                  >
+                    "url"
+                  </span>
+                  : 
+                  <span
+                    class="hljs-string"
+                  >
+                    "&lt;url&gt;"
+                  </span>
+                  
+        }
+    },
+    
+                  <span
+                    class="hljs-attr"
+                  >
+                    "message_template"
+                  </span>
+                  : {
+        
+                  <span
+                    class="hljs-attr"
+                  >
+                    "source"
+                  </span>
+                  : 
+                  <span
+                    class="hljs-string"
+                  >
+                    "The index {{ctx.index}} failed during policy execution."
+                  </span>
+                  
+    }
+}
+                </code>
+              </pre>
+              <div
+                class="euiCodeBlock__controls"
+              >
+                <button
+                  aria-label="Expand"
+                  class="euiButtonIcon euiButtonIcon--text euiCodeBlock__fullScreenButton"
+                  type="button"
+                >
+                  EuiIconMock
+                </button>
+                <div
+                  class="euiCodeBlock__copyButton"
+                >
+                  <span
+                    class="euiToolTipAnchor"
+                  >
+                    <button
+                      aria-label="Copy"
+                      class="euiButtonIcon euiButtonIcon--text"
+                      type="button"
+                    >
+                      EuiIconMock
+                    </button>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="euiModalFooter"
+        >
+          <button
+            class="euiButtonEmpty euiButtonEmpty--primary"
+            data-test-subj="jsonModalCloseButton"
+            type="button"
+          >
+            <span
+              class="euiButtonContent euiButtonEmpty__content"
+            >
+              <span
+                class="euiButtonEmpty__text"
+              >
+                Close
+              </span>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+</div>
+`;

--- a/public/components/JSONModal/index.ts
+++ b/public/components/JSONModal/index.ts
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import JSONModal from "./JSONModal";
+
+export default JSONModal;

--- a/public/pages/Policies/containers/Policies/Policies.tsx
+++ b/public/pages/Policies/containers/Policies/Policies.tsx
@@ -281,14 +281,14 @@ export default class Policies extends Component<PoliciesProps, PoliciesState> {
         },
         modal: {
           onClickModal: (onShow: (component: any, props: object) => void) => () =>
-            onShow(CreatePolicyModal, { isEdit: true, history: this.props.history, onClickContinue: this.onClickEdit }),
+            onShow(CreatePolicyModal, { isEdit: true, onClickContinue: this.onClickEdit }),
         },
       },
       {
         text: "Create policy",
         modal: {
           onClickModal: (onShow: (component: any, props: object) => void) => () =>
-            onShow(CreatePolicyModal, { history: this.props.history, onClickContinue: this.onClickCreate }),
+            onShow(CreatePolicyModal, { onClickContinue: this.onClickCreate }),
         },
       },
     ];

--- a/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.test.tsx
+++ b/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.test.tsx
@@ -16,7 +16,7 @@ import PolicySettings from "./PolicySettings";
 
 describe("<PolicySettings /> spec", () => {
   beforeAll(() => {
-    jest.useFakeTimers('modern');
+    jest.useFakeTimers("modern");
     jest.setSystemTime(new Date(2021, 7, 1));
   });
 
@@ -28,13 +28,13 @@ describe("<PolicySettings /> spec", () => {
     const { container } = render(
       <PolicySettings
         policyId={"some_id"}
-        channelId={"some_channel_id"}
+        errorNotification={null}
         primaryTerm={1}
-        lastUpdated={new Date().toString()}
+        lastUpdated={new Date().valueOf()}
         description={"some description"}
         sequenceNumber={2}
-        schemaVersion={3}
         ismTemplates={[]}
+        onEdit={() => {}}
       />
     );
 

--- a/public/pages/PolicyDetails/components/PolicySettings/__snapshots__/PolicySettings.test.tsx.snap
+++ b/public/pages/PolicyDetails/components/PolicySettings/__snapshots__/PolicySettings.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<PolicySettings /> spec renders the component 1`] = `
 <div
   class="euiPanel euiPanel--paddingMedium"
-  style="padding: 20px 20px;"
+  style="padding-left: 0px; padding-right: 0px;"
 >
   <div
     class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
@@ -90,10 +90,10 @@ exports[`<PolicySettings /> spec renders the component 1`] = `
             class="euiText euiText--extraSmall"
           >
             <dt>
-              channel ID
+              Error notification
             </dt>
             <dd>
-              some_channel_id
+              -
             </dd>
           </div>
         </div>
@@ -151,136 +151,6 @@ exports[`<PolicySettings /> spec renders the component 1`] = `
             <dd>
               2
             </dd>
-          </div>
-        </div>
-        <div
-          class="euiFlexItem"
-        >
-          <div
-            class="euiText euiText--extraSmall"
-          >
-            <dt>
-              Schema version
-            </dt>
-            <dd>
-              3
-            </dd>
-          </div>
-        </div>
-      </div>
-      <div
-        class="euiSpacer euiSpacer--s"
-      />
-      <div
-        class="euiPanel euiPanel--paddingMedium"
-        style="padding: 20px 20px;"
-      >
-        <div
-          class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-          style="padding: 0px 10px;"
-        >
-          <div
-            class="euiFlexItem"
-          >
-            <h3
-              class="euiTitle euiTitle--small"
-            >
-              ISM Templates (0)
-            </h3>
-          </div>
-        </div>
-        <hr
-          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
-        />
-        <div
-          style="padding: 10px;"
-        >
-          <div
-            class="euiBasicTable"
-          >
-            <div>
-              <div
-                class="euiTableHeaderMobile"
-              >
-                <div
-                  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
-                >
-                  <div
-                    class="euiFlexItem euiFlexItem--flexGrowZero"
-                  />
-                  <div
-                    class="euiFlexItem euiFlexItem--flexGrowZero"
-                  />
-                </div>
-              </div>
-              <table
-                class="euiTable euiTable--responsive"
-                id="some_html_id"
-                tabindex="-1"
-              >
-                <caption
-                  class="euiScreenReaderOnly euiTableCaption"
-                />
-                <thead>
-                  <tr>
-                    <th
-                      class="euiTableHeaderCell"
-                      data-test-subj="tableHeaderCell_index_patterns_0"
-                      role="columnheader"
-                      scope="col"
-                    >
-                      <div
-                        class="euiTableCellContent"
-                      >
-                        <span
-                          class="euiTableCellContent__text"
-                          title="Index patterns"
-                        >
-                          Index patterns
-                        </span>
-                      </div>
-                    </th>
-                    <th
-                      class="euiTableHeaderCell"
-                      data-test-subj="tableHeaderCell_priority_1"
-                      role="columnheader"
-                      scope="col"
-                    >
-                      <div
-                        class="euiTableCellContent"
-                      >
-                        <span
-                          class="euiTableCellContent__text"
-                          title="Priority"
-                        >
-                          Priority
-                        </span>
-                      </div>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr
-                    class="euiTableRow"
-                  >
-                    <td
-                      class="euiTableRowCell euiTableRowCell--isMobileFullWidth"
-                      colspan="2"
-                    >
-                      <div
-                        class="euiTableCellContent euiTableCellContent--alignCenter"
-                      >
-                        <span
-                          class="euiTableCellContent__text"
-                        >
-                          No items found
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
           </div>
         </div>
       </div>

--- a/public/pages/PolicyDetails/containers/PolicyDetails/PolicyDetails.tsx
+++ b/public/pages/PolicyDetails/containers/PolicyDetails/PolicyDetails.tsx
@@ -16,15 +16,13 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiButton,
-  EuiOverlayMask,
-  EuiButtonEmpty,
-  EuiModalFooter,
-  EuiModal,
-  EuiModalHeader,
-  EuiModalHeaderTitle,
-  EuiModalBody,
-  EuiCodeBlock,
   EuiLoadingSpinner,
+  EuiBasicTable,
+  EuiTableFieldDataColumnType,
+  // @ts-ignore
+  Criteria,
+  // @ts-ignore
+  Pagination,
 } from "@elastic/eui";
 import { RouteComponentProps } from "react-router-dom";
 import queryString from "query-string";
@@ -32,10 +30,13 @@ import { PolicyService } from "../../../../services";
 import { BREADCRUMBS, ROUTES } from "../../../../utils/constants";
 import { getErrorMessage } from "../../../../utils/helpers";
 import PolicySettings from "../../components/PolicySettings/PolicySettings";
-import { ISMTemplate, Policy } from "../../../../../models/interfaces";
+import { DocumentPolicy, ISMTemplate } from "../../../../../models/interfaces";
 import { CoreServicesContext } from "../../../../components/core_services";
 import DeleteModal from "../../components/DeleteModal/DeleteModal";
 import States from "../../../VisualCreatePolicy/components/States";
+import JSONModal from "../../../../components/JSONModal";
+import { ContentPanel } from "../../../../components/ContentPanel";
+import { convertTemplatesToArray } from "../../../VisualCreatePolicy/utils/helpers";
 
 interface PolicyDetailsProps extends RouteComponentProps {
   policyService: PolicyService;
@@ -44,186 +45,195 @@ interface PolicyDetailsProps extends RouteComponentProps {
 interface PolicyDetailsState {
   policyId: string;
   isJSONModalOpen: boolean;
-  policy: Policy | null;
+  policy: DocumentPolicy | null;
   isDeleteModalVisible: boolean;
-  loading: boolean;
+  pageIndex: number;
+  pageSize: number;
+  showPerPageOptions: boolean;
 }
 
-export default class PolicyDetails extends Component<PolicyDetailsProps,
-  PolicyDetailsState> {
-    static contextType = CoreServicesContext;
-    constructor(props: PolicyDetailsProps) {
-      super(props);
+export default class PolicyDetails extends Component<PolicyDetailsProps, PolicyDetailsState> {
+  static contextType = CoreServicesContext;
+  constructor(props: PolicyDetailsProps) {
+    super(props);
 
-      this.state = {
-        policyId: "",
-        isJSONModalOpen: false,
-        policy: null,
-        isDeleteModalVisible: false,
-        loading: true,
-      };
-    }
-
-    componentDidMount = async (): Promise<void> => {
-      this.context.chrome.setBreadcrumbs([BREADCRUMBS.INDEX_MANAGEMENT, BREADCRUMBS.INDEX_POLICIES]);
-      const { id } = queryString.parse(this.props.location.search);
-      if (typeof id === "string") {
-        this.context.chrome.setBreadcrumbs([BREADCRUMBS.INDEX_MANAGEMENT, BREADCRUMBS.INDEX_POLICIES, { text: id }]);
-        await this.getPolicy(id);
-      } else {
-        this.context.notifications.toasts.addDanger(`Invalid policy id: ${id}`);
-        this.props.history.push(ROUTES.INDEX_POLICIES);
-      }
+    this.state = {
+      policyId: "",
+      isJSONModalOpen: false,
+      policy: null,
+      isDeleteModalVisible: false,
+      pageIndex: 0,
+      pageSize: 10,
+      showPerPageOptions: true,
     };
-
-    getPolicy = async (policyId: string): Promise<void> => {
-      try {
-        const { policyService } = this.props;
-        const response = await policyService.getPolicy(policyId);
-
-        if (response.ok) {
-          this.setState({
-            policy: response.response,
-            policyId: response.response.id,
-            loading: false,
-          });
-
-        } else {
-          this.context.notifications.toasts.addDanger(`Could not load the policy: ${response.error}`);
-          this.props.history.push(ROUTES.INDEX_POLICIES);
-        }
-      } catch (err) {
-        this.context.notifications.toasts.addDanger(`Could not load the policy`);
-        this.props.history.push(ROUTES.INDEX_POLICIES);
-      }
-    }
-
-    onEdit = (): void => {
-      const { policyId } = this.state;
-      if (policyId) this.props.history.push(`${ROUTES.EDIT_POLICY}?id=${policyId}`);
-    };
-
-    closeDeleteModal = (): void => {
-      this.setState({ isDeleteModalVisible: false });
-    };
-
-    showDeleteModal = (): void => {
-      this.setState({ isDeleteModalVisible: true });
-    };
-
-    showJSONModal = () => this.setState({ isJSONModalOpen: true });
-
-    closeJSONModal = () => this.setState({ isJSONModalOpen: false });
-
-    onClickDelete = async (): Promise<void> => {
-      const { policyService } = this.props;
-      const { policyId } = this.state;
-
-      try {
-        const response = await policyService.deletePolicy(policyId);
-
-        if (response.ok) {
-          this.closeDeleteModal();
-          // Show success message
-          this.context.notifications.toasts.addSuccess(`"Policy ${policyId}" successfully deleted`);
-          this.props.history.push(ROUTES.INDEX_POLICIES);
-        } else {
-          this.context.notifications.toasts.addDanger(`Could not delete the policy "${policyId}" : ${response.error}`);
-        }
-      } catch (err) {
-        this.context.notifications.toasts.addDanger(getErrorMessage(err, "Could not delete the policy"));
-      }
-    };
-
-    render() {
-      const {
-        policyId,
-        isJSONModalOpen,
-        policy,
-        isDeleteModalVisible,
-        loading
-      } = this.state;
-
-      if (loading) {
-        return (
-          <EuiFlexGroup justifyContent="center" alignItems="center" style={{ marginTop: '100px' }}>
-            <EuiLoadingSpinner size="xl" />
-          </EuiFlexGroup>
-        );
-      }
-
-      // TODO: Needs states section
-      // TODO: Edit button needs destination
-      return (
-        <div style={{ padding: "5px 50px"}}>
-          <EuiFlexGroup style={{ padding: "0px 10px" }} justifyContent="spaceBetween" alignItems="center">
-            <EuiFlexItem grow={false}>
-              <EuiTitle size="m">
-                <h2>{policyId}</h2>
-              </EuiTitle>
-            </EuiFlexItem>
-
-            <EuiFlexItem grow={false}>
-              <EuiFlexGroup alignItems="center" gutterSize="s">
-                <EuiFlexItem grow={false}>
-                  <EuiButton onClick={this.showDeleteModal} color="danger" data-test-subj="deleteButton">
-                    Delete
-                  </EuiButton>
-                </EuiFlexItem>
-                <EuiFlexItem>
-                  <EuiButton onClick={this.showJSONModal} data-test-subj="viewButton">
-                    View JSON
-                  </EuiButton>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-
-          <EuiSpacer />
-          <PolicySettings
-            policyId={policyId}
-            channelId={policy.policy.error_notification}
-            primaryTerm={policy.primaryTerm}
-            lastUpdated={policy.policy.last_updated_time}
-            description={policy.policy.description}
-            sequenceNumber={policy.seqNo}
-            schemaVersion={policy.policy.schema_version}
-            ismTemplates={policy.policy.ism_template || []}
-            onEdit={this.onEdit}
-          />
-          <EuiSpacer />
-          <States
-            onOpenFlyout={() => {}}
-            onClickEditState={() => {}}
-            policy={policy.policy}
-            onClickDeleteState={() => {}}
-            isReadOnly={true}
-          />
-
-          {isJSONModalOpen && (
-            <EuiOverlayMask>
-              <EuiModal onClose={this.closeJSONModal} style={{ padding: "5px 30px" }}>
-                <EuiModalHeader>
-                  <EuiModalHeaderTitle>{"View JSON of " + policyId} </EuiModalHeaderTitle>
-                </EuiModalHeader>
-
-                <EuiModalBody>
-                  <EuiCodeBlock language="json" fontSize="m" paddingSize="m" overflowHeight={600} inline={false} isCopyable>
-                    {JSON.stringify(policy, null, 4)}
-                  </EuiCodeBlock>
-                </EuiModalBody>
-
-                <EuiModalFooter>
-                  <EuiButtonEmpty onClick={this.closeJSONModal}>Close</EuiButtonEmpty>
-                </EuiModalFooter>
-              </EuiModal>
-            </EuiOverlayMask>
-          )}
-
-          {isDeleteModalVisible && (
-            <DeleteModal policyId={policyId} closeDeleteModal={this.closeDeleteModal} onClickDelete={this.onClickDelete} />
-          )}
-        </div>
-      )
-    }
   }
+
+  componentDidMount = async (): Promise<void> => {
+    this.context.chrome.setBreadcrumbs([BREADCRUMBS.INDEX_MANAGEMENT, BREADCRUMBS.INDEX_POLICIES]);
+    const { id } = queryString.parse(this.props.location.search);
+    if (typeof id === "string") {
+      this.context.chrome.setBreadcrumbs([BREADCRUMBS.INDEX_MANAGEMENT, BREADCRUMBS.INDEX_POLICIES, { text: id }]);
+      await this.getPolicy(id);
+    } else {
+      this.context.notifications.toasts.addDanger(`Invalid policy id: ${id}`);
+      this.props.history.push(ROUTES.INDEX_POLICIES);
+    }
+  };
+
+  getPolicy = async (policyId: string): Promise<void> => {
+    try {
+      const { policyService } = this.props;
+      const response = await policyService.getPolicy(policyId);
+
+      if (response.ok && !!response.response.policy) {
+        this.setState({
+          policy: response.response,
+          policyId: response.response.id,
+        });
+      } else {
+        const errorMessage = response.ok ? "Policy was empty" : response.error;
+        this.context.notifications.toasts.addDanger(`Could not load the policy: ${errorMessage}`);
+        this.props.history.push(ROUTES.INDEX_POLICIES);
+      }
+    } catch (err) {
+      this.context.notifications.toasts.addDanger(`Could not load the policy`);
+      this.props.history.push(ROUTES.INDEX_POLICIES);
+    }
+  };
+
+  onEdit = (visual: boolean): void => {
+    const { policyId } = this.state;
+    if (policyId) this.props.history.push(`${ROUTES.EDIT_POLICY}?id=${policyId}${visual ? "&type=visual" : ""}`);
+  };
+
+  closeDeleteModal = (): void => {
+    this.setState({ isDeleteModalVisible: false });
+  };
+
+  showDeleteModal = (): void => {
+    this.setState({ isDeleteModalVisible: true });
+  };
+
+  showJSONModal = () => this.setState({ isJSONModalOpen: true });
+
+  closeJSONModal = () => this.setState({ isJSONModalOpen: false });
+
+  onClickDelete = async (): Promise<void> => {
+    const { policyService } = this.props;
+    const { policyId } = this.state;
+
+    try {
+      const response = await policyService.deletePolicy(policyId);
+
+      if (response.ok) {
+        this.closeDeleteModal();
+        // Show success message
+        this.context.notifications.toasts.addSuccess(`"Policy ${policyId}" successfully deleted`);
+        this.props.history.push(ROUTES.INDEX_POLICIES);
+      } else {
+        this.context.notifications.toasts.addDanger(`Could not delete the policy "${policyId}" : ${response.error}`);
+      }
+    } catch (err) {
+      this.context.notifications.toasts.addDanger(getErrorMessage(err, "Could not delete the policy"));
+    }
+  };
+
+  onTableChange = ({ page }: Criteria<ISMTemplate>) => {
+    const { index: pageIndex, size: pageSize } = page;
+
+    this.setState({ pageIndex, pageSize });
+  };
+
+  render() {
+    const { policyId, isJSONModalOpen, policy, isDeleteModalVisible, pageIndex, pageSize, showPerPageOptions } = this.state;
+
+    if (!policy) {
+      return (
+        <EuiFlexGroup justifyContent="center" alignItems="center" style={{ marginTop: "100px" }}>
+          <EuiLoadingSpinner size="xl" />
+        </EuiFlexGroup>
+      );
+    }
+
+    const convertedISMTemplates = convertTemplatesToArray(policy.policy.ism_template);
+
+    const columns: EuiTableFieldDataColumnType<ISMTemplate>[] = [
+      {
+        field: "index_patterns",
+        name: "Index patterns",
+        truncateText: false,
+      },
+      {
+        field: "priority",
+        name: "Priority",
+        truncateText: false,
+      },
+    ];
+
+    const pagination: Pagination = {
+      pageIndex: pageIndex,
+      pageSize,
+      totalItemCount: convertedISMTemplates.length || 0,
+      pageSizeOptions: [10, 20, 50],
+      hidePerPageOptions: !showPerPageOptions,
+    };
+
+    return (
+      <div style={{ padding: "5px 50px" }}>
+        <EuiFlexGroup style={{ padding: "0px 10px" }} justifyContent="spaceBetween" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiTitle size="m">
+              <h2>{policyId}</h2>
+            </EuiTitle>
+          </EuiFlexItem>
+
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup alignItems="center" gutterSize="s">
+              <EuiFlexItem grow={false}>
+                <EuiButton onClick={this.showDeleteModal} color="danger" data-test-subj="deleteButton">
+                  Delete
+                </EuiButton>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiButton onClick={this.showJSONModal} data-test-subj="viewButton">
+                  View JSON
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+
+        <EuiSpacer />
+        <PolicySettings
+          policyId={policyId}
+          errorNotification={policy.policy.error_notification}
+          primaryTerm={policy.primaryTerm}
+          lastUpdated={policy.policy.last_updated_time}
+          description={policy.policy.description}
+          sequenceNumber={policy.seqNo}
+          ismTemplates={policy.policy.ism_template || []}
+          onEdit={this.onEdit}
+        />
+        <EuiSpacer />
+        <ContentPanel bodyStyles={{ padding: "10px" }} title={`ISM Templates (${convertedISMTemplates.length})`} titleSize="s">
+          <EuiBasicTable items={convertedISMTemplates} columns={columns} pagination={pagination} onChange={this.onTableChange} />
+        </ContentPanel>
+        <EuiSpacer />
+        <States
+          onOpenFlyout={() => {}}
+          onChangeDefaultState={() => {}}
+          onClickEditState={() => {}}
+          policy={policy.policy}
+          onClickDeleteState={() => {}}
+          isReadOnly={true}
+        />
+
+        {isJSONModalOpen && <JSONModal title={"View JSON of " + policyId} json={policy} onClose={this.closeJSONModal} />}
+
+        {isDeleteModalVisible && (
+          <DeleteModal policyId={policyId} closeDeleteModal={this.closeDeleteModal} onClickDelete={this.onClickDelete} />
+        )}
+      </div>
+    );
+  }
+}

--- a/public/pages/VisualCreatePolicy/components/States/State.tsx
+++ b/public/pages/VisualCreatePolicy/components/States/State.tsx
@@ -27,9 +27,10 @@ interface StateProps {
   idx: number;
   onClickEditState: (state: StateData) => void;
   onClickDeleteState: (idx: number) => void;
+  isReadOnly: boolean;
 }
 
-const State = ({ state, isInitialState, idx, onClickEditState, onClickDeleteState }: StateProps) => (
+const State = ({ state, isInitialState, idx, onClickEditState, onClickDeleteState, isReadOnly = false }: StateProps) => (
   <EuiAccordion
     style={{ padding: "15px" }}
     id={state.name}
@@ -62,40 +63,42 @@ const State = ({ state, isInitialState, idx, onClickEditState, onClickDeleteStat
       </EuiFlexGroup>
     }
     extraAction={
-      <EuiFlexGroup gutterSize="m">
-        <EuiFlexItem grow={false}>
-          <ModalConsumer>
-            {({ onShow, onClose }) => (
-              <EuiButtonIcon
-                iconType="trash"
-                aria-label="Delete"
-                color="danger"
-                onClick={() =>
-                  onShow(ConfirmationModal, {
-                    title: "Delete state",
-                    bodyMessage: (
-                      <EuiText>
-                        <span>
-                          Delete "<strong>{state.name}</strong>" permanently? Deleting the state will result in deleting all transitions.
-                        </span>
-                      </EuiText>
-                    ),
-                    actionMessage: "Delete state",
-                    actionProps: { color: "danger" },
-                    modalProps: { maxWidth: 600 },
-                    onAction: () => onClickDeleteState(idx),
-                    onClose,
-                  })
-                }
-                data-test-subj="state-delete-button"
-              />
-            )}
-          </ModalConsumer>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon iconType="pencil" aria-label="Edit" color="primary" onClick={() => onClickEditState(state)} />
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      !isReadOnly && (
+        <EuiFlexGroup gutterSize="m">
+          <EuiFlexItem grow={false}>
+            <ModalConsumer>
+              {({ onShow, onClose }) => (
+                <EuiButtonIcon
+                  iconType="trash"
+                  aria-label="Delete"
+                  color="danger"
+                  onClick={() =>
+                    onShow(ConfirmationModal, {
+                      title: "Delete state",
+                      bodyMessage: (
+                        <EuiText>
+                          <span>
+                            Delete "<strong>{state.name}</strong>" permanently? Deleting the state will result in deleting all transitions.
+                          </span>
+                        </EuiText>
+                      ),
+                      actionMessage: "Delete state",
+                      actionProps: { color: "danger" },
+                      modalProps: { maxWidth: 600 },
+                      onAction: () => onClickDeleteState(idx),
+                      onClose,
+                    })
+                  }
+                  data-test-subj="state-delete-button"
+                />
+              )}
+            </ModalConsumer>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonIcon iconType="pencil" aria-label="Edit" color="primary" onClick={() => onClickEditState(state)} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      )
     }
     paddingSize="l"
   >

--- a/public/pages/VisualCreatePolicy/components/States/States.tsx
+++ b/public/pages/VisualCreatePolicy/components/States/States.tsx
@@ -36,9 +36,10 @@ interface StatesProps {
   onClickEditState: (state: StateData) => void;
   onClickDeleteState: (idx: number) => void;
   onChangeDefaultState: (event: ChangeEvent<HTMLSelectElement>) => void;
+  isReadOnly: boolean;
 }
 
-const States = ({ onOpenFlyout, policy, onClickEditState, onClickDeleteState, onChangeDefaultState }: StatesProps) => {
+const States = ({ onOpenFlyout, policy, onClickEditState, onClickDeleteState, onChangeDefaultState, isReadOnly = false }: StatesProps) => {
   return (
     <ContentPanel
       bodyStyles={{ padding: "initial" }}
@@ -58,19 +59,21 @@ const States = ({ onOpenFlyout, policy, onClickEditState, onClickDeleteState, on
       }
     >
       <div style={{ padding: "0px 10px" }}>
-        <EuiFormRow compressed style={{ maxWidth: "300px", padding: "15px" }} isInvalid={false} error={null}>
-          <EuiSelect
-            compressed
-            prepend="Initial state"
-            options={policy.states.map((state) => ({ text: state.name, value: state.name }))}
-            value={policy.default_state}
-            onChange={onChangeDefaultState}
-          />
-        </EuiFormRow>
-
-        <EuiSpacer size="s" />
-
-        <EuiHorizontalRule margin="none" />
+        {!isReadOnly && (
+          <>
+            <EuiFormRow compressed style={{ maxWidth: "300px", padding: "15px" }} isInvalid={false} error={null}>
+              <EuiSelect
+                compressed
+                prepend="Initial state"
+                options={policy.states.map((state) => ({ text: state.name, value: state.name }))}
+                value={policy.default_state}
+                onChange={onChangeDefaultState}
+              />
+            </EuiFormRow>
+            <EuiSpacer size="s" />
+            <EuiHorizontalRule margin="none" />
+          </>
+        )}
 
         <EuiFlexGroup gutterSize="none" direction="column">
           {policy.states.map((state, idx) => (
@@ -81,31 +84,33 @@ const States = ({ onOpenFlyout, policy, onClickEditState, onClickDeleteState, on
                 isInitialState={state.name === policy.default_state}
                 onClickEditState={onClickEditState}
                 onClickDeleteState={onClickDeleteState}
+                isReadOnly={isReadOnly}
               />
               <EuiHorizontalRule margin="none" />
             </EuiFlexItem>
           ))}
         </EuiFlexGroup>
 
-        {!!policy.states.length ? (
-          <>
-            <EuiSpacer />
-            <EuiButton onClick={onOpenFlyout} data-test-subj="states-add-state-button">
-              Add state
-            </EuiButton>
-          </>
-        ) : (
-          <EuiEmptyPrompt
-            title={<h2>No states</h2>}
-            titleSize="s"
-            body={<p>Your policy currently has no states defined. Add states to manage your index lifecycle.</p>}
-            actions={
-              <EuiButton color="primary" onClick={onOpenFlyout} data-test-subj="states-add-state-button">
+        {!isReadOnly &&
+          (!!policy.states.length ? (
+            <>
+              <EuiSpacer />
+              <EuiButton onClick={onOpenFlyout} data-test-subj="states-add-state-button">
                 Add state
               </EuiButton>
-            }
-          />
-        )}
+            </>
+          ) : (
+            <EuiEmptyPrompt
+              title={<h2>No states</h2>}
+              titleSize="s"
+              body={<p>Your policy currently has no states defined. Add states to manage your index lifecycle.</p>}
+              actions={
+                <EuiButton color="primary" onClick={onOpenFlyout} data-test-subj="states-add-state-button">
+                  Add state
+                </EuiButton>
+              }
+            />
+          ))}
       </div>
     </ContentPanel>
   );


### PR DESCRIPTION
* Moves ISM templates out of the policy settings panel into it's own panel
* Fixes the edit button always going to edit as JSON, now it shows a modal and lets user choose.
* We were passing in error notification and trying to render as a channel id which crashes the page whenever there is an error notification, now we changed Channel ID -> Error Notification and have a link when it exists that opens up a JSON Modal w/ the error notification JSON
* Fixes a bunch of typescript errors
* Fixes states not actually being read-only on the policy details page by utilizing the passed in isReadOnly prop
* Creates a JSONModal to reuse for policy JSON and error notification JSON

Signed-off-by: Drew Baugher <46505179+dbbaughe@users.noreply.github.com>

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

