### PR TITLE
Fix pagination of managed indices page

### DIFF
--- a/server/services/ManagedIndexService.ts
+++ b/server/services/ManagedIndexService.ts
@@ -110,7 +110,7 @@ export default class ManagedIndexService {
       const explainParams = {
         sortField: sortField ? managedIndexSorts[sortField] : null,
         sortOrder: sortDirection,
-        queryString: getSearchString(terms, indices, dataStreams),
+        queryString: getSearchString(terms, indices, dataStreams, showDataStreams),
         from: from,
         size: size
       };
@@ -155,11 +155,6 @@ export default class ManagedIndexService {
       }
 
       let totalManagedIndices = explainAllResponse.total_managed_indices;
-      // This can still lead to empty pages in pagination when there is a typed string in search bar - to fix that we
-      // need to calculate the number of data stream indices that match the pattern and remove from total_managed_indices
-      if (!showDataStreams && explainParams.queryString === "*") {
-        totalManagedIndices = explainAllResponse.total_managed_indices - Object.keys(indexToDataStreamMapping).length;
-      }
       return response.custom({
         statusCode: 200,
         body: {

--- a/server/utils/helpers.ts
+++ b/server/utils/helpers.ts
@@ -76,7 +76,7 @@ export function getMustQuery<T extends string>(field: T, search: string): MatchA
   return { match_all: {} };
 }
 
-export function getSearchString(terms?: string[], indices?: string[], dataStreams?: string[]): string {
+export function getSearchString(terms?: string[], indices?: string[], dataStreams?: string[], showDataStreams: boolean = true): string {
   // Terms are searched with a wildcard around them.
   const searchTerms = terms ? `*${_.castArray(terms).join("*,*")}*` : "";
 
@@ -86,5 +86,7 @@ export function getSearchString(terms?: string[], indices?: string[], dataStream
 
   // The overall search string is a combination of terms, indices, and data streams.
   // If the search string is blank, then '*' is used to match everything.
-  return [searchTerms, searchIndices, searchDataStreams].filter((value) => value !== "").join(",") || "*";
+  const resolved = [searchTerms, searchIndices, searchDataStreams].filter((value) => value !== "").join(",") || "*";
+  // We don't want to fetch managed datastream indices if there are not selected by caller.
+  return showDataStreams ? resolved : resolved + " -.ds"
 }


### PR DESCRIPTION
### Description
Managed indices page at the moment doesn't show more than 20 indices (the default page size). The issue is because we are not passing the page size and from query parameters when querying the backend. We are also not setting the correct total index count which is used for determining the number of pages to be shown on the UI



![Screen Shot 2021-10-22 at 2 52 40 PM](https://user-images.githubusercontent.com/6005951/138527038-7cc1ad27-bb8a-458f-8bb1-0bd96a810b5f.png)

![Screen Shot 2021-10-22 at 2 52 48 PM](https://user-images.githubusercontent.com/6005951/138527043-0cd87e2d-b6c0-4046-b997-53a6c5bd9ac8.png)

The new fix passes the from and size to the backend request
Populates the total index count correctly by removing the datastream managed indices from explain call API if toggle is not selected


![Screen Shot 2021-10-22 at 2 00 47 PM](https://user-images.githubusercontent.com/6005951/138526360-f10a7172-934e-48b7-9345-3f52acebc977.png)

![Screen Shot 2021-10-22 at 2 00 55 PM](https://user-images.githubusercontent.com/6005951/138526364-da8c80db-67fd-4ab8-8f47-0efd71a093b1.png)

![Screen Shot 2021-10-22 at 2 01 02 PM](https://user-images.githubusercontent.com/6005951/138526381-f1269335-8de3-423a-b7d9-f5ed2f484e0b.png)

![Screen Shot 2021-10-25 at 11 57 25 AM](https://user-images.githubusercontent.com/6005951/138755292-3f89c31c-9cb3-4e60-bddd-aab2b18e91b9.png)

![Screen Shot 2021-10-25 at 11 57 31 AM](https://user-images.githubusercontent.com/6005951/138755314-db952f0f-4238-47b2-8387-5219afd2927e.png)
### Issues Resolved
https://github.com/opensearch-project/index-management-dashboards-plugin/issues/112

### Check List
- [X ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
