### PR TITLE
Fixes default state not updating when changing state name

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -9,7 +9,7 @@ on:
       - development-*
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '1.x'
-  OPENSEARCH_VERSION: '1.2.0-SNAPSHOT'
+  OPENSEARCH_VERSION: '1.3.0-SNAPSHOT'
 jobs:
   tests:
     name: Run Cypress E2E tests

--- a/cypress/fixtures/sample_rollover_policy.json
+++ b/cypress/fixtures/sample_rollover_policy.json
@@ -7,7 +7,10 @@
         "name": "hot",
         "actions": [
           {
-            "rollover": {}
+            "rollover": {},
+            "retry": {
+              "count": 0
+            }
           }
         ],
         "transitions": [

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "indexManagementDashboards",
-  "version": "1.2.0.0",
-  "opensearchDashboardsVersion": "1.2.0",
+  "version": "1.3.0.0",
+  "opensearchDashboardsVersion": "1.3.0",
   "configPath": ["opensearch_index_management"],
   "requiredPlugins": ["navigation"],
   "server": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch_index_management_dashboards",
-  "version": "1.2.0.0",
+  "version": "1.3.0.0",
   "description": "Opensearch Dashboards plugin for Index Management",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
@@ -34,7 +34,7 @@ import { actionRepoSingleton, getOrderInfo } from "../../utils/helpers";
 
 interface CreateStateProps {
   policy: Policy;
-  onSaveState: (state: State, editingState: State | null, states: State[], order: string, afterBeforeState: string) => void;
+  onSaveState: (state: State, states: State[], order: string, afterBeforeState: string) => void;
   onCloseFlyout: () => void;
   state: State | null;
 }
@@ -176,14 +176,13 @@ export default class CreateState extends Component<CreateStateProps, CreateState
 
   onClickSaveState = () => {
     const { order, afterBeforeState } = this.state;
-    const { onSaveState, state, policy } = this.props;
+    const { onSaveState, policy } = this.props;
     onSaveState(
       {
         name: this.state.name,
         actions: this.state.actions.map((action) => action.toAction()),
         transitions: this.state.transitions.map((transition) => transition.transition),
       },
-      state,
       policy.states,
       order,
       afterBeforeState

--- a/public/pages/VisualCreatePolicy/utils/helpers.test.ts
+++ b/public/pages/VisualCreatePolicy/utils/helpers.test.ts
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { actionRepoSingleton, capitalizeFirstLetter, convertTemplatesToArray, getOrderInfo } from "./helpers";
+import { actionRepoSingleton, capitalizeFirstLetter, convertTemplatesToArray, getOrderInfo, getUpdatedPolicy } from "./helpers";
 import { Action, ISMTemplate, UIAction } from "../../../../models/interfaces";
 import { makeId } from "../../../utils/helpers";
+import { DEFAULT_POLICY } from "./constants";
 
 test("converts all ism template formats into a list of ism templates", () => {
   expect(convertTemplatesToArray(null)).toEqual([]);
@@ -79,4 +80,11 @@ test("action repository usage", () => {
   expect(actionRepoSingleton.getAllActionTypes().length).toBe(14);
   expect(actionRepoSingleton.getUIAction("dummy") instanceof DummyUIAction).toBe(true);
   expect(actionRepoSingleton.getUIActionFromData(DEFAULT_DUMMY) instanceof DummyUIAction).toBe(true);
+});
+
+test("changing the default state name correctly updates default_state", () => {
+  const policy = DEFAULT_POLICY;
+  const updatedState = { ...policy.states[0], name: "new_hot" };
+  const newPolicy = getUpdatedPolicy(policy, updatedState, policy.states[0], policy.states, "before", policy.states[1].name);
+  expect(newPolicy.default_state).toBe("new_hot");
 });

--- a/public/pages/VisualCreatePolicy/utils/helpers.ts
+++ b/public/pages/VisualCreatePolicy/utils/helpers.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { UIAction, Action, Transition, ISMTemplate, State } from "../../../../models/interfaces";
+import { UIAction, Action, Transition, ISMTemplate, State, Policy } from "../../../../models/interfaces";
 import {
   ActionType,
   DEFAULT_ALLOCATION,
@@ -211,4 +211,31 @@ export const getUpdatedStates = (
   });
 
   return someStates;
+};
+
+export const getUpdatedPolicy = (
+  currentPolicy: Policy,
+  updatedState: State,
+  editingState: State | null,
+  currentStates: State[],
+  order: string,
+  afterBeforeState: string
+): Policy => {
+  const updatedStates = getUpdatedStates(updatedState, editingState, currentStates, order, afterBeforeState);
+  let defaultState = currentPolicy.default_state;
+  // If there is 1 state, change it to this state
+  if (updatedStates.length === 1) {
+    defaultState = updatedStates[0].name;
+  }
+  // Change the default state if the state being edited was the default state
+  if (editingState && editingState.name === defaultState) {
+    // don't bother checking if the name itself changed, just set it regardless to the value from the new state
+    defaultState = updatedState.name;
+  }
+
+  return {
+    ...currentPolicy,
+    states: updatedStates,
+    default_state: defaultState,
+  };
 };


### PR DESCRIPTION
### Description
Changing the state name of the default state wasn't also changing the policy.default_state value (unless it was the one and only state).

This fixes it so that if we have made changes to the state that is currently the default state then we update the default state to the value of the state name.

Also fixes some react state being set after the visual editor page has unmounted.

### Issues Resolved
https://github.com/opensearch-project/index-management-dashboards-plugin/issues/139

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
