### PR TITLE
UI fixes for new ISM UI

### DIFF
--- a/models/interfaces.ts
+++ b/models/interfaces.ts
@@ -150,7 +150,7 @@ export interface UIAction<Data> {
   id: string;
   type: ActionType | string;
   render: (uiAction: UIAction<Data>, onChangeAction: (uiAction: UIAction<Data>) => void) => JSX.Element | null;
-  isValid: (action: UIAction<Data>) => boolean;
+  isValid: () => boolean;
   clone: (action: Data) => UIAction<Data>;
   content: () => JSX.Element | string | null;
   toAction: () => Action;

--- a/models/interfaces.ts
+++ b/models/interfaces.ts
@@ -244,16 +244,18 @@ export interface IndexPriorityAction extends Action {
 
 export interface AllocationAction extends Action {
   allocation: {
-    require: {
-      [key: string]: string;
-    };
-    include: {
-      [key: string]: string;
-    };
-    exclude: {
-      [key: string]: string;
-    };
-    wait_for: boolean;
+    // TODO: These require a complete UI and we are only supporting JSON editor for allocation for now
+    // require: {
+    //   [key: string]: string;
+    // };
+    // include: {
+    //   [key: string]: string;
+    // };
+    // exclude: {
+    //   [key: string]: string;
+    // };
+    // wait_for: boolean;
+    jsonString: string;
   };
 }
 

--- a/models/interfaces.ts
+++ b/models/interfaces.ts
@@ -150,6 +150,7 @@ export interface UIAction<Data> {
   id: string;
   type: ActionType | string;
   render: (uiAction: UIAction<Data>, onChangeAction: (uiAction: UIAction<Data>) => void) => JSX.Element | null;
+  isValid: (action: UIAction<Data>) => boolean;
   clone: (action: Data) => UIAction<Data>;
   content: () => JSX.Element | string | null;
   toAction: () => Action;

--- a/models/interfaces.ts
+++ b/models/interfaces.ts
@@ -158,7 +158,7 @@ export interface UIAction<Data> {
 
 export interface ForceMergeAction extends Action {
   force_merge: {
-    max_num_segments: number;
+    max_num_segments?: number;
   };
 }
 
@@ -172,7 +172,7 @@ export interface ReadWriteAction extends Action {
 
 export interface ReplicaCountAction extends Action {
   replica_count: {
-    number_of_replicas: number;
+    number_of_replicas?: number;
   };
 }
 
@@ -208,7 +208,7 @@ export interface Transition {
 
 export interface Condition {
   min_index_age?: string;
-  min_doc_count?: number;
+  min_doc_count?: number | undefined;
   min_size?: string;
   cron?: Cron;
 }
@@ -239,7 +239,7 @@ export interface SnapshotAction extends Action {
 
 export interface IndexPriorityAction extends Action {
   index_priority: {
-    priority: number;
+    priority?: number;
   };
 }
 

--- a/public/app.scss
+++ b/public/app.scss
@@ -50,3 +50,7 @@ $euiTextColor: $euiColorDarkestShade !default;
     }
   }
 }
+
+.state-accordion:hover {
+  text-decoration: none;
+}

--- a/public/pages/VisualCreatePolicy/components/DraggableItem/DraggableItem.test.tsx
+++ b/public/pages/VisualCreatePolicy/components/DraggableItem/DraggableItem.test.tsx
@@ -26,7 +26,15 @@ describe("<DraggableItem /> spec", () => {
     const { container } = render(
       <EuiDragDropContext onDragEnd={() => {}}>
         <EuiDroppable droppableId="STATE_ACTIONS_DROPPABLE_AREA">
-          <DraggableItem content={content} id={action.id} idx={0} isLast={true} onClickDelete={() => {}} onClickEdit={() => {}} />
+          <DraggableItem
+            content={content}
+            id={action.id}
+            idx={0}
+            isLast={true}
+            onClickDelete={() => {}}
+            onClickEdit={() => {}}
+            draggableType="action"
+          />
         </EuiDroppable>
       </EuiDragDropContext>
     );
@@ -40,7 +48,15 @@ describe("<DraggableItem /> spec", () => {
     const { getByTestId } = render(
       <EuiDragDropContext onDragEnd={() => {}}>
         <EuiDroppable droppableId="STATE_ACTIONS_DROPPABLE_AREA">
-          <DraggableItem content={content} id={action.id} idx={0} isLast={true} onClickDelete={onClickDelete} onClickEdit={() => {}} />
+          <DraggableItem
+            content={content}
+            id={action.id}
+            idx={0}
+            isLast={true}
+            onClickDelete={onClickDelete}
+            onClickEdit={() => {}}
+            draggableType="action"
+          />
         </EuiDroppable>
       </EuiDragDropContext>
     );
@@ -56,7 +72,15 @@ describe("<DraggableItem /> spec", () => {
     const { getByTestId } = render(
       <EuiDragDropContext onDragEnd={() => {}}>
         <EuiDroppable droppableId="STATE_ACTIONS_DROPPABLE_AREA">
-          <DraggableItem content={content} id={action.id} idx={0} isLast={true} onClickDelete={() => {}} onClickEdit={onClickEdit} />
+          <DraggableItem
+            content={content}
+            id={action.id}
+            idx={0}
+            isLast={true}
+            onClickDelete={() => {}}
+            onClickEdit={onClickEdit}
+            draggableType="action"
+          />
         </EuiDroppable>
       </EuiDragDropContext>
     );

--- a/public/pages/VisualCreatePolicy/components/DraggableItem/DraggableItem.tsx
+++ b/public/pages/VisualCreatePolicy/components/DraggableItem/DraggableItem.tsx
@@ -10,7 +10,7 @@
  */
 
 import React from "react";
-import { EuiFlexGroup, EuiFlexItem, EuiDraggable, EuiPanel, EuiIcon, EuiButtonIcon } from "@elastic/eui";
+import { EuiFlexGroup, EuiFlexItem, EuiDraggable, EuiPanel, EuiIcon, EuiButtonIcon, EuiToolTip } from "@elastic/eui";
 
 interface DraggableItemProps {
   content: string | JSX.Element | null;
@@ -19,9 +19,10 @@ interface DraggableItemProps {
   isLast: boolean;
   onClickDelete: () => void;
   onClickEdit: () => void;
+  draggableType: "action" | "transition";
 }
 
-const DraggableItem = ({ content, id, idx, isLast, onClickDelete, onClickEdit }: DraggableItemProps) => (
+const DraggableItem = ({ content, id, idx, isLast, onClickDelete, onClickEdit, draggableType }: DraggableItemProps) => (
   <EuiDraggable style={{ padding: `0px 0px ${isLast ? "0px" : "10px"} 0px` }} key={id} index={idx} draggableId={id} customDragHandle={true}>
     {(provided) => (
       <EuiPanel className="custom" paddingSize="m">
@@ -33,22 +34,26 @@ const DraggableItem = ({ content, id, idx, isLast, onClickDelete, onClickEdit }:
           </EuiFlexItem>
           <EuiFlexItem>{content}</EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon
-              iconType="trash"
-              aria-label="Delete"
-              color="danger"
-              onClick={onClickDelete}
-              data-test-subj={`draggable-item-delete-button-${id}`}
-            />
+            <EuiToolTip position="top" content={<p>Delete {draggableType}</p>}>
+              <EuiButtonIcon
+                iconType="trash"
+                aria-label="Delete"
+                color="danger"
+                onClick={onClickDelete}
+                data-test-subj={`draggable-item-delete-button-${id}`}
+              />
+            </EuiToolTip>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon
-              iconType="pencil"
-              aria-label="Edit"
-              color="primary"
-              onClick={onClickEdit}
-              data-test-subj={`draggable-item-edit-button-${id}`}
-            />
+            <EuiToolTip position="top" content={<p>Edit {draggableType}</p>}>
+              <EuiButtonIcon
+                iconType="pencil"
+                aria-label="Edit"
+                color="primary"
+                onClick={onClickEdit}
+                data-test-subj={`draggable-item-edit-button-${id}`}
+              />
+            </EuiToolTip>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiPanel>

--- a/public/pages/VisualCreatePolicy/components/DraggableItem/__snapshots__/DraggableItem.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/DraggableItem/__snapshots__/DraggableItem.test.tsx.snap
@@ -43,26 +43,34 @@ exports[`<DraggableItem /> spec renders the component 1`] = `
         <div
           class="euiFlexItem euiFlexItem--flexGrowZero"
         >
-          <button
-            aria-label="Delete"
-            class="euiButtonIcon euiButtonIcon--danger"
-            data-test-subj="draggable-item-delete-button-some_html_id"
-            type="button"
+          <span
+            class="euiToolTipAnchor"
           >
-            EuiIconMock
-          </button>
+            <button
+              aria-label="Delete"
+              class="euiButtonIcon euiButtonIcon--danger"
+              data-test-subj="draggable-item-delete-button-some_html_id"
+              type="button"
+            >
+              EuiIconMock
+            </button>
+          </span>
         </div>
         <div
           class="euiFlexItem euiFlexItem--flexGrowZero"
         >
-          <button
-            aria-label="Edit"
-            class="euiButtonIcon euiButtonIcon--primary"
-            data-test-subj="draggable-item-edit-button-some_html_id"
-            type="button"
+          <span
+            class="euiToolTipAnchor"
           >
-            EuiIconMock
-          </button>
+            <button
+              aria-label="Edit"
+              class="euiButtonIcon euiButtonIcon--primary"
+              data-test-subj="draggable-item-edit-button-some_html_id"
+              type="button"
+            >
+              EuiIconMock
+            </button>
+          </span>
         </div>
       </div>
     </div>

--- a/public/pages/VisualCreatePolicy/components/EuiFormCustomLabel/EuiFormCustomLabel.tsx
+++ b/public/pages/VisualCreatePolicy/components/EuiFormCustomLabel/EuiFormCustomLabel.tsx
@@ -17,6 +17,7 @@ interface EuiFormCustomLabelProps {
   helpText?: string;
   textStyle?: object;
   headerStyle?: object;
+  isInvalid?: boolean;
 }
 
 // New pattern for label and help text both being above the form row instead of label above and help below.
@@ -25,9 +26,12 @@ const EuiFormCustomLabel = ({
   helpText,
   textStyle = { marginBottom: "5px" },
   headerStyle = { marginBottom: "2px" },
+  isInvalid = false,
 }: EuiFormCustomLabelProps) => (
   <EuiText style={textStyle}>
-    <h5 style={headerStyle}>{title}</h5>
+    <h5 style={headerStyle} className={`euiFormLabel ${isInvalid ? "euiFormLabel-isInvalid" : ""}`}>
+      {title}
+    </h5>
     <p>
       {" "}
       {/* Keep the <p> tag even if no helpText to remove last child styling on h tags */}

--- a/public/pages/VisualCreatePolicy/components/EuiFormCustomLabel/__snapshots__/EuiFormCustomLabel.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/EuiFormCustomLabel/__snapshots__/EuiFormCustomLabel.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`<EuiFormCustomLabel /> spec renders the component 1`] = `
   style="margin-bottom: 5px;"
 >
   <h5
+    class="euiFormLabel "
     style="margin-bottom: 2px;"
   >
     Some title

--- a/public/pages/VisualCreatePolicy/components/FlyoutFooter/FlyoutFooter.tsx
+++ b/public/pages/VisualCreatePolicy/components/FlyoutFooter/FlyoutFooter.tsx
@@ -23,7 +23,7 @@ interface FlyoutFooterProps {
 const FlyoutFooter = ({ edit, action, disabledAction = false, onClickCancel, onClickAction }: FlyoutFooterProps) => (
   <EuiFlexGroup justifyContent="spaceBetween">
     <EuiFlexItem grow={false}>
-      <EuiButtonEmpty iconType="cross" onClick={onClickCancel} flush="left" data-test-subj="flyout-footer-cancel-button">
+      <EuiButtonEmpty onClick={onClickCancel} flush="left" data-test-subj="flyout-footer-cancel-button">
         Cancel
       </EuiButtonEmpty>
     </EuiFlexItem>

--- a/public/pages/VisualCreatePolicy/components/FlyoutFooter/__snapshots__/FlyoutFooter.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/FlyoutFooter/__snapshots__/FlyoutFooter.test.tsx.snap
@@ -15,7 +15,6 @@ exports[`<FlyoutFooter /> spec renders the component 1`] = `
       <span
         class="euiButtonContent euiButtonEmpty__content"
       >
-        EuiIconMock
         <span
           class="euiButtonEmpty__text"
         >

--- a/public/pages/VisualCreatePolicy/components/LegacyNotification/LegacyNotification.tsx
+++ b/public/pages/VisualCreatePolicy/components/LegacyNotification/LegacyNotification.tsx
@@ -20,16 +20,18 @@ interface LegacyNotificationProps {
   notificationJsonString: string;
   onChangeNotificationJsonString: (str: string) => void;
   actionNotification?: boolean;
+  isInvalid?: boolean;
 }
 
 const LegacyNotification = ({
   notificationJsonString,
   onChangeNotificationJsonString,
   actionNotification = false,
+  isInvalid = false, // TODO: default to false for error notification for now, but add validation logic for it
 }: LegacyNotificationProps) => {
   return (
     <>
-      <EuiFormRow isInvalid={false} error={null} style={{ maxWidth: "100%" }}>
+      <EuiFormRow isInvalid={isInvalid} error={null} style={{ maxWidth: "100%" }}>
         <DarkModeConsumer>
           {(isDarkMode) => (
             <EuiCodeEditor

--- a/public/pages/VisualCreatePolicy/components/PolicyInfo/__snapshots__/PolicyInfo.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/PolicyInfo/__snapshots__/PolicyInfo.test.tsx.snap
@@ -33,6 +33,7 @@ exports[`<PolicyInfo /> spec renders the component 1`] = `
         style="margin-bottom: 5px;"
       >
         <h5
+          class="euiFormLabel "
           style="margin-bottom: 2px;"
         >
           Policy ID
@@ -79,6 +80,7 @@ exports[`<PolicyInfo /> spec renders the component 1`] = `
         style="margin-bottom: 5px;"
       >
         <h5
+          class="euiFormLabel "
           style="margin-bottom: 2px;"
         >
           Description

--- a/public/pages/VisualCreatePolicy/components/States/State.tsx
+++ b/public/pages/VisualCreatePolicy/components/States/State.tsx
@@ -118,7 +118,7 @@ const State = ({ state, isInitialState, idx, onClickEditState, onClickDeleteStat
         {!state.actions?.length ? (
           <EuiText>No actions. Edit state to add actions.</EuiText>
         ) : (
-          <EuiFlexGroup>
+          <EuiFlexGroup wrap>
             {state.actions.map((action) => (
               <EuiFlexItem grow={false} key={makeId()}>
                 <EuiPanel>{actionRepoSingleton.getUIActionFromData(action).content()}</EuiPanel>
@@ -136,7 +136,7 @@ const State = ({ state, isInitialState, idx, onClickEditState, onClickDeleteStat
         {!state.transitions?.length ? (
           <EuiText>No transitions. Edit state to add transitions.</EuiText>
         ) : (
-          <EuiFlexGroup>
+          <EuiFlexGroup wrap>
             {state.transitions.map((transition) => (
               <EuiFlexItem grow={false} key={makeId()}>
                 <EuiPanel>

--- a/public/pages/VisualCreatePolicy/components/States/State.tsx
+++ b/public/pages/VisualCreatePolicy/components/States/State.tsx
@@ -10,7 +10,7 @@
  */
 
 import React from "react";
-import { EuiAccordion, EuiText, EuiPanel, EuiFlexGroup, EuiFlexItem, EuiButtonIcon } from "@elastic/eui";
+import { EuiAccordion, EuiText, EuiPanel, EuiFlexGroup, EuiFlexItem, EuiButtonIcon, EuiToolTip } from "@elastic/eui";
 import "brace/theme/github";
 import "brace/mode/json";
 import { State as StateData } from "../../../../../models/interfaces";
@@ -34,6 +34,7 @@ const State = ({ state, isInitialState, idx, onClickEditState, onClickDeleteStat
   <EuiAccordion
     style={{ padding: "15px" }}
     id={state.name}
+    buttonClassName="state-accordion"
     buttonContent={
       <EuiFlexGroup justifyContent="center" alignItems="center">
         <EuiFlexItem grow={false}>
@@ -68,34 +69,39 @@ const State = ({ state, isInitialState, idx, onClickEditState, onClickDeleteStat
           <EuiFlexItem grow={false}>
             <ModalConsumer>
               {({ onShow, onClose }) => (
-                <EuiButtonIcon
-                  iconType="trash"
-                  aria-label="Delete"
-                  color="danger"
-                  onClick={() =>
-                    onShow(ConfirmationModal, {
-                      title: "Delete state",
-                      bodyMessage: (
-                        <EuiText>
-                          <span>
-                            Delete "<strong>{state.name}</strong>" permanently? Deleting the state will result in deleting all transitions.
-                          </span>
-                        </EuiText>
-                      ),
-                      actionMessage: "Delete state",
-                      actionProps: { color: "danger" },
-                      modalProps: { maxWidth: 600 },
-                      onAction: () => onClickDeleteState(idx),
-                      onClose,
-                    })
-                  }
-                  data-test-subj="state-delete-button"
-                />
+                <EuiToolTip position="top" content={<p>Delete state</p>}>
+                  <EuiButtonIcon
+                    iconType="trash"
+                    aria-label="Delete"
+                    color="danger"
+                    onClick={() =>
+                      onShow(ConfirmationModal, {
+                        title: "Delete state",
+                        bodyMessage: (
+                          <EuiText>
+                            <span>
+                              Delete "<strong>{state.name}</strong>" permanently? Deleting the state will result in deleting all
+                              transitions.
+                            </span>
+                          </EuiText>
+                        ),
+                        actionMessage: "Delete state",
+                        actionProps: { color: "danger" },
+                        modalProps: { maxWidth: 600 },
+                        onAction: () => onClickDeleteState(idx),
+                        onClose,
+                      })
+                    }
+                    data-test-subj="state-delete-button"
+                  />
+                </EuiToolTip>
               )}
             </ModalConsumer>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon iconType="pencil" aria-label="Edit" color="primary" onClick={() => onClickEditState(state)} />
+            <EuiToolTip position="top" content={<p>Edit state</p>}>
+              <EuiButtonIcon iconType="pencil" aria-label="Edit" color="primary" onClick={() => onClickEditState(state)} />
+            </EuiToolTip>
           </EuiFlexItem>
         </EuiFlexGroup>
       )

--- a/public/pages/VisualCreatePolicy/components/States/__snapshots__/State.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/States/__snapshots__/State.test.tsx.snap
@@ -171,7 +171,7 @@ exports[`<State /> spec renders the component 1`] = `
             class="euiFlexItem"
           >
             <div
-              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
             >
               <div
                 class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -217,7 +217,7 @@ exports[`<State /> spec renders the component 1`] = `
             class="euiFlexItem"
           >
             <div
-              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
             >
               <div
                 class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/public/pages/VisualCreatePolicy/components/States/__snapshots__/State.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/States/__snapshots__/State.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`<State /> spec renders the component 1`] = `
     <button
       aria-controls="some_name"
       aria-expanded="false"
-      class="euiAccordion__button"
+      class="euiAccordion__button state-accordion"
       id="some_html_id"
       type="button"
     >
@@ -113,25 +113,33 @@ exports[`<State /> spec renders the component 1`] = `
         <div
           class="euiFlexItem euiFlexItem--flexGrowZero"
         >
-          <button
-            aria-label="Delete"
-            class="euiButtonIcon euiButtonIcon--danger"
-            data-test-subj="state-delete-button"
-            type="button"
+          <span
+            class="euiToolTipAnchor"
           >
-            EuiIconMock
-          </button>
+            <button
+              aria-label="Delete"
+              class="euiButtonIcon euiButtonIcon--danger"
+              data-test-subj="state-delete-button"
+              type="button"
+            >
+              EuiIconMock
+            </button>
+          </span>
         </div>
         <div
           class="euiFlexItem euiFlexItem--flexGrowZero"
         >
-          <button
-            aria-label="Edit"
-            class="euiButtonIcon euiButtonIcon--primary"
-            type="button"
+          <span
+            class="euiToolTipAnchor"
           >
-            EuiIconMock
-          </button>
+            <button
+              aria-label="Edit"
+              class="euiButtonIcon euiButtonIcon--primary"
+              type="button"
+            >
+              EuiIconMock
+            </button>
+          </span>
         </div>
       </div>
     </div>

--- a/public/pages/VisualCreatePolicy/components/States/__snapshots__/States.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/States/__snapshots__/States.test.tsx.snap
@@ -280,7 +280,7 @@ exports[`<States /> spec renders the component 1`] = `
                       class="euiFlexItem"
                     >
                       <div
-                        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
                       >
                         <div
                           class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -308,7 +308,7 @@ exports[`<States /> spec renders the component 1`] = `
                       class="euiFlexItem"
                     >
                       <div
-                        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
                       >
                         <div
                           class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -481,7 +481,7 @@ exports[`<States /> spec renders the component 1`] = `
                       class="euiFlexItem"
                     >
                       <div
-                        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
                       >
                         <div
                           class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/public/pages/VisualCreatePolicy/components/States/__snapshots__/States.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/States/__snapshots__/States.test.tsx.snap
@@ -120,7 +120,7 @@ exports[`<States /> spec renders the component 1`] = `
               <button
                 aria-controls="hot"
                 aria-expanded="false"
-                class="euiAccordion__button"
+                class="euiAccordion__button state-accordion"
                 id="some_html_id"
                 type="button"
               >
@@ -222,25 +222,33 @@ exports[`<States /> spec renders the component 1`] = `
                   <div
                     class="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <button
-                      aria-label="Delete"
-                      class="euiButtonIcon euiButtonIcon--danger"
-                      data-test-subj="state-delete-button"
-                      type="button"
+                    <span
+                      class="euiToolTipAnchor"
                     >
-                      EuiIconMock
-                    </button>
+                      <button
+                        aria-label="Delete"
+                        class="euiButtonIcon euiButtonIcon--danger"
+                        data-test-subj="state-delete-button"
+                        type="button"
+                      >
+                        EuiIconMock
+                      </button>
+                    </span>
                   </div>
                   <div
                     class="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <button
-                      aria-label="Edit"
-                      class="euiButtonIcon euiButtonIcon--primary"
-                      type="button"
+                    <span
+                      class="euiToolTipAnchor"
                     >
-                      EuiIconMock
-                    </button>
+                      <button
+                        aria-label="Edit"
+                        class="euiButtonIcon euiButtonIcon--primary"
+                        type="button"
+                      >
+                        EuiIconMock
+                      </button>
+                    </span>
                   </div>
                 </div>
               </div>
@@ -352,7 +360,7 @@ exports[`<States /> spec renders the component 1`] = `
               <button
                 aria-controls="cold"
                 aria-expanded="false"
-                class="euiAccordion__button"
+                class="euiAccordion__button state-accordion"
                 id="some_html_id"
                 type="button"
               >
@@ -415,25 +423,33 @@ exports[`<States /> spec renders the component 1`] = `
                   <div
                     class="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <button
-                      aria-label="Delete"
-                      class="euiButtonIcon euiButtonIcon--danger"
-                      data-test-subj="state-delete-button"
-                      type="button"
+                    <span
+                      class="euiToolTipAnchor"
                     >
-                      EuiIconMock
-                    </button>
+                      <button
+                        aria-label="Delete"
+                        class="euiButtonIcon euiButtonIcon--danger"
+                        data-test-subj="state-delete-button"
+                        type="button"
+                      >
+                        EuiIconMock
+                      </button>
+                    </span>
                   </div>
                   <div
                     class="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <button
-                      aria-label="Edit"
-                      class="euiButtonIcon euiButtonIcon--primary"
-                      type="button"
+                    <span
+                      class="euiToolTipAnchor"
                     >
-                      EuiIconMock
-                    </button>
+                      <button
+                        aria-label="Edit"
+                        class="euiButtonIcon euiButtonIcon--primary"
+                        type="button"
+                      >
+                        EuiIconMock
+                      </button>
+                    </span>
                   </div>
                 </div>
               </div>

--- a/public/pages/VisualCreatePolicy/components/TimeoutRetrySettings/TimeoutRetrySettings.tsx
+++ b/public/pages/VisualCreatePolicy/components/TimeoutRetrySettings/TimeoutRetrySettings.tsx
@@ -48,7 +48,7 @@ const TimeoutRetrySettings = ({ action, editAction, onChangeAction }: TimeoutRet
               <EuiFieldText
                 fullWidth
                 isInvalid={false}
-                value={action.action.timeout}
+                value={action.action.timeout || ""}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => {
                   const timeout = e.target.value;
                   onChangeAction(action.clone({ ...action.action, timeout }));
@@ -67,10 +67,12 @@ const TimeoutRetrySettings = ({ action, editAction, onChangeAction }: TimeoutRet
                 fullWidth
                 isInvalid={false}
                 min={0}
-                value={action.action.retry?.count}
+                value={typeof action.action.retry?.count === "undefined" ? "" : action.action.retry.count}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => {
                   const count = e.target.valueAsNumber;
-                  onChangeAction(action.clone({ ...action.action, retry: { ...action.action.retry, count } }));
+                  const retry = { ...action.action.retry, count };
+                  if (isNaN(count)) delete retry.count;
+                  onChangeAction(action.clone({ ...action.action, retry }));
                 }}
               />
             </EuiFlexItem>
@@ -84,7 +86,7 @@ const TimeoutRetrySettings = ({ action, editAction, onChangeAction }: TimeoutRet
             fullWidth
             id="retry-backoff-type"
             options={options}
-            value={action.action.retry?.backoff}
+            value={action.action.retry?.backoff || ""}
             onChange={(e: ChangeEvent<HTMLSelectElement>) => {
               const backoff = e.target.value;
               onChangeAction(action.clone({ ...action.action, retry: { ...action.action.retry, backoff } }));
@@ -100,7 +102,7 @@ const TimeoutRetrySettings = ({ action, editAction, onChangeAction }: TimeoutRet
               <EuiFieldText
                 fullWidth
                 isInvalid={false}
-                value={action.action.retry?.delay}
+                value={action.action.retry?.delay || ""}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => {
                   const delay = e.target.value;
                   onChangeAction(action.clone({ ...action.action, retry: { ...action.action.retry, delay } }));

--- a/public/pages/VisualCreatePolicy/components/TimeoutRetrySettings/__snapshots__/TimeoutRetrySettings.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/TimeoutRetrySettings/__snapshots__/TimeoutRetrySettings.test.tsx.snap
@@ -61,6 +61,7 @@ exports[`<TimeoutRetrySettings /> spec renders the component 1`] = `
               style="margin-bottom: 5px;"
             >
               <h5
+                class="euiFormLabel "
                 style="margin-bottom: 2px;"
               >
                 Timeout
@@ -114,6 +115,7 @@ exports[`<TimeoutRetrySettings /> spec renders the component 1`] = `
               style="margin-bottom: 5px;"
             >
               <h5
+                class="euiFormLabel "
                 style="margin-bottom: 2px;"
               >
                 Retry count
@@ -168,6 +170,7 @@ exports[`<TimeoutRetrySettings /> spec renders the component 1`] = `
               style="margin-bottom: 5px;"
             >
               <h5
+                class="euiFormLabel "
                 style="margin-bottom: 2px;"
               >
                 Retry backoff
@@ -236,6 +239,7 @@ exports[`<TimeoutRetrySettings /> spec renders the component 1`] = `
               style="margin-bottom: 5px;"
             >
               <h5
+                class="euiFormLabel "
                 style="margin-bottom: 2px;"
               >
                 Retry delay

--- a/public/pages/VisualCreatePolicy/components/Transition/Transition.tsx
+++ b/public/pages/VisualCreatePolicy/components/Transition/Transition.tsx
@@ -71,7 +71,6 @@ const Transition = ({ uiTransition, onChangeTransition }: TransitionProps) => {
           <EuiFormRow isInvalid={false} error={null}>
             <EuiFieldText
               value={conditions?.min_index_age}
-              style={{ textTransform: "capitalize" }}
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
                 const minIndexAge = e.target.value;
                 onChangeTransition({
@@ -99,7 +98,6 @@ const Transition = ({ uiTransition, onChangeTransition }: TransitionProps) => {
           <EuiFormRow isInvalid={false} error={null}>
             <EuiFieldNumber
               value={typeof conditions?.min_doc_count === "undefined" ? "" : conditions?.min_doc_count}
-              style={{ textTransform: "capitalize" }}
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
                 const minDocCount = e.target.valueAsNumber;
                 const conditions = { min_doc_count: minDocCount };
@@ -129,7 +127,6 @@ const Transition = ({ uiTransition, onChangeTransition }: TransitionProps) => {
           <EuiFormRow isInvalid={false} error={null}>
             <EuiFieldText
               value={conditions?.min_size}
-              style={{ textTransform: "capitalize" }}
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
                 const minSize = e.target.value;
                 onChangeTransition({
@@ -154,7 +151,6 @@ const Transition = ({ uiTransition, onChangeTransition }: TransitionProps) => {
           <EuiFormRow isInvalid={false} error={null}>
             <EuiFieldText
               value={conditions?.cron?.cron.expression}
-              style={{ textTransform: "capitalize" }}
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
                 const expression = e.target.value;
                 onChangeTransition({

--- a/public/pages/VisualCreatePolicy/components/Transition/Transition.tsx
+++ b/public/pages/VisualCreatePolicy/components/Transition/Transition.tsx
@@ -18,6 +18,7 @@ import { UITransition } from "../../../../../models/interfaces";
 const timezones = moment.tz.names().map((tz) => ({ label: tz, text: tz }));
 
 const conditionTypeOptions = [
+  { value: "none", text: "No condition" },
   { value: "min_index_age", text: "Minimum index age" },
   { value: "min_doc_count", text: "Minimum doc count" },
   { value: "min_size", text: "Minimum size" },
@@ -31,7 +32,8 @@ interface TransitionProps {
 
 const Transition = ({ uiTransition, onChangeTransition }: TransitionProps) => {
   // We currently only support one transition condition
-  const conditionType = Object.keys(uiTransition.transition?.conditions || []).pop() || "min_index_age";
+  const conditionType = Object.keys(uiTransition.transition?.conditions || []).pop() || "none";
+  const conditions = uiTransition.transition.conditions;
   return (
     <>
       <EuiFormCustomLabel title="Condition" helpText="Specify the condition needed to be met to transition to the destination state." />
@@ -68,7 +70,7 @@ const Transition = ({ uiTransition, onChangeTransition }: TransitionProps) => {
           <EuiFormCustomLabel title="Minimum index age" helpText="The minimum age required to transition to the next state." />
           <EuiFormRow isInvalid={false} error={null}>
             <EuiFieldText
-              value={uiTransition.transition.conditions?.min_index_age}
+              value={conditions?.min_index_age}
               style={{ textTransform: "capitalize" }}
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
                 const minIndexAge = e.target.value;
@@ -96,17 +98,19 @@ const Transition = ({ uiTransition, onChangeTransition }: TransitionProps) => {
           />
           <EuiFormRow isInvalid={false} error={null}>
             <EuiFieldNumber
-              value={uiTransition.transition.conditions?.min_doc_count}
+              value={typeof conditions?.min_doc_count === "undefined" ? "" : conditions?.min_doc_count}
               style={{ textTransform: "capitalize" }}
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
                 const minDocCount = e.target.valueAsNumber;
+                const conditions = { min_doc_count: minDocCount };
+                // TODO: clean this up..
+                // set it to undefined instead of deleting... as we use the presence of the key itself for the type of transition
+                if (isNaN(minDocCount)) conditions.min_doc_count = undefined;
                 onChangeTransition({
                   ...uiTransition,
                   transition: {
                     ...uiTransition.transition,
-                    conditions: {
-                      min_doc_count: minDocCount,
-                    },
+                    conditions,
                   },
                 });
               }}
@@ -124,7 +128,7 @@ const Transition = ({ uiTransition, onChangeTransition }: TransitionProps) => {
           />
           <EuiFormRow isInvalid={false} error={null}>
             <EuiFieldText
-              value={uiTransition.transition.conditions?.min_size}
+              value={conditions?.min_size}
               style={{ textTransform: "capitalize" }}
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
                 const minSize = e.target.value;
@@ -149,7 +153,7 @@ const Transition = ({ uiTransition, onChangeTransition }: TransitionProps) => {
           <EuiFormCustomLabel title="Cron expression" helpText="The matching cron expression required to transition to the next state." />
           <EuiFormRow isInvalid={false} error={null}>
             <EuiFieldText
-              value={uiTransition.transition.conditions?.cron?.cron.expression}
+              value={conditions?.cron?.cron.expression}
               style={{ textTransform: "capitalize" }}
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
                 const expression = e.target.value;
@@ -179,7 +183,7 @@ const Transition = ({ uiTransition, onChangeTransition }: TransitionProps) => {
             <EuiSelect
               id="timezone"
               options={timezones}
-              value={uiTransition.transition.conditions?.cron?.cron.timezone}
+              value={conditions?.cron?.cron.timezone}
               onChange={(e: ChangeEvent<HTMLSelectElement>) => {
                 const timezone = e.target.value;
                 onChangeTransition({

--- a/public/pages/VisualCreatePolicy/components/Transition/__snapshots__/Transition.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/Transition/__snapshots__/Transition.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`<Transition /> spec renders the component 1`] = `
   style="margin-bottom: 5px;"
 >
   <h5
+    class="euiFormLabel "
     style="margin-bottom: 2px;"
   >
     Condition

--- a/public/pages/VisualCreatePolicy/components/UIActions/AllocationUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/AllocationUIAction.tsx
@@ -35,7 +35,6 @@ export default class AllocationUIAction implements UIAction<AllocationAction> {
       JSON.parse(this.getActionJsonString(this.action));
       return true;
     } catch (err) {
-      console.error(err);
       return false;
     }
   };
@@ -43,6 +42,11 @@ export default class AllocationUIAction implements UIAction<AllocationAction> {
   getActionJsonString = (action: AllocationAction) => {
     const allocation = action.allocation;
     return allocation.hasOwnProperty("jsonString") ? allocation.jsonString : JSON.stringify(allocation, null, 4);
+  };
+
+  getActionJson = (action: AllocationAction) => {
+    const allocation = action.allocation;
+    return allocation.hasOwnProperty("jsonString") ? JSON.parse(allocation.jsonString) : allocation;
   };
 
   render = (action: UIAction<AllocationAction>, onChangeAction: (action: UIAction<AllocationAction>) => void) => {
@@ -58,7 +62,7 @@ export default class AllocationUIAction implements UIAction<AllocationAction> {
               onChange={(str) => {
                 onChangeAction(
                   this.clone({
-                    ...action,
+                    ...action.action,
                     allocation: { jsonString: str },
                   })
                 );
@@ -72,9 +76,8 @@ export default class AllocationUIAction implements UIAction<AllocationAction> {
     );
   };
 
-  toAction = () => {
-    const newAction = { ...this.action };
-    const allocation = JSON.parse(newAction.allocation.jsonString);
-    return { ...newAction, allocation };
-  };
+  toAction = () => ({
+    ...this.action,
+    allocation: this.getActionJson(this.action),
+  });
 }

--- a/public/pages/VisualCreatePolicy/components/UIActions/AllocationUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/AllocationUIAction.tsx
@@ -30,9 +30,9 @@ export default class AllocationUIAction implements UIAction<AllocationAction> {
 
   clone = (action: AllocationAction = this.action) => new AllocationUIAction(action, this.id);
 
-  isValid = (action: UIAction<AllocationAction>) => {
+  isValid = () => {
     try {
-      JSON.parse(this.getActionJsonString(action));
+      JSON.parse(this.getActionJsonString(this.action));
       return true;
     } catch (err) {
       console.error(err);
@@ -40,21 +40,21 @@ export default class AllocationUIAction implements UIAction<AllocationAction> {
     }
   };
 
-  getActionJsonString = (action: UIAction<AllocationAction>) => {
-    const allocation = action.action.allocation;
+  getActionJsonString = (action: AllocationAction) => {
+    const allocation = action.allocation;
     return allocation.hasOwnProperty("jsonString") ? allocation.jsonString : JSON.stringify(allocation, null, 4);
   };
 
   render = (action: UIAction<AllocationAction>, onChangeAction: (action: UIAction<AllocationAction>) => void) => {
     return (
-      <EuiFormRow isInvalid={false} error={null} style={{ maxWidth: "100%" }}>
+      <EuiFormRow isInvalid={!this.isValid()} error={null} style={{ maxWidth: "100%" }}>
         <DarkModeConsumer>
           {(isDarkMode) => (
             <EuiCodeEditor
               mode="json"
               theme={isDarkMode ? "sense-dark" : "github"}
               width="100%"
-              value={this.getActionJsonString(action)}
+              value={this.getActionJsonString(action.action)}
               onChange={(str) => {
                 onChangeAction(
                   this.clone({

--- a/public/pages/VisualCreatePolicy/components/UIActions/CloseUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/CloseUIAction.tsx
@@ -28,6 +28,8 @@ export default class CloseUIAction implements UIAction<CloseAction> {
 
   clone = (action: CloseAction) => new CloseUIAction(action, this.id);
 
+  isValid = (action: UIAction<CloseAction>) => true;
+
   render = (action: UIAction<CloseAction>, onChangeAction: (action: UIAction<CloseAction>) => void) => {
     return <div />;
   };

--- a/public/pages/VisualCreatePolicy/components/UIActions/CloseUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/CloseUIAction.tsx
@@ -28,7 +28,7 @@ export default class CloseUIAction implements UIAction<CloseAction> {
 
   clone = (action: CloseAction) => new CloseUIAction(action, this.id);
 
-  isValid = (action: UIAction<CloseAction>) => true;
+  isValid = () => true;
 
   render = (action: UIAction<CloseAction>, onChangeAction: (action: UIAction<CloseAction>) => void) => {
     return <div />;

--- a/public/pages/VisualCreatePolicy/components/UIActions/DeleteUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/DeleteUIAction.tsx
@@ -28,6 +28,8 @@ export default class DeleteUIAction implements UIAction<DeleteAction> {
 
   clone = (action: DeleteAction) => new DeleteUIAction(action, this.id);
 
+  isValid = (action: UIAction<DeleteAction>) => true;
+
   render = (action: UIAction<DeleteAction>, onChangeAction: (action: UIAction<DeleteAction>) => void) => {
     return <div />;
   };

--- a/public/pages/VisualCreatePolicy/components/UIActions/DeleteUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/DeleteUIAction.tsx
@@ -28,7 +28,7 @@ export default class DeleteUIAction implements UIAction<DeleteAction> {
 
   clone = (action: DeleteAction) => new DeleteUIAction(action, this.id);
 
-  isValid = (action: UIAction<DeleteAction>) => true;
+  isValid = () => true;
 
   render = (action: UIAction<DeleteAction>, onChangeAction: (action: UIAction<DeleteAction>) => void) => {
     return <div />;

--- a/public/pages/VisualCreatePolicy/components/UIActions/ForceMergeUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ForceMergeUIAction.tsx
@@ -31,26 +31,24 @@ export default class ForceMergeUIAction implements UIAction<ForceMergeAction> {
   clone = (action: ForceMergeAction) => new ForceMergeUIAction(action, this.id);
 
   isValid = (action: UIAction<ForceMergeAction>) => {
-    return action.action.force_merge.max_num_segments > 0;
+    const segments = action.action.force_merge.max_num_segments;
+    return !!segments && segments > 0;
   };
 
   render = (action: UIAction<ForceMergeAction>, onChangeAction: (action: UIAction<ForceMergeAction>) => void) => {
+    const segments = action.action.force_merge.max_num_segments;
     return (
       <>
         <EuiFormCustomLabel title="Max num segments" helpText="The number of segments to merge to." />
         <EuiFormRow isInvalid={false} error={null}>
           <EuiFieldNumber
-            value={(action.action as ForceMergeAction).force_merge.max_num_segments}
+            value={typeof segments === "undefined" ? "" : segments}
             style={{ textTransform: "capitalize" }}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const maxNumSegments = e.target.valueAsNumber;
-              onChangeAction(
-                this.clone({
-                  force_merge: {
-                    max_num_segments: maxNumSegments,
-                  },
-                })
-              );
+              const forceMerge = { max_num_segments: maxNumSegments };
+              if (isNaN(maxNumSegments)) delete forceMerge.max_num_segments;
+              onChangeAction(this.clone({ force_merge: forceMerge }));
             }}
             data-test-subj="action-render-force-merge"
           />

--- a/public/pages/VisualCreatePolicy/components/UIActions/ForceMergeUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ForceMergeUIAction.tsx
@@ -30,8 +30,8 @@ export default class ForceMergeUIAction implements UIAction<ForceMergeAction> {
 
   clone = (action: ForceMergeAction) => new ForceMergeUIAction(action, this.id);
 
-  isValid = (action: UIAction<ForceMergeAction>) => {
-    const segments = action.action.force_merge.max_num_segments;
+  isValid = () => {
+    const segments = this.action.force_merge.max_num_segments;
     return !!segments && segments > 0;
   };
 
@@ -39,11 +39,10 @@ export default class ForceMergeUIAction implements UIAction<ForceMergeAction> {
     const segments = action.action.force_merge.max_num_segments;
     return (
       <>
-        <EuiFormCustomLabel title="Max num segments" helpText="The number of segments to merge to." />
-        <EuiFormRow isInvalid={false} error={null}>
+        <EuiFormCustomLabel title="Max num segments" helpText="The number of segments to merge to." isInvalid={!this.isValid()} />
+        <EuiFormRow isInvalid={!this.isValid()} error={null}>
           <EuiFieldNumber
             value={typeof segments === "undefined" ? "" : segments}
-            style={{ textTransform: "capitalize" }}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const maxNumSegments = e.target.valueAsNumber;
               const forceMerge = { max_num_segments: maxNumSegments };

--- a/public/pages/VisualCreatePolicy/components/UIActions/ForceMergeUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ForceMergeUIAction.tsx
@@ -30,6 +30,10 @@ export default class ForceMergeUIAction implements UIAction<ForceMergeAction> {
 
   clone = (action: ForceMergeAction) => new ForceMergeUIAction(action, this.id);
 
+  isValid = (action: UIAction<ForceMergeAction>) => {
+    return action.action.force_merge.max_num_segments > 0;
+  };
+
   render = (action: UIAction<ForceMergeAction>, onChangeAction: (action: UIAction<ForceMergeAction>) => void) => {
     return (
       <>

--- a/public/pages/VisualCreatePolicy/components/UIActions/IndexPriorityUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/IndexPriorityUIAction.tsx
@@ -30,6 +30,10 @@ export default class IndexPriorityUIAction implements UIAction<IndexPriorityActi
 
   clone = (action: IndexPriorityAction) => new IndexPriorityUIAction(action, this.id);
 
+  isValid = (action: UIAction<IndexPriorityAction>) => {
+    return action.action.index_priority.priority >= 0;
+  };
+
   render = (action: UIAction<IndexPriorityAction>, onChangeAction: (action: UIAction<IndexPriorityAction>) => void) => {
     return (
       <>

--- a/public/pages/VisualCreatePolicy/components/UIActions/IndexPriorityUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/IndexPriorityUIAction.tsx
@@ -30,8 +30,8 @@ export default class IndexPriorityUIAction implements UIAction<IndexPriorityActi
 
   clone = (action: IndexPriorityAction) => new IndexPriorityUIAction(action, this.id);
 
-  isValid = (action: UIAction<IndexPriorityAction>) => {
-    const priority = action.action.index_priority.priority;
+  isValid = () => {
+    const priority = this.action.index_priority.priority;
     return typeof priority !== "undefined" && priority >= 0;
   };
 
@@ -39,11 +39,14 @@ export default class IndexPriorityUIAction implements UIAction<IndexPriorityActi
     const priority = action.action.index_priority.priority;
     return (
       <>
-        <EuiFormCustomLabel title="Priority" helpText="Higher priority indices are recovered first when possible." />
-        <EuiFormRow isInvalid={false} error={null}>
+        <EuiFormCustomLabel
+          title="Priority"
+          helpText="Higher priority indices are recovered first when possible."
+          isInvalid={!this.isValid()}
+        />
+        <EuiFormRow isInvalid={!this.isValid()} error={null}>
           <EuiFieldNumber
             value={typeof priority === "undefined" ? "" : priority}
-            style={{ textTransform: "capitalize" }}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const priority = e.target.valueAsNumber;
               const indexPriority = { priority };

--- a/public/pages/VisualCreatePolicy/components/UIActions/IndexPriorityUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/IndexPriorityUIAction.tsx
@@ -31,24 +31,24 @@ export default class IndexPriorityUIAction implements UIAction<IndexPriorityActi
   clone = (action: IndexPriorityAction) => new IndexPriorityUIAction(action, this.id);
 
   isValid = (action: UIAction<IndexPriorityAction>) => {
-    return action.action.index_priority.priority >= 0;
+    const priority = action.action.index_priority.priority;
+    return typeof priority !== "undefined" && priority >= 0;
   };
 
   render = (action: UIAction<IndexPriorityAction>, onChangeAction: (action: UIAction<IndexPriorityAction>) => void) => {
+    const priority = action.action.index_priority.priority;
     return (
       <>
         <EuiFormCustomLabel title="Priority" helpText="Higher priority indices are recovered first when possible." />
         <EuiFormRow isInvalid={false} error={null}>
           <EuiFieldNumber
-            value={(action.action as IndexPriorityAction).index_priority.priority}
+            value={typeof priority === "undefined" ? "" : priority}
             style={{ textTransform: "capitalize" }}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const priority = e.target.valueAsNumber;
-              onChangeAction(
-                this.clone({
-                  index_priority: { priority },
-                })
-              );
+              const indexPriority = { priority };
+              if (isNaN(priority)) delete indexPriority.priority;
+              onChangeAction(this.clone({ index_priority: indexPriority }));
             }}
             data-test-subj="action-render-index-priority"
           />

--- a/public/pages/VisualCreatePolicy/components/UIActions/NotificationUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/NotificationUIAction.tsx
@@ -61,6 +61,16 @@ export default class NotificationUIAction implements UIAction<NotificationAction
 
   clone = (action: NotificationAction) => new NotificationUIAction(action, this.id);
 
+  isValid = (action: UIAction<NotificationAction>) => {
+    try {
+      JSON.parse(action.action.notificationJsonString);
+      return true;
+    } catch (err) {
+      console.error(err);
+      return false;
+    }
+  };
+
   render = (action: UIAction<NotificationAction>, onChangeAction: (action: UIAction<NotificationAction>) => void) => {
     return (
       <ServicesConsumer>

--- a/public/pages/VisualCreatePolicy/components/UIActions/NotificationUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/NotificationUIAction.tsx
@@ -22,6 +22,7 @@ interface NotifUIProps {
   action: NotificationAction;
   clone: (action: NotificationAction) => NotificationUIAction;
   onChangeAction: (action: UIAction<NotificationAction>) => void;
+  isInvalid: boolean;
 }
 class NotifUI extends React.Component<NotifUIProps, NotifUIState> {
   onChangeNotificationJsonString = (str: string) => {
@@ -35,12 +36,13 @@ class NotifUI extends React.Component<NotifUIProps, NotifUIState> {
   };
 
   render() {
-    const { action } = this.props;
+    const { action, isInvalid } = this.props;
     return (
       <LegacyNotification
         notificationJsonString={action.notificationJsonString || ""}
         onChangeNotificationJsonString={this.onChangeNotificationJsonString}
         actionNotification
+        isInvalid={isInvalid}
       />
     );
   }
@@ -61,9 +63,9 @@ export default class NotificationUIAction implements UIAction<NotificationAction
 
   clone = (action: NotificationAction) => new NotificationUIAction(action, this.id);
 
-  isValid = (action: UIAction<NotificationAction>) => {
+  isValid = () => {
     try {
-      JSON.parse(action.action.notificationJsonString);
+      JSON.parse(this.action.notificationJsonString);
       return true;
     } catch (err) {
       console.error(err);
@@ -75,7 +77,7 @@ export default class NotificationUIAction implements UIAction<NotificationAction
     return (
       <ServicesConsumer>
         {(services: BrowserServices | null) =>
-          services && <NotifUI onChangeAction={onChangeAction} action={this.action} clone={this.clone} />
+          services && <NotifUI onChangeAction={onChangeAction} action={this.action} clone={this.clone} isInvalid={!this.isValid()} />
         }
       </ServicesConsumer>
     );

--- a/public/pages/VisualCreatePolicy/components/UIActions/OpenUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/OpenUIAction.tsx
@@ -28,6 +28,8 @@ export default class OpenUIAction implements UIAction<OpenAction> {
 
   clone = (action: OpenAction) => new OpenUIAction(action, this.id);
 
+  isValid = (action: UIAction<OpenAction>) => true;
+
   render = (action: UIAction<OpenAction>, onChangeAction: (action: UIAction<OpenAction>) => void) => {
     return <div />;
   };

--- a/public/pages/VisualCreatePolicy/components/UIActions/OpenUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/OpenUIAction.tsx
@@ -28,7 +28,7 @@ export default class OpenUIAction implements UIAction<OpenAction> {
 
   clone = (action: OpenAction) => new OpenUIAction(action, this.id);
 
-  isValid = (action: UIAction<OpenAction>) => true;
+  isValid = () => true;
 
   render = (action: UIAction<OpenAction>, onChangeAction: (action: UIAction<OpenAction>) => void) => {
     return <div />;

--- a/public/pages/VisualCreatePolicy/components/UIActions/ReadOnlyUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ReadOnlyUIAction.tsx
@@ -28,7 +28,7 @@ export default class ReadOnlyUIAction implements UIAction<ReadOnlyAction> {
 
   clone = (action: ReadOnlyAction) => new ReadOnlyUIAction(action, this.id);
 
-  isValid = (action: UIAction<ReadOnlyAction>) => true;
+  isValid = () => true;
 
   render = (action: UIAction<ReadOnlyAction>, onChangeAction: (action: UIAction<ReadOnlyAction>) => void) => {
     return <div />;

--- a/public/pages/VisualCreatePolicy/components/UIActions/ReadOnlyUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ReadOnlyUIAction.tsx
@@ -28,6 +28,8 @@ export default class ReadOnlyUIAction implements UIAction<ReadOnlyAction> {
 
   clone = (action: ReadOnlyAction) => new ReadOnlyUIAction(action, this.id);
 
+  isValid = (action: UIAction<ReadOnlyAction>) => true;
+
   render = (action: UIAction<ReadOnlyAction>, onChangeAction: (action: UIAction<ReadOnlyAction>) => void) => {
     return <div />;
   };

--- a/public/pages/VisualCreatePolicy/components/UIActions/ReadWriteUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ReadWriteUIAction.tsx
@@ -28,7 +28,7 @@ export default class ReadWriteUIAction implements UIAction<ReadWriteAction> {
 
   clone = (action: ReadWriteAction) => new ReadWriteUIAction(action, this.id);
 
-  isValid = (action: UIAction<ReadWriteAction>) => true;
+  isValid = () => true;
 
   render = (action: UIAction<ReadWriteAction>, onChangeAction: (action: UIAction<ReadWriteAction>) => void) => {
     return <div />;

--- a/public/pages/VisualCreatePolicy/components/UIActions/ReadWriteUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ReadWriteUIAction.tsx
@@ -28,6 +28,8 @@ export default class ReadWriteUIAction implements UIAction<ReadWriteAction> {
 
   clone = (action: ReadWriteAction) => new ReadWriteUIAction(action, this.id);
 
+  isValid = (action: UIAction<ReadWriteAction>) => true;
+
   render = (action: UIAction<ReadWriteAction>, onChangeAction: (action: UIAction<ReadWriteAction>) => void) => {
     return <div />;
   };

--- a/public/pages/VisualCreatePolicy/components/UIActions/ReplicaCountUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ReplicaCountUIAction.tsx
@@ -29,6 +29,10 @@ export default class ReplicaCountUIAction implements UIAction<ReplicaCountAction
 
   clone = (action: ReplicaCountAction) => new ReplicaCountUIAction(action, this.id);
 
+  isValid = (action: UIAction<ReplicaCountAction>) => {
+    return action.action.replica_count.number_of_replicas >= 0;
+  };
+
   render = (action: UIAction<ReplicaCountAction>, onChangeAction: (action: UIAction<ReplicaCountAction>) => void) => {
     return (
       <EuiFormRow label="Number of replicas" helpText="The number of replicas to set for the index." isInvalid={false} error={null}>

--- a/public/pages/VisualCreatePolicy/components/UIActions/ReplicaCountUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ReplicaCountUIAction.tsx
@@ -14,6 +14,7 @@ import { EuiFormRow, EuiFieldNumber } from "@elastic/eui";
 import { ReplicaCountAction, UIAction } from "../../../../../models/interfaces";
 import { makeId } from "../../../../utils/helpers";
 import { ActionType } from "../../utils/constants";
+import EuiFormCustomLabel from "../EuiFormCustomLabel";
 
 export default class ReplicaCountUIAction implements UIAction<ReplicaCountAction> {
   id: string;
@@ -29,27 +30,33 @@ export default class ReplicaCountUIAction implements UIAction<ReplicaCountAction
 
   clone = (action: ReplicaCountAction) => new ReplicaCountUIAction(action, this.id);
 
-  isValid = (action: UIAction<ReplicaCountAction>) => {
-    const numberOfReplicas = action.action.replica_count.number_of_replicas;
+  isValid = () => {
+    const numberOfReplicas = this.action.replica_count.number_of_replicas;
     return typeof numberOfReplicas !== "undefined" && numberOfReplicas >= 0;
   };
 
   render = (action: UIAction<ReplicaCountAction>, onChangeAction: (action: UIAction<ReplicaCountAction>) => void) => {
     const replicas = action.action.replica_count.number_of_replicas;
     return (
-      <EuiFormRow label="Number of replicas" helpText="The number of replicas to set for the index." isInvalid={false} error={null}>
-        <EuiFieldNumber
-          value={typeof replicas === "undefined" ? "" : replicas}
-          style={{ textTransform: "capitalize" }}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => {
-            const numberOfReplicas = e.target.valueAsNumber;
-            const replicaCount = { number_of_replicas: numberOfReplicas };
-            if (isNaN(numberOfReplicas)) delete replicaCount.number_of_replicas;
-            onChangeAction(this.clone({ replica_count: replicaCount }));
-          }}
-          data-test-subj="action-render-replica-count"
+      <>
+        <EuiFormCustomLabel
+          title="Number of replicas"
+          helpText="The number of replicas to set for the index."
+          isInvalid={!this.isValid()}
         />
-      </EuiFormRow>
+        <EuiFormRow isInvalid={!this.isValid()} error={null}>
+          <EuiFieldNumber
+            value={typeof replicas === "undefined" ? "" : replicas}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              const numberOfReplicas = e.target.valueAsNumber;
+              const replicaCount = { number_of_replicas: numberOfReplicas };
+              if (isNaN(numberOfReplicas)) delete replicaCount.number_of_replicas;
+              onChangeAction(this.clone({ replica_count: replicaCount }));
+            }}
+            data-test-subj="action-render-replica-count"
+          />
+        </EuiFormRow>
+      </>
     );
   };
 

--- a/public/pages/VisualCreatePolicy/components/UIActions/ReplicaCountUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ReplicaCountUIAction.tsx
@@ -30,24 +30,22 @@ export default class ReplicaCountUIAction implements UIAction<ReplicaCountAction
   clone = (action: ReplicaCountAction) => new ReplicaCountUIAction(action, this.id);
 
   isValid = (action: UIAction<ReplicaCountAction>) => {
-    return action.action.replica_count.number_of_replicas >= 0;
+    const numberOfReplicas = action.action.replica_count.number_of_replicas;
+    return typeof numberOfReplicas !== "undefined" && numberOfReplicas >= 0;
   };
 
   render = (action: UIAction<ReplicaCountAction>, onChangeAction: (action: UIAction<ReplicaCountAction>) => void) => {
+    const replicas = action.action.replica_count.number_of_replicas;
     return (
       <EuiFormRow label="Number of replicas" helpText="The number of replicas to set for the index." isInvalid={false} error={null}>
         <EuiFieldNumber
-          value={(action.action as ReplicaCountAction).replica_count.number_of_replicas}
+          value={typeof replicas === "undefined" ? "" : replicas}
           style={{ textTransform: "capitalize" }}
           onChange={(e: ChangeEvent<HTMLInputElement>) => {
             const numberOfReplicas = e.target.valueAsNumber;
-            onChangeAction(
-              this.clone({
-                replica_count: {
-                  number_of_replicas: numberOfReplicas,
-                },
-              })
-            );
+            const replicaCount = { number_of_replicas: numberOfReplicas };
+            if (isNaN(numberOfReplicas)) delete replicaCount.number_of_replicas;
+            onChangeAction(this.clone({ replica_count: replicaCount }));
           }}
           data-test-subj="action-render-replica-count"
         />

--- a/public/pages/VisualCreatePolicy/components/UIActions/RolloverUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/RolloverUIAction.tsx
@@ -29,6 +29,19 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
 
   clone = (action: RolloverAction) => new RolloverUIAction(action, this.id);
 
+  isValid = (action: UIAction<RolloverAction>) => {
+    const minIndexAge = action.action.rollover.min_index_age;
+    const minDocCount = action.action.rollover.min_doc_count;
+    const minSize = action.action.rollover.min_size;
+    if (typeof minDocCount !== "undefined") {
+      if (minDocCount <= 0) return false;
+    }
+
+    // for minIndexAge and minSize just let them through and backend will fail the validation
+    // TODO -> add validation for index age and size.. but involves replicating checks for byte strings and time strings
+    return !!minIndexAge || minDocCount === 0 || !!minDocCount || !!minSize;
+  };
+
   render = (action: UIAction<RolloverAction>, onChangeAction: (action: UIAction<RolloverAction>) => void) => {
     return (
       <>

--- a/public/pages/VisualCreatePolicy/components/UIActions/RolloverUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/RolloverUIAction.tsx
@@ -43,22 +43,19 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
   };
 
   render = (action: UIAction<RolloverAction>, onChangeAction: (action: UIAction<RolloverAction>) => void) => {
+    const rollover = action.action.rollover;
     return (
       <>
         <EuiFormRow label="Minimum index age" helpText="The minimum age required to roll over the index." isInvalid={false} error={null}>
           <EuiFieldText
-            value={(action.action as RolloverAction).rollover.min_index_age}
+            value={rollover.min_index_age || ""}
             style={{ textTransform: "capitalize" }}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const minIndexAge = e.target.value;
-              onChangeAction(
-                this.clone({
-                  rollover: {
-                    ...action.action.rollover,
-                    min_index_age: minIndexAge,
-                  },
-                })
-              );
+              const rollover = { ...action.action.rollover };
+              if (minIndexAge) rollover.min_index_age = minIndexAge;
+              else delete rollover.min_index_age;
+              onChangeAction(this.clone({ rollover }));
             }}
             data-test-subj="action-render-rollover-min-index-age"
           />
@@ -70,18 +67,14 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
           error={null}
         >
           <EuiFieldNumber
-            value={(action.action as RolloverAction).rollover.min_doc_count}
+            value={typeof rollover.min_doc_count === "undefined" ? "" : rollover.min_doc_count}
             style={{ textTransform: "capitalize" }}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const minDocCount = e.target.valueAsNumber;
-              onChangeAction(
-                this.clone({
-                  rollover: {
-                    ...action.action.rollover,
-                    min_doc_count: minDocCount,
-                  },
-                })
-              );
+              const rollover = { ...action.action.rollover };
+              if (!isNaN(minDocCount)) rollover.min_doc_count = minDocCount;
+              else delete rollover.min_doc_count;
+              onChangeAction(this.clone({ rollover }));
             }}
             data-test-subj="action-render-rollover-min-doc-count"
           />
@@ -93,18 +86,14 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
           error={null}
         >
           <EuiFieldText
-            value={(action.action as RolloverAction).rollover.min_size}
+            value={rollover.min_size || ""}
             style={{ textTransform: "capitalize" }}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const minSize = e.target.value;
-              onChangeAction(
-                this.clone({
-                  rollover: {
-                    ...action.action.rollover,
-                    min_size: minSize,
-                  },
-                })
-              );
+              const rollover = { ...action.action.rollover };
+              if (minSize) rollover.min_size = minSize;
+              else delete rollover.min_size;
+              onChangeAction(this.clone({ rollover }));
             }}
             data-test-subj="action-render-rollover-min-size"
           />

--- a/public/pages/VisualCreatePolicy/components/UIActions/RolloverUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/RolloverUIAction.tsx
@@ -14,6 +14,7 @@ import { EuiFormRow, EuiFieldNumber, EuiFieldText } from "@elastic/eui";
 import { RolloverAction, UIAction } from "../../../../../models/interfaces";
 import { makeId } from "../../../../utils/helpers";
 import { ActionType } from "../../utils/constants";
+import EuiFormCustomLabel from "../EuiFormCustomLabel";
 
 export default class RolloverUIAction implements UIAction<RolloverAction> {
   id: string;
@@ -29,10 +30,10 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
 
   clone = (action: RolloverAction) => new RolloverUIAction(action, this.id);
 
-  isValid = (action: UIAction<RolloverAction>) => {
-    const minIndexAge = action.action.rollover.min_index_age;
-    const minDocCount = action.action.rollover.min_doc_count;
-    const minSize = action.action.rollover.min_size;
+  isValid = () => {
+    const minIndexAge = this.action.rollover.min_index_age;
+    const minDocCount = this.action.rollover.min_doc_count;
+    const minSize = this.action.rollover.min_size;
     if (typeof minDocCount !== "undefined") {
       if (minDocCount <= 0) return false;
     }
@@ -46,10 +47,14 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
     const rollover = action.action.rollover;
     return (
       <>
-        <EuiFormRow label="Minimum index age" helpText="The minimum age required to roll over the index." isInvalid={false} error={null}>
+        <EuiFormCustomLabel
+          title="Minimum index age"
+          helpText="The minimum age required to roll over the index."
+          isInvalid={!this.isValid()}
+        />
+        <EuiFormRow isInvalid={!this.isValid()} error={null}>
           <EuiFieldText
             value={rollover.min_index_age || ""}
-            style={{ textTransform: "capitalize" }}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const minIndexAge = e.target.value;
               const rollover = { ...action.action.rollover };
@@ -60,15 +65,14 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
             data-test-subj="action-render-rollover-min-index-age"
           />
         </EuiFormRow>
-        <EuiFormRow
-          label="Minimum doc count"
+        <EuiFormCustomLabel
+          title="Minimum doc count"
           helpText="The minimum number of documents required to roll over the index."
-          isInvalid={false}
-          error={null}
-        >
+          isInvalid={!this.isValid()}
+        />
+        <EuiFormRow isInvalid={false} error={null}>
           <EuiFieldNumber
             value={typeof rollover.min_doc_count === "undefined" ? "" : rollover.min_doc_count}
-            style={{ textTransform: "capitalize" }}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const minDocCount = e.target.valueAsNumber;
               const rollover = { ...action.action.rollover };
@@ -79,15 +83,14 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
             data-test-subj="action-render-rollover-min-doc-count"
           />
         </EuiFormRow>
-        <EuiFormRow
-          label="Minimum index size"
+        <EuiFormCustomLabel
+          title="Minimum index size"
           helpText="The minimum size of the total primary shard storage required to roll over the index."
-          isInvalid={false}
-          error={null}
-        >
+          isInvalid={!this.isValid()}
+        />
+        <EuiFormRow isInvalid={false} error={null}>
           <EuiFieldText
             value={rollover.min_size || ""}
-            style={{ textTransform: "capitalize" }}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const minSize = e.target.value;
               const rollover = { ...action.action.rollover };

--- a/public/pages/VisualCreatePolicy/components/UIActions/RollupUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/RollupUIAction.tsx
@@ -35,7 +35,6 @@ export default class RollupUIAction implements UIAction<RollupAction> {
       JSON.parse(this.getActionJsonString(this.action));
       return true;
     } catch (err) {
-      console.error(err);
       return false;
     }
   };
@@ -64,7 +63,7 @@ export default class RollupUIAction implements UIAction<RollupAction> {
               onChange={(str) => {
                 onChangeAction(
                   this.clone({
-                    ...action,
+                    ...action.action,
                     rollup: { jsonString: str },
                   })
                 );

--- a/public/pages/VisualCreatePolicy/components/UIActions/RollupUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/RollupUIAction.tsx
@@ -30,7 +30,23 @@ export default class RollupUIAction implements UIAction<RollupAction> {
 
   clone = (action: RollupAction) => new RollupUIAction(action, this.id);
 
+  isValid = (action: UIAction<RollupAction>) => {
+    try {
+      JSON.parse(this.getActionJsonString(action));
+      return true;
+    } catch (err) {
+      console.error(err);
+      return false;
+    }
+  };
+
+  getActionJsonString = (action: UIAction<RollupAction>) => {
+    const rollup = action.action.rollup;
+    return rollup.hasOwnProperty("jsonString") ? rollup.jsonString : JSON.stringify(rollup, null, 4);
+  };
+
   render = (action: UIAction<RollupAction>, onChangeAction: (action: UIAction<RollupAction>) => void) => {
+    // If we don't have a JSON string yet it just means we haven't converted the rollup to it yet
     return (
       <EuiFormRow isInvalid={false} error={null} style={{ maxWidth: "100%" }}>
         <DarkModeConsumer>
@@ -39,7 +55,7 @@ export default class RollupUIAction implements UIAction<RollupAction> {
               mode="json"
               theme={isDarkMode ? "sense-dark" : "github"}
               width="100%"
-              value={action.action.rollup.jsonString}
+              value={this.getActionJsonString(action)}
               onChange={(str) => {
                 onChangeAction(
                   this.clone({
@@ -59,7 +75,6 @@ export default class RollupUIAction implements UIAction<RollupAction> {
 
   toAction = () => ({
     ...this.action,
-    // TODO: validate this in UI before parsing here in case it failsZ
     rollup: { ism_rollup: JSON.parse(this.action.rollup.jsonString) },
   });
 }

--- a/public/pages/VisualCreatePolicy/components/UIActions/RollupUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/RollupUIAction.tsx
@@ -45,6 +45,11 @@ export default class RollupUIAction implements UIAction<RollupAction> {
     return rollup.hasOwnProperty("jsonString") ? rollup.jsonString : JSON.stringify(rollup, null, 4);
   };
 
+  getActionJson = (action: RollupAction) => {
+    const rollup = action.rollup;
+    return rollup.hasOwnProperty("jsonString") ? JSON.parse(rollup.jsonString) : rollup;
+  };
+
   render = (action: UIAction<RollupAction>, onChangeAction: (action: UIAction<RollupAction>) => void) => {
     // If we don't have a JSON string yet it just means we haven't converted the rollup to it yet
     return (
@@ -75,6 +80,6 @@ export default class RollupUIAction implements UIAction<RollupAction> {
 
   toAction = () => ({
     ...this.action,
-    rollup: { ism_rollup: JSON.parse(this.action.rollup.jsonString) },
+    rollup: this.getActionJson(this.action),
   });
 }

--- a/public/pages/VisualCreatePolicy/components/UIActions/RollupUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/RollupUIAction.tsx
@@ -30,9 +30,9 @@ export default class RollupUIAction implements UIAction<RollupAction> {
 
   clone = (action: RollupAction) => new RollupUIAction(action, this.id);
 
-  isValid = (action: UIAction<RollupAction>) => {
+  isValid = () => {
     try {
-      JSON.parse(this.getActionJsonString(action));
+      JSON.parse(this.getActionJsonString(this.action));
       return true;
     } catch (err) {
       console.error(err);
@@ -40,8 +40,8 @@ export default class RollupUIAction implements UIAction<RollupAction> {
     }
   };
 
-  getActionJsonString = (action: UIAction<RollupAction>) => {
-    const rollup = action.action.rollup;
+  getActionJsonString = (action: RollupAction) => {
+    const rollup = action.rollup;
     return rollup.hasOwnProperty("jsonString") ? rollup.jsonString : JSON.stringify(rollup, null, 4);
   };
 
@@ -53,14 +53,14 @@ export default class RollupUIAction implements UIAction<RollupAction> {
   render = (action: UIAction<RollupAction>, onChangeAction: (action: UIAction<RollupAction>) => void) => {
     // If we don't have a JSON string yet it just means we haven't converted the rollup to it yet
     return (
-      <EuiFormRow isInvalid={false} error={null} style={{ maxWidth: "100%" }}>
+      <EuiFormRow isInvalid={!this.isValid()} error={null} style={{ maxWidth: "100%" }}>
         <DarkModeConsumer>
           {(isDarkMode) => (
             <EuiCodeEditor
               mode="json"
               theme={isDarkMode ? "sense-dark" : "github"}
               width="100%"
-              value={this.getActionJsonString(action)}
+              value={this.getActionJsonString(action.action)}
               onChange={(str) => {
                 onChangeAction(
                   this.clone({

--- a/public/pages/VisualCreatePolicy/components/UIActions/SnapshotUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/SnapshotUIAction.tsx
@@ -14,6 +14,7 @@ import { EuiFormRow, EuiFieldText } from "@elastic/eui";
 import { SnapshotAction, UIAction } from "../../../../../models/interfaces";
 import { makeId } from "../../../../utils/helpers";
 import { ActionType } from "../../utils/constants";
+import EuiFormCustomLabel from "../EuiFormCustomLabel";
 
 export default class SnapshotUIAction implements UIAction<SnapshotAction> {
   id: string;
@@ -29,22 +30,21 @@ export default class SnapshotUIAction implements UIAction<SnapshotAction> {
 
   clone = (action: SnapshotAction) => new SnapshotUIAction(action, this.id);
 
-  isValid = (action: UIAction<SnapshotAction>) => {
-    return !!action.action.snapshot.snapshot && !!action.action.snapshot.repository;
+  isValid = () => {
+    return !!this.action.snapshot.snapshot && !!this.action.snapshot.repository;
   };
 
   render = (action: UIAction<SnapshotAction>, onChangeAction: (action: UIAction<SnapshotAction>) => void) => {
     return (
       <>
-        <EuiFormRow
-          label="Repository"
+        <EuiFormCustomLabel
+          title="Repository"
           helpText="The repository name that you register through the native snapshot API operations."
-          isInvalid={false}
-          error={null}
-        >
+          isInvalid={!this.isValid()}
+        />
+        <EuiFormRow isInvalid={!this.isValid()} error={null}>
           <EuiFieldText
             value={(action.action as SnapshotAction).snapshot.repository}
-            style={{ textTransform: "capitalize" }}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const repository = e.target.value;
               onChangeAction(
@@ -59,10 +59,10 @@ export default class SnapshotUIAction implements UIAction<SnapshotAction> {
             data-test-subj="action-render-snapshot-repository"
           />
         </EuiFormRow>
-        <EuiFormRow label="Snapshot" helpText="The name of the snapshot." isInvalid={false} error={null}>
+        <EuiFormCustomLabel title="Snapshot" helpText="The name of the snapshot." isInvalid={!this.isValid()} />
+        <EuiFormRow isInvalid={!this.isValid()} error={null}>
           <EuiFieldText
             value={(action.action as SnapshotAction).snapshot.snapshot}
-            style={{ textTransform: "capitalize" }}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const snapshot = e.target.value;
               onChangeAction(

--- a/public/pages/VisualCreatePolicy/components/UIActions/SnapshotUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/SnapshotUIAction.tsx
@@ -29,6 +29,10 @@ export default class SnapshotUIAction implements UIAction<SnapshotAction> {
 
   clone = (action: SnapshotAction) => new SnapshotUIAction(action, this.id);
 
+  isValid = (action: UIAction<SnapshotAction>) => {
+    return !!action.action.snapshot.snapshot && !!action.action.snapshot.repository;
+  };
+
   render = (action: UIAction<SnapshotAction>, onChangeAction: (action: UIAction<SnapshotAction>) => void) => {
     return (
       <>

--- a/public/pages/VisualCreatePolicy/containers/CreateAction/CreateAction.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateAction/CreateAction.tsx
@@ -12,7 +12,6 @@
 import React, { Component, ChangeEvent } from "react";
 import { EuiFlyoutBody, EuiFlyoutFooter, EuiTitle, EuiFormRow, EuiSelect, EuiSpacer } from "@elastic/eui";
 import { UIAction, Action } from "../../../../../models/interfaces";
-import { actions } from "../../utils/constants";
 import TimeoutRetrySettings from "../../components/TimeoutRetrySettings";
 import { actionRepoSingleton, capitalizeFirstLetter } from "../../utils/helpers";
 import FlyoutFooter from "../../components/FlyoutFooter";
@@ -112,7 +111,7 @@ export default class CreateAction extends Component<CreateActionProps, CreateAct
           <FlyoutFooter
             edit={!!editAction}
             action="action"
-            disabledAction={!action}
+            disabledAction={!action || !action.isValid(action)}
             onClickCancel={this.props.onClickCancelAction}
             onClickAction={this.onClickSaveAction}
           />

--- a/public/pages/VisualCreatePolicy/containers/CreateAction/__snapshots__/CreateAction.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateAction/__snapshots__/CreateAction.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`<CreateAction /> spec renders the component 1`] = `
         style="margin-bottom: 5px;"
       >
         <h5
+          class="euiFormLabel "
           style="margin-bottom: 2px;"
         >
           Action type
@@ -147,63 +148,71 @@ exports[`<CreateAction /> spec renders the component 1`] = `
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow"
-        id="some_html_id-row"
+        class="euiText euiText--medium"
+        style="margin-bottom: 5px;"
       >
-        <div
-          class="euiFormRow__labelWrapper"
+        <h5
+          class="euiFormLabel "
+          style="margin-bottom: 2px;"
         >
-          <label
-            aria-invalid="false"
-            class="euiFormLabel euiFormRow__label"
-            for="some_html_id"
-          >
-            Minimum index age
-          </label>
-        </div>
-        <div
-          class="euiFormRow__fieldWrapper"
-        >
-          <div
-            class="euiFormControlLayout"
-          >
-            <div
-              class="euiFormControlLayout__childrenWrapper"
-            >
-              <input
-                aria-describedby="some_html_id-help"
-                class="euiFieldText"
-                data-test-subj="action-render-rollover-min-index-age"
-                id="some_html_id"
-                style="text-transform: capitalize;"
-                type="text"
-                value=""
-              />
-            </div>
-          </div>
-          <div
-            class="euiFormHelpText euiFormRow__text"
-            id="some_html_id-help"
+          Minimum index age
+        </h5>
+        <p>
+           
+          <span
+            style="color: grey; font-weight: 200; font-size: 12px;"
           >
             The minimum age required to roll over the index.
-          </div>
-        </div>
+          </span>
+        </p>
       </div>
       <div
         class="euiFormRow"
         id="some_html_id-row"
       >
         <div
-          class="euiFormRow__labelWrapper"
+          class="euiFormRow__fieldWrapper"
         >
-          <label
-            aria-invalid="false"
-            class="euiFormLabel euiFormRow__label"
-            for="some_html_id"
+          <div
+            class="euiFormControlLayout"
           >
-            Minimum doc count
-          </label>
+            <div
+              class="euiFormControlLayout__childrenWrapper"
+            >
+              <input
+                class="euiFieldText"
+                data-test-subj="action-render-rollover-min-index-age"
+                id="some_html_id"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
         </div>
+      </div>
+      <div
+        class="euiText euiText--medium"
+        style="margin-bottom: 5px;"
+      >
+        <h5
+          class="euiFormLabel "
+          style="margin-bottom: 2px;"
+        >
+          Minimum doc count
+        </h5>
+        <p>
+           
+          <span
+            style="color: grey; font-weight: 200; font-size: 12px;"
+          >
+            The minimum number of documents required to roll over the index.
+          </span>
+        </p>
+      </div>
+      <div
+        class="euiFormRow"
+        id="some_html_id-row"
+      >
         <div
           class="euiFormRow__fieldWrapper"
         >
@@ -214,39 +223,39 @@ exports[`<CreateAction /> spec renders the component 1`] = `
               class="euiFormControlLayout__childrenWrapper"
             >
               <input
-                aria-describedby="some_html_id-help"
                 class="euiFieldNumber"
                 data-test-subj="action-render-rollover-min-doc-count"
                 id="some_html_id"
-                style="text-transform: capitalize;"
                 type="number"
                 value="5"
               />
             </div>
           </div>
-          <div
-            class="euiFormHelpText euiFormRow__text"
-            id="some_html_id-help"
-          >
-            The minimum number of documents required to roll over the index.
-          </div>
         </div>
+      </div>
+      <div
+        class="euiText euiText--medium"
+        style="margin-bottom: 5px;"
+      >
+        <h5
+          class="euiFormLabel "
+          style="margin-bottom: 2px;"
+        >
+          Minimum index size
+        </h5>
+        <p>
+           
+          <span
+            style="color: grey; font-weight: 200; font-size: 12px;"
+          >
+            The minimum size of the total primary shard storage required to roll over the index.
+          </span>
+        </p>
       </div>
       <div
         class="euiFormRow"
         id="some_html_id-row"
       >
-        <div
-          class="euiFormRow__labelWrapper"
-        >
-          <label
-            aria-invalid="false"
-            class="euiFormLabel euiFormRow__label"
-            for="some_html_id"
-          >
-            Minimum index size
-          </label>
-        </div>
         <div
           class="euiFormRow__fieldWrapper"
         >
@@ -257,21 +266,13 @@ exports[`<CreateAction /> spec renders the component 1`] = `
               class="euiFormControlLayout__childrenWrapper"
             >
               <input
-                aria-describedby="some_html_id-help"
                 class="euiFieldText"
                 data-test-subj="action-render-rollover-min-size"
                 id="some_html_id"
-                style="text-transform: capitalize;"
                 type="text"
                 value=""
               />
             </div>
-          </div>
-          <div
-            class="euiFormHelpText euiFormRow__text"
-            id="some_html_id-help"
-          >
-            The minimum size of the total primary shard storage required to roll over the index.
           </div>
         </div>
       </div>
@@ -338,6 +339,7 @@ exports[`<CreateAction /> spec renders the component 1`] = `
                     style="margin-bottom: 5px;"
                   >
                     <h5
+                      class="euiFormLabel "
                       style="margin-bottom: 2px;"
                     >
                       Timeout
@@ -391,6 +393,7 @@ exports[`<CreateAction /> spec renders the component 1`] = `
                     style="margin-bottom: 5px;"
                   >
                     <h5
+                      class="euiFormLabel "
                       style="margin-bottom: 2px;"
                     >
                       Retry count
@@ -445,6 +448,7 @@ exports[`<CreateAction /> spec renders the component 1`] = `
                     style="margin-bottom: 5px;"
                   >
                     <h5
+                      class="euiFormLabel "
                       style="margin-bottom: 2px;"
                     >
                       Retry backoff
@@ -513,6 +517,7 @@ exports[`<CreateAction /> spec renders the component 1`] = `
                     style="margin-bottom: 5px;"
                   >
                     <h5
+                      class="euiFormLabel "
                       style="margin-bottom: 2px;"
                     >
                       Retry delay

--- a/public/pages/VisualCreatePolicy/containers/CreateState/Actions.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/Actions.tsx
@@ -41,6 +41,7 @@ const Actions = ({ actions, onClickDeleteAction, onClickEditAction, onDragEndAct
                   isLast={actions.length - 1 === idx}
                   onClickDelete={() => onClickDeleteAction(idx)}
                   onClickEdit={() => onClickEditAction(action)}
+                  draggableType="action"
                 />
               ))}
             </EuiDroppable>

--- a/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
@@ -323,7 +323,7 @@ export default class CreateState extends Component<CreateStateProps, CreateState
       );
     return (
       <EuiPortal>
-        <EuiFlyout ownFocus onClose={onCloseFlyout} maxWidth={600} size="m" aria-labelledby="flyoutTitle">
+        <EuiFlyout hideCloseButton ownFocus={false} onClose={onCloseFlyout} maxWidth={600} size="m" aria-labelledby="flyoutTitle">
           <EuiFlyoutHeader hasBorder>
             <EuiTitle size="m">
               <h2 id="flyoutTitle">{title}</h2>

--- a/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
@@ -270,8 +270,8 @@ export default class CreateState extends Component<CreateStateProps, CreateState
     return (
       <EuiFlexGroup justifyContent="spaceBetween">
         <EuiFlexItem grow={false}>
-          <EuiButtonEmpty iconType="cross" onClick={onCloseFlyout} flush="left">
-            Close
+          <EuiButtonEmpty onClick={onCloseFlyout} flush="left">
+            Cancel
           </EuiButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>

--- a/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
@@ -158,7 +158,9 @@ export default class CreateState extends Component<CreateStateProps, CreateState
     if (action?.action) {
       let newActions = [...actions, action];
       if (!!editAction) {
-        const foundActionIdx = actions.findIndex(({ id }) => action.id === id);
+        // Use edit action id instead of action id.. as current logic of editing an action can end
+        // up with a new id if you switch action types, i.e. rollover -> delete will create a new class w/ a new id
+        const foundActionIdx = actions.findIndex(({ id }) => editAction.id === id);
         if (foundActionIdx >= 0) {
           newActions = actions
             .slice(0, foundActionIdx)

--- a/public/pages/VisualCreatePolicy/containers/CreateState/Transitions.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/Transitions.tsx
@@ -50,6 +50,7 @@ const Transitions = ({
                   isLast={transitions.length - 1 === idx}
                   onClickDelete={() => onClickDeleteTransition(idx)}
                   onClickEdit={() => onClickEditTransition(transition)}
+                  draggableType="transition"
                 />
               ))}
             </EuiDroppable>

--- a/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/Actions.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/Actions.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`<Actions /> spec renders the component 1`] = `
   style="margin-bottom: 5px;"
 >
   <h5
+    class="euiFormLabel "
     style="margin-bottom: 2px;"
   >
     Actions

--- a/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/CreateState.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/CreateState.test.tsx.snap
@@ -27,14 +27,6 @@ exports[`<CreateState /> spec renders the component 1`] = `
         style="max-width: 600px;"
         tabindex="0"
       >
-        <button
-          aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--text euiFlyout__closeButton"
-          data-test-subj="euiFlyoutCloseButton"
-          type="button"
-        >
-          EuiIconMock
-        </button>
         <div
           class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
         >
@@ -323,11 +315,10 @@ exports[`<CreateState /> spec renders the component 1`] = `
                 <span
                   class="euiButtonContent euiButtonEmpty__content"
                 >
-                  EuiIconMock
                   <span
                     class="euiButtonEmpty__text"
                   >
-                    Close
+                    Cancel
                   </span>
                 </span>
               </button>

--- a/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/CreateState.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/CreateState.test.tsx.snap
@@ -196,6 +196,7 @@ exports[`<CreateState /> spec renders the component 1`] = `
                 style="margin-bottom: 5px;"
               >
                 <h5
+                  class="euiFormLabel "
                   style="margin-bottom: 2px;"
                 >
                   Actions
@@ -250,6 +251,7 @@ exports[`<CreateState /> spec renders the component 1`] = `
                 style="margin-bottom: 5px;"
               >
                 <h5
+                  class="euiFormLabel "
                   style="margin-bottom: 2px;"
                 >
                   Transitions

--- a/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/Transitions.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/Transitions.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`<Transitions /> spec renders the component 1`] = `
   style="margin-bottom: 5px;"
 >
   <h5
+    class="euiFormLabel "
     style="margin-bottom: 2px;"
   >
     Transitions

--- a/public/pages/VisualCreatePolicy/containers/CreateTransition/CreateTransition.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateTransition/CreateTransition.tsx
@@ -38,7 +38,7 @@ export default class CreateTransition extends Component<CreateTransitionProps, C
       uiTransition = {
         transition: {
           state_name: "",
-          conditions: { min_index_age: "30d" },
+          conditions: {},
         },
         id: makeId(),
       };

--- a/public/pages/VisualCreatePolicy/containers/CreateTransition/__snapshots__/CreateTransition.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateTransition/__snapshots__/CreateTransition.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`<CreateTransition /> spec renders the component 1`] = `
         style="margin-bottom: 5px;"
       >
         <h5
+          class="euiFormLabel "
           style="margin-bottom: 2px;"
         >
           Destination state
@@ -115,6 +116,7 @@ exports[`<CreateTransition /> spec renders the component 1`] = `
         style="margin-bottom: 5px;"
       >
         <h5
+          class="euiFormLabel "
           style="margin-bottom: 2px;"
         >
           Condition
@@ -194,6 +196,7 @@ exports[`<CreateTransition /> spec renders the component 1`] = `
         style="margin-bottom: 5px;"
       >
         <h5
+          class="euiFormLabel "
           style="margin-bottom: 2px;"
         >
           Minimum index age
@@ -224,7 +227,6 @@ exports[`<CreateTransition /> spec renders the component 1`] = `
                 class="euiFieldText"
                 data-test-subj="transition-render-conditions-min-index-age"
                 id="some_html_id"
-                style="text-transform: capitalize;"
                 type="text"
                 value="30d"
               />

--- a/public/pages/VisualCreatePolicy/containers/CreateTransition/__snapshots__/CreateTransition.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateTransition/__snapshots__/CreateTransition.test.tsx.snap
@@ -148,6 +148,11 @@ exports[`<CreateTransition /> spec renders the component 1`] = `
                 style="text-transform: capitalize;"
               >
                 <option
+                  value="none"
+                >
+                  No condition
+                </option>
+                <option
                   value="min_index_age"
                 >
                   Minimum index age

--- a/public/pages/VisualCreatePolicy/containers/VisualCreatePolicy/VisualCreatePolicy.tsx
+++ b/public/pages/VisualCreatePolicy/containers/VisualCreatePolicy/VisualCreatePolicy.tsx
@@ -181,7 +181,9 @@ export default class VisualCreatePolicy extends Component<VisualCreatePolicyProp
         this.context.notifications.toasts.addDanger(`Failed to create policy: ${response.error}`);
       }
     } catch (err) {
-      this.setState({ submitError: getErrorMessage(err, "There was a problem creating the policy") });
+      const errorMessage = getErrorMessage(err, "There was a problem creating the policy");
+      this.context.notifications.toasts.addDanger(errorMessage);
+      this.setState({ submitError: errorMessage });
     }
   };
 
@@ -198,10 +200,13 @@ export default class VisualCreatePolicy extends Component<VisualCreatePolicyProp
         this.context.notifications.toasts.addSuccess(`Updated policy: ${response.response._id}`);
         this.props.history.push(ROUTES.INDEX_POLICIES);
       } else {
+        this.context.notifications.toasts.addDanger(`Failed to update policy: ${response.error}`);
         this.setState({ submitError: response.error });
       }
     } catch (err) {
-      this.setState({ submitError: getErrorMessage(err, "There was a problem updating the policy") });
+      const errorMessage = getErrorMessage(err, "There was a problem updating the policy");
+      this.context.notifications.toasts.addDanger(errorMessage);
+      this.setState({ submitError: errorMessage });
     }
   };
 

--- a/public/pages/VisualCreatePolicy/utils/constants.ts
+++ b/public/pages/VisualCreatePolicy/utils/constants.ts
@@ -176,8 +176,8 @@ export const DEFAULT_ROLLUP = {
 };
 export const DEFAULT_SNAPSHOT = {
   snapshot: {
-    repository: "",
-    snapshot: "",
+    repository: "example-repository",
+    snapshot: "example-snapshot",
   },
 };
 

--- a/public/pages/VisualCreatePolicy/utils/constants.ts
+++ b/public/pages/VisualCreatePolicy/utils/constants.ts
@@ -129,45 +129,47 @@ export const DEFAULT_ROLLUP = {
   rollup: {
     jsonString: JSON.stringify(
       {
-        target_index: "rollup-nyc-taxi-data",
-        description: "Example rollup job",
-        page_size: 200,
-        dimensions: [
-          {
-            date_histogram: {
-              source_field: "tpep_pickup_datetime",
-              fixed_interval: "1h",
-              timezone: "America/Los_Angeles",
+        ism_rollup: {
+          target_index: "rollup-nyc-taxi-data",
+          description: "Example rollup job",
+          page_size: 200,
+          dimensions: [
+            {
+              date_histogram: {
+                source_field: "tpep_pickup_datetime",
+                fixed_interval: "1h",
+                timezone: "America/Los_Angeles",
+              },
             },
-          },
-          {
-            terms: {
-              source_field: "PULocationID",
+            {
+              terms: {
+                source_field: "PULocationID",
+              },
             },
-          },
-        ],
-        metrics: [
-          {
-            source_field: "passenger_count",
-            metrics: [
-              {
-                avg: {},
-              },
-              {
-                sum: {},
-              },
-              {
-                max: {},
-              },
-              {
-                min: {},
-              },
-              {
-                value_count: {},
-              },
-            ],
-          },
-        ],
+          ],
+          metrics: [
+            {
+              source_field: "passenger_count",
+              metrics: [
+                {
+                  avg: {},
+                },
+                {
+                  sum: {},
+                },
+                {
+                  max: {},
+                },
+                {
+                  min: {},
+                },
+                {
+                  value_count: {},
+                },
+              ],
+            },
+          ],
+        },
       },
       null,
       4

--- a/release-notes/opensearch-index-management-dashboards-plugin.release-notes-1.1.0.0.md
+++ b/release-notes/opensearch-index-management-dashboards-plugin.release-notes-1.1.0.0.md
@@ -34,6 +34,7 @@ Compatible with OpenSearchDashboards 1.1.0
 ### Bug Fixes
 * Address data stream API security breaking issue ([#69](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/69))
 * Fix flaky ([#76](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/76))
+* UI fixes for new ISM UI ([#84](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/84))
 
 ### Documentation
 * Adding support to correctly set the dashboards and opensearch endpoint ([#33](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/33))


### PR DESCRIPTION
### Description

* Adds isValid method to actions, implements logic, and sets on UI to show error state and disable buttons
* Fixes update/create not showing error toaster when there is a failure
* Fixes a bunch of the number type inputs from setting the value as NaN
* Fixes the timeout/retry settings turning into uncontrolled inputs
* Fixes allocation and rollup actions not being able to correctly save when edited and not edited.
* A bunch of the UI inputs had text transform capitalize on them for some reason, probably from copy pasting from other components, removed them.
* Adds default no conditions option in transition conditions
* Fixes editing an action bug that instead adding a new action when switching the action type
* Blocks creating a state if a state with that name already exists on UI
* Removes unused rollover keys if they are not used
* We were missing the UI for Allocation action, considering time just added simple JSON editor and we can go back and add a more friendly UI.
* Removes X from top right of flyout
* Removes flyout overlay and makes outside clicks not close flyout
* Changes state flyout button from "X Close" to "Cancel"
* Removes X icon from action/transition cancel button
* Adds toolips for edit/delete icons for states, transitions, and actions
* Removes underline when hovering states

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
