### PR TITLE
Disables jitter for managed_indices_spec cypress tests

### DIFF
--- a/cypress/integration/managed_indices_spec.js
+++ b/cypress/integration/managed_indices_spec.js
@@ -36,6 +36,8 @@ describe("Managed indices", () => {
   beforeEach(() => {
     // Set welcome screen tracking to false
     localStorage.setItem("home:welcome:show", "false");
+    // Disable jitter so ISM jobs run without an additional delay
+    cy.disableJitter();
 
     cy.wait(3000);
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -161,3 +161,17 @@ Cypress.Commands.add("rollover", (target) => {
 Cypress.Commands.add("createTransform", (transformId, transformJSON) => {
   cy.request("PUT", `${Cypress.env("opensearch")}${API.TRANSFORM_JOBS_BASE}/${transformId}`, transformJSON);
 });
+
+Cypress.Commands.add("disableJitter", () => {
+  // Sets the jitter to 0 in the ISM plugin cluster settings
+  const jitterJson = {
+    persistent: {
+      plugins: {
+        index_state_management: {
+          jitter: "0.0",
+        },
+      },
+    },
+  };
+  cy.request("PUT", `${Cypress.env("opensearch")}/_cluster/settings`, jitterJson);
+});

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -51,7 +51,10 @@ declare namespace Cypress {
 
     /**
      * Updated the managed index config's start time to
-     * make it run in 3 seconds after calling this
+     * make it run in 3 seconds after calling this.
+     * Note: if you are calling this then you likely are forcing
+     * an ISM job to run. Make sure disableJitter is called sometime
+     * before this or else the delay may cause test flakiness.
      * @example
      * cy.updateManagedIndexConfigStartTime("some_index")
      */
@@ -105,5 +108,15 @@ declare namespace Cypress {
      * cy.createTransform("some_transform", { "transform": { ... } })
      */
     createTransform(transformId: string, transformJSON: object): Chainable<any>;
+
+    /**
+     * Disables jitter on a cluster. The jitter is used in
+     * index state management to add a randomized delay to the start
+     * time of jobs. This helps spread the resource load when there are
+     * many jobs scheduled for the same time, but can cause flakiness in tests.
+     * @example
+     * cy.disableJitter()
+     */
+    disableJitter(): Chainable<any>;
   }
 }


### PR DESCRIPTION
Signed-off-by: Robert Downs <downsrob@amazon.com>

### Description
After adding the jitter cluster setting to index state management in [this commit](https://github.com/opensearch-project/index-management/commit/ab122799283a58bb3f5c6f6d8576c7ba5875f13b), the ISM dashboards cypress test "managed_indices_spec.js/Managed indices -- can change policies" has been failing the majority of the time. The jitter caused the managed index execution to be delayed, which made the success check timeout.

This PR fixes this failure by disabling the jitter at the start of the cypress tests.

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
