### PR TITLE
Changes the default policy of the visual editor to be an empty one

### DIFF
--- a/public/pages/VisualCreatePolicy/containers/VisualCreatePolicy/VisualCreatePolicy.tsx
+++ b/public/pages/VisualCreatePolicy/containers/VisualCreatePolicy/VisualCreatePolicy.tsx
@@ -13,7 +13,7 @@ import React, { ChangeEvent, Component } from "react";
 import { EuiText, EuiSpacer, EuiTitle, EuiFlexGroup, EuiFlexItem, EuiButton, EuiLink, EuiIcon } from "@elastic/eui";
 import { RouteComponentProps } from "react-router-dom";
 import queryString from "query-string";
-import { DEFAULT_POLICY } from "../../utils/constants";
+import { EMPTY_DEFAULT_POLICY } from "../../utils/constants";
 import { Policy, State } from "../../../../../models/interfaces";
 import { PolicyService } from "../../../../services";
 import { BREADCRUMBS, POLICY_DOCUMENTATION_URL, ROUTES } from "../../../../utils/constants";
@@ -52,7 +52,7 @@ export default class VisualCreatePolicy extends Component<VisualCreatePolicyProp
 
     this.state = {
       policyId: "",
-      policy: DEFAULT_POLICY,
+      policy: EMPTY_DEFAULT_POLICY,
       showFlyout: false,
       editingState: null,
 

--- a/public/pages/VisualCreatePolicy/utils/constants.ts
+++ b/public/pages/VisualCreatePolicy/utils/constants.ts
@@ -50,6 +50,13 @@ export const DEFAULT_POLICY = {
   ism_template: [],
 };
 
+export const EMPTY_DEFAULT_POLICY = {
+  description: "A sample description of the policy",
+  default_state: "",
+  states: [],
+  ism_template: [],
+};
+
 export const DEFAULT_LEGACY_ERROR_NOTIFICATION = {
   destination: {
     slack: {

--- a/release-notes/opensearch-index-management-dashboards-plugin.release-notes-1.1.0.0.md
+++ b/release-notes/opensearch-index-management-dashboards-plugin.release-notes-1.1.0.0.md
@@ -30,6 +30,7 @@ Compatible with OpenSearchDashboards 1.1.0
 * Register action hook ([#64](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/64))
 * Fixes policy details page ([#80](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/80))
 * Removes support for notification channels ([#81](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/81))
+* Changes the default policy of the visual editor to be an empty one ([#100](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/100))
 
 ### Bug Fixes
 * Address data stream API security breaking issue ([#69](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/69))


### PR DESCRIPTION
Signed-off-by: Drew Baugher <46505179+dbbaughe@users.noreply.github.com>

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
