### PR TITLE
Add refresh button to rollup page

### DIFF
--- a/public/pages/Rollups/containers/Rollups/Rollups.test.tsx
+++ b/public/pages/Rollups/containers/Rollups/Rollups.test.tsx
@@ -227,4 +227,14 @@ describe("<Rollups /> spec", () => {
     expect(coreServicesMock.notifications.toasts.addSuccess).toHaveBeenCalledTimes(1);
     expect(coreServicesMock.notifications.toasts.addSuccess).toHaveBeenCalledWith(`${testRollup._id} is disabled`);
   });
+
+  it("calls getRollups when clicking refresh button", async () => {
+    browserServicesMock.rollupService.getRollups = jest.fn();
+
+    const { getByTestId } = renderRollupsWithRouter();
+
+    userEvent.click(getByTestId("refreshButton"));
+
+    expect(browserServicesMock.rollupService.getRollups).toHaveBeenCalledTimes(1);
+  });
 });

--- a/public/pages/Rollups/containers/Rollups/Rollups.tsx
+++ b/public/pages/Rollups/containers/Rollups/Rollups.tsx
@@ -393,6 +393,11 @@ export default class Rollups extends Component<RollupsProps, RollupsState> {
           <EuiFlexItem grow={false}>
             <EuiFlexGroup alignItems="center" gutterSize="s">
               <EuiFlexItem grow={false}>
+                <EuiButton iconType="refresh" onClick={this.getRollups} data-test-subj="refreshButton">
+                  Refresh
+                </EuiButton>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
                 <EuiButton disabled={!selectedItems.length} onClick={this.onDisable} data-test-subj="disableButton">
                   Disable
                 </EuiButton>

--- a/public/pages/Rollups/containers/Rollups/__snapshots__/Rollups.test.tsx.snap
+++ b/public/pages/Rollups/containers/Rollups/__snapshots__/Rollups.test.tsx.snap
@@ -31,6 +31,26 @@ exports[`<Rollups /> spec renders the component 1`] = `
             class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <button
+              class="euiButton euiButton--primary"
+              data-test-subj="refreshButton"
+              type="button"
+            >
+              <span
+                class="euiButtonContent euiButton__content"
+              >
+                EuiIconMock
+                <span
+                  class="euiButton__text"
+                >
+                  Refresh
+                </span>
+              </span>
+            </button>
+          </div>
+          <div
+            class="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <button
               class="euiButton euiButton--primary euiButton-isDisabled"
               data-test-subj="disableButton"
               disabled=""

--- a/public/pages/Transforms/containers/Transforms/Transforms.test.tsx
+++ b/public/pages/Transforms/containers/Transforms/Transforms.test.tsx
@@ -233,4 +233,14 @@ describe("<Transforms /> spec", () => {
     expect(coreServicesMock.notifications.toasts.addSuccess).toHaveBeenCalledTimes(1);
     expect(coreServicesMock.notifications.toasts.addSuccess).toHaveBeenCalledWith(`\"${testTransform2._id}\" is disabled`);
   });
+
+  it("calls getTransforms when clicking refresh button", async () => {
+    browserServicesMock.transformService.getTransforms = jest.fn();
+
+    const { getByTestId } = renderTransformsWithRouter();
+
+    userEvent.click(getByTestId("refreshButton"));
+
+    expect(browserServicesMock.transformService.getTransforms).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Signed-off-by: Annie Lee <leeyun@amazon.com>

### Description
Adding a refresh button to rollup landing page

### Issues Resolved
N/A

### Screenshot
<img width="1790" alt="image" src="https://user-images.githubusercontent.com/71157062/141857903-40e7d2fb-a91d-4dab-84dc-d919750bef2d.png">

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
