### PR TITLE
Fixes some small UI touchups/issues for new ISM UI

### DIFF
--- a/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.tsx
+++ b/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.tsx
@@ -11,10 +11,9 @@
 
 import React, { Component } from "react";
 import { EuiLink, EuiFlexGrid, EuiSpacer, EuiFlexItem, EuiText } from "@elastic/eui";
-import { ContentPanel, ContentPanelActions } from "../../../../components/ContentPanel";
+import { ContentPanel } from "../../../../components/ContentPanel";
 import { ModalConsumer } from "../../../../components/Modal";
 import { ErrorNotification, ISMTemplate } from "../../../../../models/interfaces";
-import CreatePolicyModal from "../../../../components/CreatePolicyModal";
 import JSONModal from "../../../../components/JSONModal";
 
 interface PolicySettingsProps {
@@ -25,14 +24,13 @@ interface PolicySettingsProps {
   description: string;
   sequenceNumber: number;
   ismTemplates: ISMTemplate[] | ISMTemplate | null;
-  onEdit: (visual: boolean) => void;
 }
 
 interface PolicySettingsState {}
 
 export default class PolicySettings extends Component<PolicySettingsProps, PolicySettingsState> {
   render() {
-    const { policyId, errorNotification, primaryTerm, lastUpdated, description, sequenceNumber, onEdit } = this.props;
+    const { policyId, errorNotification, primaryTerm, lastUpdated, description, sequenceNumber } = this.props;
 
     const updatedDate = lastUpdated ? new Date(lastUpdated).toLocaleString() : "-";
 
@@ -58,31 +56,7 @@ export default class PolicySettings extends Component<PolicySettingsProps, Polic
     ];
 
     return (
-      <ContentPanel
-        actions={
-          <ModalConsumer>
-            {() => (
-              <ContentPanelActions
-                actions={[
-                  {
-                    text: "Edit",
-                    buttonProps: {
-                      onClick: onEdit,
-                    },
-                    modal: {
-                      onClickModal: (onShow: (component: any, props: object) => void) => () =>
-                        onShow(CreatePolicyModal, { isEdit: true, onClickContinue: onEdit }),
-                    },
-                  },
-                ]}
-              />
-            )}
-          </ModalConsumer>
-        }
-        bodyStyles={{ padding: "10px" }}
-        title="Policy settings"
-        titleSize="s"
-      >
+      <ContentPanel bodyStyles={{ padding: "10px" }} title="Policy settings" titleSize="s">
         <div style={{ paddingLeft: "10px" }}>
           <EuiSpacer size="s" />
           <EuiFlexGrid columns={4}>

--- a/public/pages/PolicyDetails/components/PolicySettings/__snapshots__/PolicySettings.test.tsx.snap
+++ b/public/pages/PolicyDetails/components/PolicySettings/__snapshots__/PolicySettings.test.tsx.snap
@@ -18,41 +18,6 @@ exports[`<PolicySettings /> spec renders the component 1`] = `
         Policy settings
       </h3>
     </div>
-    <div
-      class="euiFlexItem euiFlexItem--flexGrowZero"
-    >
-      <div
-        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-      >
-        <div
-          class="euiFlexItem"
-        >
-          <div
-            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-          >
-            <div
-              class="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <button
-                class="euiButton euiButton--primary"
-                data-test-subj="EditButton"
-                type="button"
-              >
-                <span
-                  class="euiButtonContent euiButton__content"
-                >
-                  <span
-                    class="euiButton__text"
-                  >
-                    Edit
-                  </span>
-                </span>
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
   </div>
   <hr
     class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"

--- a/public/pages/PolicyDetails/containers/PolicyDetails/PolicyDetails.tsx
+++ b/public/pages/PolicyDetails/containers/PolicyDetails/PolicyDetails.tsx
@@ -37,6 +37,8 @@ import States from "../../../VisualCreatePolicy/components/States";
 import JSONModal from "../../../../components/JSONModal";
 import { ContentPanel } from "../../../../components/ContentPanel";
 import { convertTemplatesToArray } from "../../../VisualCreatePolicy/utils/helpers";
+import CreatePolicyModal from "../../../../components/CreatePolicyModal";
+import { ModalConsumer } from "../../../../components/Modal";
 
 interface PolicyDetailsProps extends RouteComponentProps {
   policyService: PolicyService;
@@ -190,6 +192,18 @@ export default class PolicyDetails extends Component<PolicyDetailsProps, PolicyD
           <EuiFlexItem grow={false}>
             <EuiFlexGroup alignItems="center" gutterSize="s">
               <EuiFlexItem grow={false}>
+                <ModalConsumer>
+                  {({ onShow }) => (
+                    <EuiButton
+                      onClick={() => onShow(CreatePolicyModal, { isEdit: true, onClickContinue: this.onEdit })}
+                      data-test-subj="policy-details-edit-button"
+                    >
+                      Edit
+                    </EuiButton>
+                  )}
+                </ModalConsumer>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
                 <EuiButton onClick={this.showDeleteModal} color="danger" data-test-subj="deleteButton">
                   Delete
                 </EuiButton>
@@ -212,7 +226,6 @@ export default class PolicyDetails extends Component<PolicyDetailsProps, PolicyD
           description={policy.policy.description}
           sequenceNumber={policy.seqNo}
           ismTemplates={policy.policy.ism_template || []}
-          onEdit={this.onEdit}
         />
         <EuiSpacer />
         <ContentPanel bodyStyles={{ padding: "10px" }} title={`ISM Templates (${convertedISMTemplates.length})`} titleSize="s">

--- a/public/pages/VisualCreatePolicy/components/FlyoutFooter/FlyoutFooter.tsx
+++ b/public/pages/VisualCreatePolicy/components/FlyoutFooter/FlyoutFooter.tsx
@@ -21,7 +21,7 @@ interface FlyoutFooterProps {
 }
 
 const FlyoutFooter = ({ edit, action, disabledAction = false, onClickCancel, onClickAction }: FlyoutFooterProps) => (
-  <EuiFlexGroup justifyContent="spaceBetween">
+  <EuiFlexGroup justifyContent="flexEnd">
     <EuiFlexItem grow={false}>
       <EuiButtonEmpty onClick={onClickCancel} flush="left" data-test-subj="flyout-footer-cancel-button">
         Cancel

--- a/public/pages/VisualCreatePolicy/components/FlyoutFooter/__snapshots__/FlyoutFooter.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/FlyoutFooter/__snapshots__/FlyoutFooter.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<FlyoutFooter /> spec renders the component 1`] = `
 <div
-  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
 >
   <div
     class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/public/pages/VisualCreatePolicy/components/ISMTemplates/ISMTemplates.tsx
+++ b/public/pages/VisualCreatePolicy/components/ISMTemplates/ISMTemplates.tsx
@@ -109,6 +109,7 @@ const ISMTemplates = ({ policy, onChangePolicy }: ISMTemplatesProps) => {
         {!templates.length ? (
           <EuiEmptyPrompt
             title={<h2>No ISM templates</h2>}
+            style={{ maxWidth: "37em" }}
             titleSize="s"
             body={
               <p>

--- a/public/pages/VisualCreatePolicy/components/ISMTemplates/__snapshots__/ISMTemplates.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/ISMTemplates/__snapshots__/ISMTemplates.test.tsx.snap
@@ -74,186 +74,50 @@ exports[`<ISMTemplates /> spec renders the component 1`] = `
       style="padding: 10px 0px 0px 10px;"
     >
       <div
-        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-      >
-        <div
-          class="euiFlexItem"
-          style="max-width: 400px;"
-        >
-          <div
-            class="euiText euiText--medium"
-          >
-            <h5>
-              Index patterns
-            </h5>
-          </div>
-        </div>
-        <div
-          class="euiFlexItem euiFlexItem--flexGrowZero"
-        >
-          <div
-            class="euiText euiText--medium"
-          >
-            <h5>
-              Priority
-            </h5>
-          </div>
-        </div>
-      </div>
-      <div
-        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-      >
-        <div
-          class="euiFlexItem"
-          style="max-width: 400px;"
-        >
-          <div
-            class="euiFormRow"
-            id="some_html_id-row"
-          >
-            <div
-              class="euiFormRow__fieldWrapper"
-            >
-              <div
-                aria-expanded="false"
-                aria-haspopup="listbox"
-                class="euiComboBox"
-                data-test-subj="ism-template-index-pattern-input"
-                role="combobox"
-              >
-                <div
-                  class="euiFormControlLayout"
-                >
-                  <div
-                    class="euiFormControlLayout__childrenWrapper"
-                  >
-                    <div
-                      class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
-                      data-test-subj="comboBoxInput"
-                      tabindex="-1"
-                    >
-                      <span
-                        class="euiBadge euiBadge--hollow euiBadge--iconRight euiComboBoxPill"
-                        title="logs-*"
-                      >
-                        <span
-                          class="euiBadge__content"
-                        >
-                          <span
-                            class="euiBadge__text"
-                          >
-                            logs-*
-                          </span>
-                          <button
-                            aria-label="Remove logs-* from selection in this group"
-                            class="euiBadge__iconButton"
-                            title="Remove logs-* from selection in this group"
-                          >
-                            EuiIconMock
-                          </button>
-                        </span>
-                      </span>
-                      <div
-                        class="euiComboBox__input"
-                        style="font-size: 14px; display: inline-block;"
-                      >
-                        <input
-                          aria-controls=""
-                          data-test-subj="comboBoxSearchInput"
-                          id="some_html_id"
-                          role="textbox"
-                          style="box-sizing: content-box; width: 2px;"
-                          value=""
-                        />
-                        <div
-                          style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                    >
-                      <button
-                        aria-label="Clear input"
-                        class="euiFormControlLayoutClearButton"
-                        data-test-subj="comboBoxClearButton"
-                        type="button"
-                      >
-                        EuiIconMock
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="euiFlexItem euiFlexItem--flexGrowZero"
-        >
-          <div
-            class="euiFormRow"
-            id="some_html_id-row"
-          >
-            <div
-              class="euiFormRow__fieldWrapper"
-            >
-              <div
-                class="euiFormControlLayout"
-              >
-                <div
-                  class="euiFormControlLayout__childrenWrapper"
-                >
-                  <input
-                    class="euiFieldNumber"
-                    data-test-subj="ism-template-priority-input"
-                    id="some_html_id"
-                    type="number"
-                    value="5"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="euiFlexItem euiFlexItem--flexGrowZero"
-        >
-          <button
-            class="euiButton euiButton--danger"
-            data-test-subj="ism-template-remove-button"
-            type="button"
-          >
-            <span
-              class="euiButtonContent euiButton__content"
-            >
-              <span
-                class="euiButton__text"
-              >
-                Remove
-              </span>
-            </span>
-          </button>
-        </div>
-      </div>
-      <div
-        class="euiSpacer euiSpacer--l"
-      />
-      <button
-        class="euiButton euiButton--primary"
-        data-test-subj="ism-templates-add-template-button"
-        type="button"
+        class="euiEmptyPrompt"
+        style="max-width: 37em;"
       >
         <span
-          class="euiButtonContent euiButton__content"
+          class="euiTextColor euiTextColor--subdued"
+        >
+          <h2
+            class="euiTitle euiTitle--small"
+          >
+            No ISM templates
+          </h2>
+          <div
+            class="euiSpacer euiSpacer--m"
+          />
+          <div
+            class="euiText euiText--medium"
+          >
+            <p>
+              Your policy currently has no ISM templates defined. Add ISM templates to automatically apply the policy to indices created in the future.
+            </p>
+          </div>
+        </span>
+        <div
+          class="euiSpacer euiSpacer--l"
+        />
+        <div
+          class="euiSpacer euiSpacer--s"
+        />
+        <button
+          class="euiButton euiButton--primary"
+          data-test-subj="ism-templates-add-template-button"
+          type="button"
         >
           <span
-            class="euiButton__text"
+            class="euiButtonContent euiButton__content"
           >
-            Add template
+            <span
+              class="euiButton__text"
+            >
+              Add template
+            </span>
           </span>
-        </span>
-      </button>
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/public/pages/VisualCreatePolicy/components/LegacyNotification/LegacyNotification.tsx
+++ b/public/pages/VisualCreatePolicy/components/LegacyNotification/LegacyNotification.tsx
@@ -31,7 +31,7 @@ const LegacyNotification = ({
 }: LegacyNotificationProps) => {
   return (
     <>
-      <EuiFormRow isInvalid={isInvalid} error={null} style={{ maxWidth: "100%" }}>
+      <EuiFormRow fullWidth isInvalid={isInvalid} error={null} style={{ maxWidth: "100%" }}>
         <DarkModeConsumer>
           {(isDarkMode) => (
             <EuiCodeEditor

--- a/public/pages/VisualCreatePolicy/components/LegacyNotification/__snapshots__/LegacyNotification.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/LegacyNotification/__snapshots__/LegacyNotification.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<LegacyNotification /> spec renders the component 1`] = `
 <div
-  class="euiFormRow"
+  class="euiFormRow euiFormRow--fullWidth"
   id="some_html_id-row"
   style="max-width: 100%;"
 >

--- a/public/pages/VisualCreatePolicy/components/PolicyInfo/PolicyInfo.tsx
+++ b/public/pages/VisualCreatePolicy/components/PolicyInfo/PolicyInfo.tsx
@@ -44,7 +44,7 @@ const PolicyInfo = ({ isEdit, policyId, policyIdError, description, onChangePoli
 
       <EuiSpacer size="m" />
 
-      <EuiFormCustomLabel title="Description" helpText="Describe the policy" />
+      <EuiFormCustomLabel title="Description" helpText="Describe the policy." />
 
       <EuiFormRow isInvalid={false} error={null}>
         <EuiTextArea

--- a/public/pages/VisualCreatePolicy/components/PolicyInfo/__snapshots__/PolicyInfo.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/PolicyInfo/__snapshots__/PolicyInfo.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`<PolicyInfo /> spec renders the component 1`] = `
           <span
             style="color: grey; font-weight: 200; font-size: 12px;"
           >
-            Describe the policy
+            Describe the policy.
           </span>
         </p>
       </div>

--- a/public/pages/VisualCreatePolicy/components/TimeoutRetrySettings/TimeoutRetrySettings.tsx
+++ b/public/pages/VisualCreatePolicy/components/TimeoutRetrySettings/TimeoutRetrySettings.tsx
@@ -46,8 +46,8 @@ const TimeoutRetrySettings = ({ action, editAction, onChangeAction }: TimeoutRet
           <EuiFlexGroup>
             <EuiFlexItem>
               <EuiFieldText
-                fullWidth
                 isInvalid={false}
+                fullWidth
                 value={action.action.timeout || ""}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => {
                   const timeout = e.target.value;
@@ -59,13 +59,16 @@ const TimeoutRetrySettings = ({ action, editAction, onChangeAction }: TimeoutRet
         </EuiFormRow>
       </EuiFlexItem>
       <EuiFlexItem>
-        <EuiFormCustomLabel title="Retry count" helpText="The number of times the action should be retried if it fails." />
+        <EuiFormCustomLabel
+          title="Retry count"
+          helpText="The number of times the action should be retried if it fails. Must be greater than 0."
+        />
         <EuiFormRow fullWidth isInvalid={false} error={null}>
           <EuiFlexGroup>
             <EuiFlexItem>
               <EuiFieldNumber
-                fullWidth
                 isInvalid={false}
+                fullWidth
                 min={0}
                 value={typeof action.action.retry?.count === "undefined" ? "" : action.action.retry.count}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => {
@@ -83,8 +86,8 @@ const TimeoutRetrySettings = ({ action, editAction, onChangeAction }: TimeoutRet
         <EuiFormCustomLabel title="Retry backoff" helpText="The backoff policy type to use when retrying." />
         <EuiFormRow fullWidth isInvalid={false} error={null}>
           <EuiSelect
-            fullWidth
             id="retry-backoff-type"
+            fullWidth
             options={options}
             value={action.action.retry?.backoff || ""}
             onChange={(e: ChangeEvent<HTMLSelectElement>) => {
@@ -100,8 +103,8 @@ const TimeoutRetrySettings = ({ action, editAction, onChangeAction }: TimeoutRet
           <EuiFlexGroup>
             <EuiFlexItem>
               <EuiFieldText
-                fullWidth
                 isInvalid={false}
+                fullWidth
                 value={action.action.retry?.delay || ""}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => {
                   const delay = e.target.value;

--- a/public/pages/VisualCreatePolicy/components/TimeoutRetrySettings/__snapshots__/TimeoutRetrySettings.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/TimeoutRetrySettings/__snapshots__/TimeoutRetrySettings.test.tsx.snap
@@ -125,7 +125,7 @@ exports[`<TimeoutRetrySettings /> spec renders the component 1`] = `
                 <span
                   style="color: grey; font-weight: 200; font-size: 12px;"
                 >
-                  The number of times the action should be retried if it fails.
+                  The number of times the action should be retried if it fails. Must be greater than 0.
                 </span>
               </p>
             </div>

--- a/public/pages/VisualCreatePolicy/components/Transition/Transition.tsx
+++ b/public/pages/VisualCreatePolicy/components/Transition/Transition.tsx
@@ -32,7 +32,7 @@ interface TransitionProps {
 
 const Transition = ({ uiTransition, onChangeTransition }: TransitionProps) => {
   // We currently only support one transition condition
-  const conditionType = Object.keys(uiTransition.transition?.conditions || []).pop() || "none";
+  const conditionType = Object.keys(uiTransition.transition.conditions || []).pop() || "none";
   const conditions = uiTransition.transition.conditions;
   return (
     <>
@@ -45,18 +45,16 @@ const Transition = ({ uiTransition, onChangeTransition }: TransitionProps) => {
           style={{ textTransform: "capitalize" }}
           onChange={(e) => {
             const selectedConditionType = e.target.value;
-            let condition = {};
-            if (selectedConditionType === "min_index_age") condition = { min_index_age: "30d" };
-            if (selectedConditionType === "min_doc_count") condition = { min_doc_count: 1000000 };
-            if (selectedConditionType === "min_size") condition = { min_size: "50gb" };
+            const transition = { ...uiTransition.transition };
+            if (selectedConditionType === "none") delete transition.conditions;
+            if (selectedConditionType === "min_index_age") transition.conditions = { min_index_age: "30d" };
+            if (selectedConditionType === "min_doc_count") transition.conditions = { min_doc_count: 1000000 };
+            if (selectedConditionType === "min_size") transition.conditions = { min_size: "50gb" };
             if (selectedConditionType === "cron")
-              condition = { cron: { cron: { expression: "* 17 * * SAT", timezone: "America/Los_Angeles" } } };
+              transition.conditions = { cron: { cron: { expression: "* 17 * * SAT", timezone: "America/Los_Angeles" } } };
             onChangeTransition({
               ...uiTransition,
-              transition: {
-                ...uiTransition.transition,
-                conditions: condition,
-              },
+              transition,
             });
           }}
           data-test-subj="create-state-action-type"

--- a/public/pages/VisualCreatePolicy/components/UIActions/AllocationUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/AllocationUIAction.tsx
@@ -51,7 +51,7 @@ export default class AllocationUIAction implements UIAction<AllocationAction> {
 
   render = (action: UIAction<AllocationAction>, onChangeAction: (action: UIAction<AllocationAction>) => void) => {
     return (
-      <EuiFormRow isInvalid={!this.isValid()} error={null} style={{ maxWidth: "100%" }}>
+      <EuiFormRow fullWidth isInvalid={!this.isValid()} error={null} style={{ maxWidth: "100%" }}>
         <DarkModeConsumer>
           {(isDarkMode) => (
             <EuiCodeEditor

--- a/public/pages/VisualCreatePolicy/components/UIActions/ForceMergeUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ForceMergeUIAction.tsx
@@ -40,8 +40,9 @@ export default class ForceMergeUIAction implements UIAction<ForceMergeAction> {
     return (
       <>
         <EuiFormCustomLabel title="Max num segments" helpText="The number of segments to merge to." isInvalid={!this.isValid()} />
-        <EuiFormRow isInvalid={!this.isValid()} error={null}>
+        <EuiFormRow fullWidth isInvalid={!this.isValid()} error={null}>
           <EuiFieldNumber
+            fullWidth
             value={typeof segments === "undefined" ? "" : segments}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const maxNumSegments = e.target.valueAsNumber;

--- a/public/pages/VisualCreatePolicy/components/UIActions/IndexPriorityUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/IndexPriorityUIAction.tsx
@@ -44,8 +44,9 @@ export default class IndexPriorityUIAction implements UIAction<IndexPriorityActi
           helpText="Higher priority indices are recovered first when possible."
           isInvalid={!this.isValid()}
         />
-        <EuiFormRow isInvalid={!this.isValid()} error={null}>
+        <EuiFormRow fullWidth isInvalid={!this.isValid()} error={null}>
           <EuiFieldNumber
+            fullWidth
             value={typeof priority === "undefined" ? "" : priority}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const priority = e.target.valueAsNumber;

--- a/public/pages/VisualCreatePolicy/components/UIActions/ReplicaCountUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ReplicaCountUIAction.tsx
@@ -44,8 +44,9 @@ export default class ReplicaCountUIAction implements UIAction<ReplicaCountAction
           helpText="The number of replicas to set for the index."
           isInvalid={!this.isValid()}
         />
-        <EuiFormRow isInvalid={!this.isValid()} error={null}>
+        <EuiFormRow fullWidth isInvalid={!this.isValid()} error={null}>
           <EuiFieldNumber
+            fullWidth
             value={typeof replicas === "undefined" ? "" : replicas}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const numberOfReplicas = e.target.valueAsNumber;

--- a/public/pages/VisualCreatePolicy/components/UIActions/RolloverUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/RolloverUIAction.tsx
@@ -10,7 +10,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiFormRow, EuiFieldNumber, EuiFieldText } from "@elastic/eui";
+import { EuiFormRow, EuiFieldNumber, EuiFieldText, EuiSpacer } from "@elastic/eui";
 import { RolloverAction, UIAction } from "../../../../../models/interfaces";
 import { makeId } from "../../../../utils/helpers";
 import { ActionType } from "../../utils/constants";
@@ -52,8 +52,9 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
           helpText="The minimum age required to roll over the index."
           isInvalid={!this.isValid()}
         />
-        <EuiFormRow isInvalid={!this.isValid()} error={null}>
+        <EuiFormRow fullWidth isInvalid={!this.isValid()} error={null}>
           <EuiFieldText
+            fullWidth
             value={rollover.min_index_age || ""}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const minIndexAge = e.target.value;
@@ -65,13 +66,15 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
             data-test-subj="action-render-rollover-min-index-age"
           />
         </EuiFormRow>
+        <EuiSpacer size="s" />
         <EuiFormCustomLabel
           title="Minimum doc count"
           helpText="The minimum number of documents required to roll over the index."
           isInvalid={!this.isValid()}
         />
-        <EuiFormRow isInvalid={false} error={null}>
+        <EuiFormRow fullWidth isInvalid={false} error={null}>
           <EuiFieldNumber
+            fullWidth
             value={typeof rollover.min_doc_count === "undefined" ? "" : rollover.min_doc_count}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const minDocCount = e.target.valueAsNumber;
@@ -83,13 +86,15 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
             data-test-subj="action-render-rollover-min-doc-count"
           />
         </EuiFormRow>
+        <EuiSpacer size="s" />
         <EuiFormCustomLabel
           title="Minimum index size"
           helpText="The minimum size of the total primary shard storage required to roll over the index."
           isInvalid={!this.isValid()}
         />
-        <EuiFormRow isInvalid={false} error={null}>
+        <EuiFormRow fullWidth isInvalid={false} error={null}>
           <EuiFieldText
+            fullWidth
             value={rollover.min_size || ""}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const minSize = e.target.value;

--- a/public/pages/VisualCreatePolicy/components/UIActions/RollupUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/RollupUIAction.tsx
@@ -52,7 +52,7 @@ export default class RollupUIAction implements UIAction<RollupAction> {
   render = (action: UIAction<RollupAction>, onChangeAction: (action: UIAction<RollupAction>) => void) => {
     // If we don't have a JSON string yet it just means we haven't converted the rollup to it yet
     return (
-      <EuiFormRow isInvalid={!this.isValid()} error={null} style={{ maxWidth: "100%" }}>
+      <EuiFormRow fullWidth isInvalid={!this.isValid()} error={null} style={{ maxWidth: "100%" }}>
         <DarkModeConsumer>
           {(isDarkMode) => (
             <EuiCodeEditor

--- a/public/pages/VisualCreatePolicy/components/UIActions/SnapshotUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/SnapshotUIAction.tsx
@@ -10,7 +10,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiFormRow, EuiFieldText } from "@elastic/eui";
+import { EuiFormRow, EuiFieldText, EuiSpacer } from "@elastic/eui";
 import { SnapshotAction, UIAction } from "../../../../../models/interfaces";
 import { makeId } from "../../../../utils/helpers";
 import { ActionType } from "../../utils/constants";
@@ -42,8 +42,9 @@ export default class SnapshotUIAction implements UIAction<SnapshotAction> {
           helpText="The repository name that you register through the native snapshot API operations."
           isInvalid={!this.isValid()}
         />
-        <EuiFormRow isInvalid={!this.isValid()} error={null}>
+        <EuiFormRow fullWidth isInvalid={!this.isValid()} error={null}>
           <EuiFieldText
+            fullWidth
             value={(action.action as SnapshotAction).snapshot.repository}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const repository = e.target.value;
@@ -59,9 +60,11 @@ export default class SnapshotUIAction implements UIAction<SnapshotAction> {
             data-test-subj="action-render-snapshot-repository"
           />
         </EuiFormRow>
+        <EuiSpacer size="s" />
         <EuiFormCustomLabel title="Snapshot" helpText="The name of the snapshot." isInvalid={!this.isValid()} />
-        <EuiFormRow isInvalid={!this.isValid()} error={null}>
+        <EuiFormRow fullWidth isInvalid={!this.isValid()} error={null}>
           <EuiFieldText
+            fullWidth
             value={(action.action as SnapshotAction).snapshot.snapshot}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const snapshot = e.target.value;

--- a/public/pages/VisualCreatePolicy/containers/CreateAction/CreateAction.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateAction/CreateAction.tsx
@@ -83,8 +83,9 @@ export default class CreateAction extends Component<CreateActionProps, CreateAct
           <EuiSpacer />
 
           <EuiFormCustomLabel title="Action type" helpText="Select the action you want to add to this state." />
-          <EuiFormRow isInvalid={false} error={null}>
+          <EuiFormRow fullWidth isInvalid={false} error={null}>
             <EuiSelect
+              fullWidth
               placeholder="Select action type"
               id="action-type"
               hasNoInitialSelection

--- a/public/pages/VisualCreatePolicy/containers/CreateAction/__snapshots__/CreateAction.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateAction/__snapshots__/CreateAction.test.tsx.snap
@@ -38,20 +38,20 @@ exports[`<CreateAction /> spec renders the component 1`] = `
         </p>
       </div>
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--fullWidth"
         id="some_html_id-row"
       >
         <div
           class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormControlLayout"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <select
-                class="euiSelect"
+                class="euiSelect euiSelect--fullWidth"
                 data-test-subj="create-state-action-type"
                 id="some_html_id"
                 placeholder="Select action type"
@@ -167,20 +167,20 @@ exports[`<CreateAction /> spec renders the component 1`] = `
         </p>
       </div>
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--fullWidth"
         id="some_html_id-row"
       >
         <div
           class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormControlLayout"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <input
-                class="euiFieldText"
+                class="euiFieldText euiFieldText--fullWidth"
                 data-test-subj="action-render-rollover-min-index-age"
                 id="some_html_id"
                 type="text"
@@ -190,6 +190,9 @@ exports[`<CreateAction /> spec renders the component 1`] = `
           </div>
         </div>
       </div>
+      <div
+        class="euiSpacer euiSpacer--s"
+      />
       <div
         class="euiText euiText--medium"
         style="margin-bottom: 5px;"
@@ -210,20 +213,20 @@ exports[`<CreateAction /> spec renders the component 1`] = `
         </p>
       </div>
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--fullWidth"
         id="some_html_id-row"
       >
         <div
           class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormControlLayout"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <input
-                class="euiFieldNumber"
+                class="euiFieldNumber euiFieldNumber--fullWidth"
                 data-test-subj="action-render-rollover-min-doc-count"
                 id="some_html_id"
                 type="number"
@@ -233,6 +236,9 @@ exports[`<CreateAction /> spec renders the component 1`] = `
           </div>
         </div>
       </div>
+      <div
+        class="euiSpacer euiSpacer--s"
+      />
       <div
         class="euiText euiText--medium"
         style="margin-bottom: 5px;"
@@ -253,20 +259,20 @@ exports[`<CreateAction /> spec renders the component 1`] = `
         </p>
       </div>
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--fullWidth"
         id="some_html_id-row"
       >
         <div
           class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormControlLayout"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <input
-                class="euiFieldText"
+                class="euiFieldText euiFieldText--fullWidth"
                 data-test-subj="action-render-rollover-min-size"
                 id="some_html_id"
                 type="text"
@@ -403,7 +409,7 @@ exports[`<CreateAction /> spec renders the component 1`] = `
                       <span
                         style="color: grey; font-weight: 200; font-size: 12px;"
                       >
-                        The number of times the action should be retried if it fails.
+                        The number of times the action should be retried if it fails. Must be greater than 0.
                       </span>
                     </p>
                   </div>

--- a/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
@@ -285,7 +285,7 @@ export default class CreateState extends Component<CreateStateProps, CreateState
     return (
       <EuiFlexGroup justifyContent="spaceBetween">
         <EuiFlexItem grow={false}>
-          <EuiButtonEmpty onClick={onCloseFlyout} flush="left">
+          <EuiButtonEmpty iconType="cross" onClick={onCloseFlyout} flush="left">
             Cancel
           </EuiButtonEmpty>
         </EuiFlexItem>

--- a/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/CreateState.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/CreateState.test.tsx.snap
@@ -317,6 +317,7 @@ exports[`<CreateState /> spec renders the component 1`] = `
                 <span
                   class="euiButtonContent euiButtonEmpty__content"
                 >
+                  EuiIconMock
                   <span
                     class="euiButtonEmpty__text"
                   >

--- a/public/pages/VisualCreatePolicy/containers/CreateTransition/CreateTransition.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateTransition/CreateTransition.tsx
@@ -38,7 +38,6 @@ export default class CreateTransition extends Component<CreateTransitionProps, C
       uiTransition = {
         transition: {
           state_name: "",
-          conditions: {},
         },
         id: makeId(),
       };

--- a/public/pages/VisualCreatePolicy/containers/ErrorNotification/__snapshots__/ErrorNotification.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/ErrorNotification/__snapshots__/ErrorNotification.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`<ErrorNotification /> spec renders the component 1`] = `
       style="padding: 10px 0px 0px 10px;"
     >
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--fullWidth"
         id="some_html_id-row"
         style="max-width: 100%;"
       >

--- a/public/pages/VisualCreatePolicy/utils/constants.ts
+++ b/public/pages/VisualCreatePolicy/utils/constants.ts
@@ -47,12 +47,7 @@ export const DEFAULT_POLICY = {
       transitions: [],
     },
   ],
-  ism_template: [
-    {
-      index_patterns: ["logs-*"],
-      priority: 5,
-    },
-  ],
+  ism_template: [],
 };
 
 export const DEFAULT_LEGACY_ERROR_NOTIFICATION = {

--- a/release-notes/opensearch-index-management-dashboards-plugin.release-notes-1.1.0.0.md
+++ b/release-notes/opensearch-index-management-dashboards-plugin.release-notes-1.1.0.0.md
@@ -35,6 +35,7 @@ Compatible with OpenSearchDashboards 1.1.0
 * Address data stream API security breaking issue ([#69](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/69))
 * Fix flaky ([#76](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/76))
 * UI fixes for new ISM UI ([#84](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/84))
+* Fixes some small UI touchups/issues for new ISM UI ([#85](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/85))
 
 ### Documentation
 * Adding support to correctly set the dashboards and opensearch endpoint ([#33](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/33))


### PR DESCRIPTION
### Description
* Moves edit button from the policy settings content panel to the page
* Updates transitions to not include a conditions object by default as the backend throws an error if you pass it an empty conditions object
* Makes all inputs in flyouts full width
* Updates retry help text
* Adds some extra spacing between inputs
* Adds back X icon next to Cancel in state flyout
* Fixes missing punctuation
* Removes default ISM template and increases width of empty prompt message
* Moves action/transition flyout secondary button (cancel) to be next to primary button

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
