### PR TITLE
Fixes editing rollup delay

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -8,7 +8,7 @@ on:
       - main
       - development-*
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '1.x'
+  OPENSEARCH_DASHBOARDS_VERSION: '1.1'
   OPENSEARCH_VERSION: '1.1.0-SNAPSHOT'
 jobs:
   tests:

--- a/public/pages/CreateRollup/components/ScheduleRolesAndNotifications/ScheduleRolesAndNotifications.tsx
+++ b/public/pages/CreateRollup/components/ScheduleRolesAndNotifications/ScheduleRolesAndNotifications.tsx
@@ -28,7 +28,7 @@ import React, { Component } from "react";
 import { EuiFlexGrid, EuiFlexItem, EuiSpacer, EuiText } from "@elastic/eui";
 import { ContentPanel, ContentPanelActions } from "../../../../components/ContentPanel";
 import { ModalConsumer } from "../../../../components/Modal";
-import { parseTimeunit } from "../../utils/helpers";
+import { parseTimeunit, buildIntervalScheduleText, buildCronScheduleText } from "../../utils/helpers";
 
 interface ScheduleRolesAndNotificationsProps {
   rollupId: string;
@@ -60,12 +60,10 @@ export default class ScheduleRolesAndNotifications extends Component<ScheduleRol
       delayTimeunit,
     } = this.props;
 
-    let scheduleText = continuousJob ? "Continuous, " : "Not continuous, ";
-    if (continuousDefinition == "fixed") {
-      scheduleText += "every " + interval + " " + parseTimeunit(intervalTimeunit);
-    } else {
-      scheduleText += "defined by cron expression: " + cronExpression;
-    }
+    let scheduleText =
+      continuousDefinition === "fixed"
+        ? buildIntervalScheduleText(continuousJob === "yes", interval, intervalTimeunit)
+        : buildCronScheduleText(continuousJob === "yes", cronExpression);
 
     return (
       <ContentPanel

--- a/public/pages/CreateRollup/containers/CreateRollupForm/CreateRollupForm.tsx
+++ b/public/pages/CreateRollup/containers/CreateRollupForm/CreateRollupForm.tsx
@@ -36,6 +36,7 @@ import CreateRollup from "../CreateRollup";
 import CreateRollupStep2 from "../CreateRollupStep2";
 import { DimensionItem, FieldItem, IndexItem, MetricItem, Rollup } from "../../../../../models/interfaces";
 import { getErrorMessage } from "../../../../utils/helpers";
+import { delayTimeUnitToMS } from "../../utils/helpers";
 import { EMPTY_ROLLUP } from "../../utils/constants";
 import CreateRollupStep3 from "../CreateRollupStep3";
 import CreateRollupStep4 from "../CreateRollupStep4";
@@ -375,15 +376,7 @@ export default class CreateRollupForm extends Component<CreateRollupFormProps, C
     const { delayTimeunit, delayTime } = this.state;
     let newJSON = this.state.rollupJSON;
     if (delayTime == undefined) newJSON.rollup.delay = 0;
-    else if (delayTimeunit == "SECONDS") {
-      newJSON.rollup.delay = moment.duration(delayTime, "seconds").asMilliseconds();
-    } else if (delayTimeunit == "MINUTES") {
-      newJSON.rollup.delay = moment.duration(delayTime, "minutes").asMilliseconds();
-    } else if (delayTimeunit == "HOURS") {
-      newJSON.rollup.delay = moment.duration(delayTime, "hours").asMilliseconds();
-    } else {
-      newJSON.rollup.delay = moment.duration(delayTime, "days").asMilliseconds();
-    }
+    else newJSON.rollup.delay = delayTimeUnitToMS(delayTime, delayTimeunit);
     this.setState({ rollupJSON: newJSON });
   };
 

--- a/public/pages/CreateRollup/utils/helpers.ts
+++ b/public/pages/CreateRollup/utils/helpers.ts
@@ -26,19 +26,98 @@
 
 import { FieldItem } from "../../../../models/interfaces";
 import { COMPARISON_OPERATORS } from "./constants";
+import moment from "moment";
+
+const timeunits = {
+  isMilliseconds: function (stringToCheck: string): boolean {
+    return stringToCheck.trim().toLowerCase() == "milliseconds" || stringToCheck.trim().toLowerCase() == "ms";
+  },
+  isSeconds: function (stringToCheck: string): boolean {
+    return stringToCheck.trim().toLowerCase() == "seconds" || stringToCheck.trim().toLowerCase() == "s";
+  },
+  isMinutes: function (stringToCheck: string): boolean {
+    return stringToCheck.trim().toLowerCase() == "minutes" || stringToCheck.trim() == "m";
+  },
+  isHours: function (stringToCheck: string): boolean {
+    return stringToCheck.trim().toLowerCase() == "hours" || stringToCheck.trim().toLowerCase() == "h";
+  },
+  isDays: function (stringToCheck: string): boolean {
+    return stringToCheck.trim().toLowerCase() == "days" || stringToCheck.trim().toLowerCase() == "d";
+  },
+  isWeeks: function (stringToCheck: string): boolean {
+    return stringToCheck.trim().toLowerCase() == "weeks" || stringToCheck.trim().toLowerCase() == "w";
+  },
+  isMonths: function (stringToCheck: string): boolean {
+    return stringToCheck.trim().toLowerCase() == "months" || stringToCheck.trim() == "M";
+  },
+  isQuarters: function (stringToCheck: string): boolean {
+    return stringToCheck.trim().toLowerCase() == "quarters" || stringToCheck.trim().toLowerCase() == "q";
+  },
+  isYears: function (stringToCheck: string): boolean {
+    return stringToCheck.trim().toLowerCase() == "years" || stringToCheck.trim().toLowerCase() == "y";
+  },
+} as const;
+
+export const buildIntervalScheduleText = (continuous: boolean, interval: number, intervalTimeUnit: string): string => {
+  let scheduleText = "";
+  if (continuous) {
+    scheduleText += "Continuous, every " + interval + " " + parseTimeunit(intervalTimeUnit);
+  } else {
+    scheduleText += "Not continuous";
+  }
+  return scheduleText;
+};
+
+export const buildCronScheduleText = (continuous: boolean, cronExpression: string): string => {
+  let scheduleText = "";
+  if (continuous) {
+    scheduleText += "Continuous, defined by cron expression: " + cronExpression;
+  } else {
+    scheduleText += "Not continuous";
+  }
+  return scheduleText;
+};
 
 export const parseTimeunit = (timeunit: string): string => {
-  if (timeunit == "ms" || timeunit == "Milliseconds") return "millisecond(s)";
-  else if (timeunit == "SECONDS" || timeunit == "s" || timeunit == "Seconds") return "second(s)";
-  else if (timeunit == "MINUTES" || timeunit == "m" || timeunit == "Minutes") return "minute(s)";
-  else if (timeunit == "HOURS" || timeunit == "h" || timeunit == "Hours") return "hour(s)";
-  else if (timeunit == "DAYS" || timeunit == "d" || timeunit == "Days") return "day(s)";
-  else if (timeunit == "w") return "week";
-  else if (timeunit == "M") return "month";
-  else if (timeunit == "q") return "quarter";
-  else if (timeunit == "y") return "year";
+  if (timeunits.isMilliseconds(timeunit)) return "millisecond(s)";
+  else if (timeunits.isSeconds(timeunit)) return "second(s)";
+  else if (timeunits.isMinutes(timeunit)) return "minute(s)";
+  else if (timeunits.isHours(timeunit)) return "hour(s)";
+  else if (timeunits.isDays(timeunit)) return "day(s)";
+  else if (timeunits.isWeeks(timeunit)) return "week";
+  else if (timeunits.isMonths(timeunit)) return "month";
+  else if (timeunits.isQuarters(timeunit)) return "quarter";
+  else if (timeunits.isYears(timeunit)) return "year";
 
   return timeunit;
+};
+
+export const delayTimeUnitToMS = (delay: number, timeunit: string): number => {
+  if (timeunits.isSeconds(timeunit)) {
+    return moment.duration(delay, "seconds").asMilliseconds();
+  } else if (timeunits.isMinutes(timeunit)) {
+    return moment.duration(delay, "minutes").asMilliseconds();
+  } else if (timeunits.isHours(timeunit)) {
+    return moment.duration(delay, "hours").asMilliseconds();
+  } else if (timeunits.isDays(timeunit)) {
+    return moment.duration(delay, "days").asMilliseconds();
+  } else {
+    return delay;
+  }
+};
+
+export const msToDelayTimeUnit = (delay: number, timeunit: string): number => {
+  if (timeunits.isSeconds(timeunit)) {
+    return moment.duration(delay, "milliseconds").asSeconds();
+  } else if (timeunits.isMinutes(timeunit)) {
+    return moment.duration(delay, "milliseconds").asMinutes();
+  } else if (timeunits.isHours(timeunit)) {
+    return moment.duration(delay, "milliseconds").asHours();
+  } else if (timeunits.isDays(timeunit)) {
+    return moment.duration(delay, "milliseconds").asDays();
+  } else {
+    return delay;
+  }
 };
 
 //Returns true if field type is numeric

--- a/public/pages/EditRollup/containers/EditRollup.test.tsx
+++ b/public/pages/EditRollup/containers/EditRollup.test.tsx
@@ -140,4 +140,21 @@ describe("<EditRollup /> spec", () => {
 
     //TODO: Verify changes are saved.
   });
+
+  it("shows rollup job delay", async () => {
+    let rollupJob = testRollup;
+    rollupJob.rollup.delay = 90000;
+
+    browserServicesMock.rollupService.getRollup = jest.fn().mockResolvedValue({
+      ok: true,
+      response: rollupJob,
+    });
+
+    const { queryByText } = renderEditRollupWithRouter([`${ROUTES.ROLLUP_DETAILS}?id=${testRollup._id}`]);
+
+    await waitFor(() => {});
+
+    await waitFor(() => queryByText("1.5"));
+    await waitFor(() => queryByText("Minute(s)"));
+  });
 });

--- a/public/pages/RollupDetails/containers/RollupDetails/RollupDetails.tsx
+++ b/public/pages/RollupDetails/containers/RollupDetails/RollupDetails.tsx
@@ -49,7 +49,7 @@ import { getErrorMessage } from "../../../../utils/helpers";
 import GeneralInformation from "../../components/GeneralInformation/GeneralInformation";
 import RollupStatus from "../../components/RollupStatus/RollupStatus";
 import AggregationAndMetricsSettings from "../../components/AggregationAndMetricsSettings/AggregationAndMetricsSettings";
-import { parseTimeunit } from "../../../CreateRollup/utils/helpers";
+import { parseTimeunit, buildIntervalScheduleText, buildCronScheduleText } from "../../../CreateRollup/utils/helpers";
 import { DimensionItem, MetricItem, RollupDimensionItem, RollupMetadata, RollupMetricItem } from "../../../../../models/interfaces";
 import { renderTime } from "../../../Rollups/utils/helpers";
 import DeleteModal from "../../../Rollups/components/DeleteModal";
@@ -331,11 +331,12 @@ export default class RollupDetails extends Component<RollupDetailsProps, RollupD
       isDeleteModalVisible,
     } = this.state;
 
-    let scheduleText = continuousJob ? "Continuous, " : "Not continuous, ";
-    if (continuousDefinition == "fixed") {
-      scheduleText += "every " + interval + " " + parseTimeunit(intervalTimeunit);
-    } else {
-      scheduleText += "defined by cron expression: " + cronExpression;
+    let scheduleText = "";
+    if (rollupJSON.rollup != null) {
+      scheduleText =
+        rollupJSON.rollup.schedule.interval != null
+          ? buildIntervalScheduleText(rollupJSON.rollup.continuous, interval, intervalTimeunit)
+          : buildCronScheduleText(rollupJSON.rollup.continuous, rollupJSON.rollup.schedule.cron.expression);
     }
 
     return (


### PR DESCRIPTION
Signed-off-by: Clay Downs downsrob@amazon.com

### Description

Rollup delay values are stored in index management in milliseconds only, but with a time unit in the dashboards plugin. Adds a translation for the millisecond value to the displayed time unit when editing, then converts it back to milliseconds on submission.  Also updates the rollup schedule display to correctly show if the job is continuous or non continuous.

### Screenshots
#### Rollup delay fix:
Before:
Displaying in milliseconds for any selected execution delay unit
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/89109232/131903454-19d18a7f-2781-42aa-9698-aea957a80cbe.png">

After:
Converting milliseconds to the correct execution delay unit
<img width="1917" alt="image" src="https://user-images.githubusercontent.com/89109232/131902283-690e79d1-91d2-4cc0-ac1e-e6c9cfd7afa3.png">

After saving the edit of execution delay to 60 minutes, before fix:
Incorrectly storing internally as a delay of 60 ms
<img width="738" alt="image" src="https://user-images.githubusercontent.com/89109232/131903643-87c5f675-27a0-46c9-80d2-54ceffc365eb.png">

After saving the edit, after fix:
The 60 minutes from the edit menu was correctly converted to milliseconds
<img width="740" alt="image" src="https://user-images.githubusercontent.com/89109232/131902526-b4f343c8-3f89-47e9-98ef-3ac74edb72c5.png">

#### Rollup schedule:
This is for a non continuous rollup.
Before:
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/89109232/131903249-bbad306d-e714-45f0-bc5a-a409922b056f.png">

After:
<img width="1919" alt="image" src="https://user-images.githubusercontent.com/89109232/131901994-94279e60-1ed3-41d2-8651-41979f968b9c.png">


### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).