### PR TITLE
Bumps version to 1.2

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -8,8 +8,8 @@ on:
       - main
       - development-*
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '1.1'
-  OPENSEARCH_VERSION: '1.1.0-SNAPSHOT'
+  OPENSEARCH_DASHBOARDS_VERSION: '1.2'
+  OPENSEARCH_VERSION: '1.2.0-SNAPSHOT'
 jobs:
   tests:
     name: Run Cypress E2E tests

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: opensearch-project/OpenSearch-Dashboards
-          ref: '1.0'
+          ref: 'main'
           path: OpenSearch-Dashboards
       - name: Get node and yarn versions
         id: versions

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "indexManagementDashboards",
-  "version": "1.1.0.0",
-  "opensearchDashboardsVersion": "1.1.0",
+  "version": "1.2.0.0",
+  "opensearchDashboardsVersion": "1.2.0",
   "configPath": ["opensearch_index_management"],
   "requiredPlugins": ["navigation"],
   "server": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch_index_management_dashboards",
-  "version": "1.1.0.0",
+  "version": "1.2.0.0",
   "description": "Opensearch Dashboards plugin for Index Management",
   "main": "index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
Signed-off-by: Clay Downs <downsrob@amazon.com>

### Description
Updates index management dashboards version to 1.2. Changes the package jsons, as well as the github test workflows.

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
