### PR TITLE
Fixes flakey rollup enable and disable Cypress test

### DIFF
--- a/cypress/integration/rollups_spec.js
+++ b/cypress/integration/rollups_spec.js
@@ -236,6 +236,9 @@ describe("Rollups", () => {
 
       cy.contains(`${ROLLUP_ID}`);
 
+      // Disable button is enabled
+      cy.get(`[data-test-subj="disableButton"]`).should("not.be.disabled");
+
       // Click Disable button
       cy.get(`[data-test-subj="disableButton"]`).trigger("click", { force: true });
 


### PR DESCRIPTION
Signed-off-by: Clay Downs <downsrob@amazon.com>

### Description
Fixes flakey rollup enable and disable Cypress test. The test was flakey as sometimes test latency would cause a button click to be missed. Added a check before the click to test that the button was enabled.

### Issues Resolved
https://github.com/opensearch-project/index-management-dashboards-plugin/issues/30

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
