### PR TITLE
Fixed Transforms geo_point bug and boolean render

### DIFF
--- a/public/pages/CreateTransform/components/DefineTransforms/DefineTransforms.tsx
+++ b/public/pages/CreateTransform/components/DefineTransforms/DefineTransforms.tsx
@@ -150,6 +150,11 @@ export default function DefineTransforms({
         return data[rowIndex]._source[correspondingTextColumnId] ? data[rowIndex]._source[correspondingTextColumnId] : "-";
       } else if (columns?.find((column) => column.id == columnId).schema == "date") {
         return data[rowIndex]._source[columnId] ? renderTime(data[rowIndex]._source[columnId]) : "-";
+      } else if (columns?.find((column) => column.id == columnId).schema == "geo_point") {
+        return data[rowIndex]._source[columnId].lat + ", " + data[rowIndex]._source[columnId].lon ?
+          data[rowIndex]._source[columnId].lat + ", " + data[rowIndex]._source[columnId].lon : "-";
+      } else if (columns?.find((column) => column.id == columnId).schema == "boolean") {
+        return data[rowIndex]._source[columnId] == null ? "-" : (data[rowIndex]._source[columnId] ? "true" : "false");
       }
       return data[rowIndex]._source[columnId] ? data[rowIndex]._source[columnId] : "-";
     }

--- a/public/pages/CreateTransform/components/DefineTransforms/DefineTransforms.tsx
+++ b/public/pages/CreateTransform/components/DefineTransforms/DefineTransforms.tsx
@@ -156,7 +156,7 @@ export default function DefineTransforms({
       } else if (columns?.find((column) => column.id == columnId).schema == "boolean") {
         return data[rowIndex]._source[columnId] == null ? "-" : (data[rowIndex]._source[columnId] ? "true" : "false");
       }
-      return JSON.stringify(data[rowIndex]._source[columnId]) ? JSON.stringify(data[rowIndex]._source[columnId]) : "-";
+      return data[rowIndex]._source[columnId] !== null ? JSON.stringify(data[rowIndex]._source[columnId]) : "-";
     }
     return "-";
   };

--- a/public/pages/CreateTransform/components/DefineTransforms/DefineTransforms.tsx
+++ b/public/pages/CreateTransform/components/DefineTransforms/DefineTransforms.tsx
@@ -156,7 +156,7 @@ export default function DefineTransforms({
       } else if (columns?.find((column) => column.id == columnId).schema == "boolean") {
         return data[rowIndex]._source[columnId] == null ? "-" : (data[rowIndex]._source[columnId] ? "true" : "false");
       }
-      return data[rowIndex]._source[columnId] ? data[rowIndex]._source[columnId] : "-";
+      return JSON.stringify(data[rowIndex]._source[columnId]) ? JSON.stringify(data[rowIndex]._source[columnId]) : "-";
     }
     return "-";
   };


### PR DESCRIPTION
Signed-off-by: Eric Lobdell <lobdelle@amazon.com>

### Description 
Fixes crash on rendering geo_point fields in Create Transform workflow
Also fixes issue rendering boolean fields, now properly shows true/false

### Issues Resolved
https://github.com/opensearch-project/index-management-dashboards-plugin/issues/91

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
