### PR TITLE
Fixes retry failed managed index cypress test

### DIFF
--- a/cypress/fixtures/sample_rollover_policy.json
+++ b/cypress/fixtures/sample_rollover_policy.json
@@ -1,0 +1,35 @@
+{
+  "policy": {
+    "description": "A simple description",
+    "default_state": "hot",
+    "states": [
+      {
+        "name": "hot",
+        "actions": [
+          {
+            "rollover": {}
+          }
+        ],
+        "transitions": [
+          {
+            "state_name": "cold",
+            "conditions": {
+              "min_index_age": "30d"
+            }
+          }
+        ]
+      },
+      {
+        "name": "cold",
+        "actions": [
+          {
+            "replica_count": {
+              "number_of_replicas": 2
+            }
+          }
+        ],
+        "transitions": []
+      }
+    ]
+  }
+}

--- a/cypress/integration/managed_indices_spec.js
+++ b/cypress/integration/managed_indices_spec.js
@@ -26,11 +26,14 @@
 
 import { PLUGIN_NAME } from "../support/constants";
 import samplePolicy from "../fixtures/sample_policy";
+import sampleRolloverPolicy from "../fixtures/sample_rollover_policy";
 import sampleDataStreamPolicy from "../fixtures/sample_data_stream_policy.json";
 
 const POLICY_ID = "test_policy_id";
 const POLICY_ID_2 = "test_policy_id_2";
+const POLICY_ID_ROLLOVER = "test_policy_rollover";
 const SAMPLE_INDEX = "sample_index";
+const SAMPLE_INDEX_ROLLOVER = "sample_index-01";
 
 describe("Managed indices", () => {
   beforeEach(() => {
@@ -43,8 +46,9 @@ describe("Managed indices", () => {
     cy.visit(`${Cypress.env("opensearch_dashboards")}/app/${PLUGIN_NAME}#/managed-indices`);
 
     // Common text to wait for to confirm page loaded, give up to 60 seconds for initial load
-    // TODO flaky: page may not rendered right with below line
-    cy.contains("Rows per page", { timeout: 60000 });
+    cy.contains("Edit rollover alias", { timeout: 60000 });
+
+    cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
   });
 
   describe("can have policies removed", () => {
@@ -78,31 +82,46 @@ describe("Managed indices", () => {
     });
   });
 
-  describe.skip("can have policies retried", () => {
+  describe("can have policies retried", () => {
     before(() => {
       cy.deleteAllIndices();
-      // Add a non-existent policy to the index
-      cy.createIndex(SAMPLE_INDEX, POLICY_ID);
-      // Speed up execution time to happen in a few seconds
-      cy.updateManagedIndexConfigStartTime(SAMPLE_INDEX);
+      // Create a policy that rolls over
+      cy.createPolicy(POLICY_ID_ROLLOVER, sampleRolloverPolicy);
+      // Create index with alias to rollover
+      cy.createIndex(SAMPLE_INDEX_ROLLOVER, POLICY_ID_ROLLOVER, { aliases: { "retry-rollover-alias": {} } });
     });
 
     it("successfully", () => {
       // Confirm we have initial policy
-      cy.contains(POLICY_ID);
+      cy.contains(POLICY_ID_ROLLOVER);
+
+      // Speed up execution time to happen in a few seconds
+      cy.updateManagedIndexConfigStartTime(SAMPLE_INDEX_ROLLOVER);
 
       // Wait up to 5 seconds for the managed index to execute
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(5000).reload();
+      cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+
+      // Confirm managed index successfully initialized the policy
+      cy.contains("Successfully initialized", { timeout: 20000 });
+
+      cy.updateManagedIndexConfigStartTime(SAMPLE_INDEX_ROLLOVER);
+
+      // Wait up to 5 seconds for managed index to execute
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(5000).reload();
+      cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
 
       // Confirm we have a Failed execution, wait up to 20 seconds as OSD takes a while to load
       cy.contains("Failed", { timeout: 20000 });
+      cy.contains("Missing rollover_alias");
 
-      // Create the policy we were missing
-      cy.createPolicy(POLICY_ID, samplePolicy);
+      // Add rollover alias
+      cy.updateIndexSettings(SAMPLE_INDEX_ROLLOVER, { "plugins.index_state_management.rollover_alias": "retry-rollover-alias" });
 
       // Select checkbox for our managed index
-      cy.get(`[data-test-subj="checkboxSelectRow-${SAMPLE_INDEX}"]`).check({ force: true });
+      cy.get(`[data-test-subj="checkboxSelectRow-${SAMPLE_INDEX_ROLLOVER}"]`).check({ force: true });
 
       // Click the retry policy button
       cy.get(`[data-test-subj="Retry policyButton"]`).click({ force: true });
@@ -115,19 +134,21 @@ describe("Managed indices", () => {
 
       // Reload the page
       cy.reload();
+      cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
 
       // Confirm we see managed index attempting to retry, give 20 seconds for OSD load
       cy.contains("Pending retry of failed managed index", { timeout: 20000 });
 
       // Speed up next execution of managed index
-      cy.updateManagedIndexConfigStartTime(SAMPLE_INDEX);
+      cy.updateManagedIndexConfigStartTime(SAMPLE_INDEX_ROLLOVER);
 
       // Wait up to 5 seconds for managed index to execute
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(5000).reload();
+      cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
 
-      // Confirm managed index successfully initialized the policy
-      cy.contains("Successfully initialized", { timeout: 20000 });
+      // Confirm managed index successfully rolled over
+      cy.contains("Successfully rolled over", { timeout: 20000 });
     });
   });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -112,6 +112,10 @@ Cypress.Commands.add("getIndexSettings", (index) => {
   cy.request("GET", `${Cypress.env("opensearch")}/${index}/_settings`);
 });
 
+Cypress.Commands.add("updateIndexSettings", (index, settings) => {
+  cy.request("PUT", `${Cypress.env("opensearch")}/${index}/_settings`, settings);
+});
+
 Cypress.Commands.add("updateManagedIndexConfigStartTime", (index) => {
   // Creating closure over startTime so it's not calculated until actual update_by_query call
   // eslint-disable-next-line cypress/no-unnecessary-waiting

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -31,7 +31,7 @@ declare namespace Cypress {
     /**
      * Deletes all indices in cluster
      * @example
-     * cy.wipeCluster()
+     * cy.deleteAllIndices()
      */
     deleteAllIndices(): Chainable<any>;
 
@@ -48,6 +48,13 @@ declare namespace Cypress {
      * cy.getIndexSettings("some_index")
      */
     getIndexSettings(index: string): Chainable<any>;
+
+    /**
+     * Updates settings for index
+     * @example
+     * cy.updateIndexSettings("some_index", settings)
+     */
+    updateIndexSettings(index: string, settings: object): Chainable<any>;
 
     /**
      * Updated the managed index config's start time to


### PR DESCRIPTION
Signed-off-by: Drew Baugher <46505179+dbbaughe@users.noreply.github.com>

### Description
Fixes the retry managed index cypress test that broke as part of some backend changes from previous version. Now, we rely on lack of rollover_alias to have a job enter a failed state and then set the alias and retry it.

### Issues Resolved
https://github.com/opensearch-project/index-management-dashboards-plugin/issues/70

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
