### PR TITLE
Fixes flakey tests

### DIFF
--- a/cypress/integration/rollups_spec.js
+++ b/cypress/integration/rollups_spec.js
@@ -236,6 +236,9 @@ describe("Rollups", () => {
 
       cy.contains(`${ROLLUP_ID}`);
 
+      // Disable button is enabled
+      cy.get(`[data-test-subj="disableButton"]`).should("not.be.disabled");
+
       // Click Disable button
       cy.get(`[data-test-subj="disableButton"]`).trigger("click", { force: true });
 

--- a/public/pages/RollupDetails/containers/RollupDetails/RollupDetails.test.tsx
+++ b/public/pages/RollupDetails/containers/RollupDetails/RollupDetails.test.tsx
@@ -183,7 +183,9 @@ describe("<RollupDetails /> spec", () => {
     browserServicesMock.rollupService.deleteRollup = jest.fn().mockResolvedValue({ ok: true, response: true });
     const { getByTestId } = renderRollupDetailsWithRouter([`${ROUTES.ROLLUP_DETAILS}?id=${testRollup._id}`]);
 
-    await waitFor(() => {});
+    await waitFor(() => {
+      getByTestId("deleteButton");
+    });
 
     userEvent.click(getByTestId("deleteButton"));
 


### PR DESCRIPTION
Signed-off-by: Clay Downs <downsrob@amazon.com>

### Description
Fixes the flakey rollup enable and disable test. This test would sometimes fail because it would attempt to click the disable button before the rollup details were received. By waiting for the button to display as enabled, this should no longer fail.

Attempts to fix 'can delete a rollup job' unit test by waiting for a button to load before attempting to click it. The empty waitfor statement only waits for tick in the event loop, see [here](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-wait-for-empty-callback.md), and does not enforce that the button is available to click.

### Issues Resolved
https://github.com/opensearch-project/index-management-dashboards-plugin/issues/30

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
