### PR TITLE
Adds support for creating and displaying the transform continuous mode

### DIFF
--- a/cypress/integration/transforms_spec.js
+++ b/cypress/integration/transforms_spec.js
@@ -241,4 +241,87 @@ describe("Transforms", () => {
       cy.contains(`"${TRANSFORM_ID}" is enabled`);
     });
   });
+
+  describe("can be created in continuous mode", () => {
+    it("successfully", () => {
+      // Confirm we loaded empty state
+      cy.contains("Transform jobs help you create a materialized view on top of existing data.");
+
+      // Route to create transform page
+      cy.contains("Create transform").click({ force: true });
+
+      // Type in transform ID
+      cy.get(`input[placeholder="my-transformjob1"]`).type(TRANSFORM_ID, { force: true });
+
+      // Get description input box
+      cy.get(`textarea[data-test-subj="description"]`).focus().type("some description");
+
+      // Enter source index
+      cy.get(`div[data-test-subj="sourceIndexCombobox"]`)
+        .find(`input[data-test-subj="comboBoxSearchInput"]`)
+        .focus()
+        .type("opensearch_dashboards_sample_data_ecommerce{enter}");
+
+      // Enter target index
+      cy.get(`div[data-test-subj="targetIndexCombobox"]`)
+        .find(`input[data-test-subj="comboBoxSearchInput"]`)
+        .focus()
+        .type("test_transform{enter}");
+
+      // Click the next button
+      cy.get("button").contains("Next").click({ force: true });
+
+      // Confirm that we got to step 2 of creation page
+      cy.contains("Select fields to transform");
+
+      cy.get(`button[data-test-subj="category.keywordOptionsPopover"]`).click({ force: true });
+
+      cy.contains("Group by terms").click({ force: true });
+
+      // Confirm group was added
+      cy.contains("category.keyword_terms");
+
+      // Add aggregable field
+      cy.contains("50 columns hidden").click({ force: true });
+      cy.contains("taxless_total_price").click({ force: true });
+      // Click out of the window
+      cy.contains("Select fields to transform").click({ force: true });
+
+      cy.get(`button[data-test-subj="taxless_total_priceOptionsPopover"]`).click({ force: true });
+
+      cy.contains("Aggregate by avg").click({ force: true });
+
+      // Confirm agg was added
+      cy.contains("avg_taxless_total_price");
+
+      // Click the next button
+      cy.get("button").contains("Next").click({ force: true });
+
+      // Confirm that we got to step 3 of creation page
+      cy.contains("Job enabled by default");
+
+      // Make the transform continuous
+      cy.get("[id=yes]").click({ force: true });
+
+      // Click the next button
+      cy.get("button").contains("Next").click({ force: true });
+
+      // Confirm that we got to step 4 of creation page
+      cy.contains("Review and create");
+
+      // Confirm that the transform is continuous
+      cy.contains("Continuous, every");
+
+      // Click the create button
+      cy.get("button").contains("Create").click({ force: true });
+
+      // Verify that sample data is add by checking toast notification
+      cy.contains(`Transform job "${TRANSFORM_ID}" successfully created.`);
+      cy.location("hash").should("contain", "transforms");
+      cy.get(`button[data-test-subj="transformLink_${TRANSFORM_ID}"]`);
+
+      // The continuous column should say 'Yes'
+      cy.contains("Yes");
+    });
+  });
 });

--- a/public/pages/CreateTransform/components/ReviewSchedule/ReviewSchedule.tsx
+++ b/public/pages/CreateTransform/components/ReviewSchedule/ReviewSchedule.tsx
@@ -7,9 +7,11 @@ import React, { Component } from "react";
 import { EuiFlexGrid, EuiFlexItem, EuiText } from "@elastic/eui";
 import { ContentPanel, ContentPanelActions } from "../../../../components/ContentPanel";
 import { ModalConsumer } from "../../../../components/Modal";
+import { buildIntervalScheduleText } from "../../../CreateRollup/utils/helpers";
 
 interface ReviewScheduleProps {
   jobEnabledByDefault: boolean;
+  continuousJob: string;
   interval: number;
   intervalTimeunit: string;
   pageSize: number;
@@ -22,11 +24,11 @@ export default class ReviewSchedule extends Component<ReviewScheduleProps> {
   }
 
   render() {
-    const { jobEnabledByDefault, interval, intervalTimeunit, pageSize, onChangeStep } = this.props;
+    const { jobEnabledByDefault, continuousJob, interval, intervalTimeunit, pageSize, onChangeStep } = this.props;
 
     const enabled = jobEnabledByDefault ? "Yes" : "No";
 
-    const schedule = "Every " + interval + " " + intervalTimeunit.toLowerCase();
+    const schedule = buildIntervalScheduleText(continuousJob === "yes", interval, intervalTimeunit);
 
     return (
       <ContentPanel

--- a/public/pages/CreateTransform/components/Schedule/Schedule.tsx
+++ b/public/pages/CreateTransform/components/Schedule/Schedule.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, Component } from "react";
-import { EuiSpacer, EuiCheckbox, EuiFormRow, EuiFieldNumber, EuiAccordion, EuiHorizontalRule } from "@elastic/eui";
+import { EuiSpacer, EuiCheckbox, EuiRadioGroup, EuiFormRow, EuiFieldNumber, EuiAccordion, EuiHorizontalRule } from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
 import { selectInterval } from "../../../Transforms/utils/metadataHelper";
 
@@ -13,15 +13,37 @@ interface ScheduleProps {
   transformId: string;
   transformIdError: string;
   jobEnabledByDefault: boolean;
+  continuousJob: string;
   pageSize: number;
   onChangeJobEnabledByDefault: () => void;
   interval: number;
   intervalTimeunit: string;
   intervalError: string;
+  onChangeContinuousJob: (optionId: string) => void;
   onChangeIntervalTime: (e: ChangeEvent<HTMLInputElement>) => void;
   onChangeIntervalTimeunit: (e: ChangeEvent<HTMLSelectElement>) => void;
   onChangePage: (e: ChangeEvent<HTMLInputElement>) => void;
 }
+
+const radios = [
+  {
+    id: "no",
+    label: "No",
+  },
+  {
+    id: "yes",
+    label: "Yes",
+  },
+];
+
+const isContinuous = (continuousJob: string, onChangeContinuousJob: (optionId: string) => void) => (
+  <React.Fragment>
+    <EuiFormRow label="Continuous">
+      <EuiRadioGroup options={radios} idSelected={continuousJob} onChange={(id) => onChangeContinuousJob(id)} name="continuousJob" />
+    </EuiFormRow>
+    <EuiSpacer size="m" />
+  </React.Fragment>
+);
 
 export default class Schedule extends Component<ScheduleProps> {
   constructor(props: ScheduleProps) {
@@ -32,11 +54,13 @@ export default class Schedule extends Component<ScheduleProps> {
     const {
       isEdit,
       jobEnabledByDefault,
+      continuousJob,
       interval,
       intervalTimeunit,
       intervalError,
       pageSize,
       onChangeJobEnabledByDefault,
+      onChangeContinuousJob,
       onChangeIntervalTime,
       onChangeIntervalTimeunit,
       onChangePage,
@@ -55,7 +79,7 @@ export default class Schedule extends Component<ScheduleProps> {
           )}
           <EuiSpacer size="m" />
 
-          {!isEdit}
+          {!isEdit && isContinuous(continuousJob, onChangeContinuousJob)}
 
           {/* TODO: Replace with switch block when define by cron expressions is supported. */}
           {selectInterval(interval, intervalTimeunit, intervalError, onChangeIntervalTime, onChangeIntervalTimeunit)}

--- a/public/pages/CreateTransform/containers/CreateTransformForm/CreateTransformForm.tsx
+++ b/public/pages/CreateTransform/containers/CreateTransformForm/CreateTransformForm.tsx
@@ -68,6 +68,7 @@ interface CreateTransformFormState {
   selectedFields: FieldItem[];
   jobEnabledByDefault: boolean;
 
+  continuousJob: string;
   interval: number;
   intervalError: string;
   intervalTimeunit: string;
@@ -118,6 +119,7 @@ export default class CreateTransformForm extends Component<CreateTransformFormPr
       intervalError: "",
 
       jobEnabledByDefault: true,
+      continuousJob: "no",
       interval: 1,
       intervalTimeunit: "MINUTES",
       pageSize: 1000,
@@ -394,6 +396,12 @@ export default class CreateTransformForm extends Component<CreateTransformFormPr
     this.setState({ jobEnabledByDefault: !checked, transformJSON: newJSON });
   };
 
+  onChangeContinuousJob = (optionId: string): void => {
+    let newJSON = this.state.transformJSON;
+    newJSON.transform.continuous = optionId == "yes";
+    this.setState({ continuousJob: optionId, transformJSON: newJSON });
+  };
+
   onChangeIntervalTime = (e: ChangeEvent<HTMLInputElement>): void => {
     this.setState({ interval: e.target.valueAsNumber });
     if (e.target.value == "") {
@@ -526,6 +534,7 @@ export default class CreateTransformForm extends Component<CreateTransformFormPr
       selectedAggregations,
       aggList,
       jobEnabledByDefault,
+      continuousJob,
       interval,
       intervalTimeunit,
       intervalError,
@@ -580,11 +589,13 @@ export default class CreateTransformForm extends Component<CreateTransformFormPr
           {...this.props}
           currentStep={this.state.currentStep}
           jobEnabledByDefault={jobEnabledByDefault}
+          continuousJob={continuousJob}
           interval={interval}
           intervalTimeunit={intervalTimeunit}
           intervalError={intervalError}
           pageSize={pageSize}
           onChangeJobEnabledByDefault={this.onChangeJobEnabledByDefault}
+          onChangeContinuousJob={this.onChangeContinuousJob}
           onChangeIntervalTime={this.onChangeIntervalTime}
           onChangePage={this.onChangePage}
           onChangeIntervalTimeunit={this.onChangeIntervalTimeunit}
@@ -605,6 +616,7 @@ export default class CreateTransformForm extends Component<CreateTransformFormPr
           onRemoveTransformation={this.onRemoveTransformation}
           previewTransform={previewTransform}
           jobEnabledByDefault={jobEnabledByDefault}
+          continuousJob={continuousJob}
           interval={interval}
           intervalTimeunit={intervalTimeunit}
           pageSize={pageSize}

--- a/public/pages/CreateTransform/containers/ReviewAndCreateStep/ReviewAndCreateStep.tsx
+++ b/public/pages/CreateTransform/containers/ReviewAndCreateStep/ReviewAndCreateStep.tsx
@@ -27,6 +27,7 @@ interface ReviewAndCreateStepProps extends RouteComponentProps {
   sourceIndexFilter: string;
 
   jobEnabledByDefault: boolean;
+  continuousJob: string;
   pageSize: number;
   fields: FieldItem[];
   selectedGroupField: TransformGroupItem[];

--- a/public/pages/CreateTransform/containers/SpecifyScheduleStep/SpecifyScheduleStep.tsx
+++ b/public/pages/CreateTransform/containers/SpecifyScheduleStep/SpecifyScheduleStep.tsx
@@ -19,11 +19,13 @@ interface SpecifyScheduleStepProps extends RouteComponentProps {
   transformService: TransformService;
   currentStep: number;
   jobEnabledByDefault: boolean;
+  continuousJob: string;
   interval: number;
   intervalTimeunit: string;
   intervalError: string;
   pageSize: number;
   onChangeJobEnabledByDefault: () => void;
+  onChangeContinuousJob: (optionId: string) => void;
   onChangeIntervalTime: (e: ChangeEvent<HTMLInputElement>) => void;
   onChangePage: (e: ChangeEvent<HTMLInputElement>) => void;
   onChangeIntervalTimeunit: (e: ChangeEvent<HTMLSelectElement>) => void;
@@ -109,10 +111,12 @@ export default class SpecifyScheduleStep extends Component<SpecifyScheduleStepPr
     if (this.props.currentStep != 3) return null;
     const {
       jobEnabledByDefault,
+      continuousJob,
       interval,
       intervalTimeunit,
       pageSize,
       onChangeJobEnabledByDefault,
+      onChangeContinuousJob,
       onChangeIntervalTime,
       onChangePage,
       onChangeIntervalTimeunit,
@@ -135,10 +139,12 @@ export default class SpecifyScheduleStep extends Component<SpecifyScheduleStepPr
               transformId={transformId}
               transformIdError={transformIdError}
               jobEnabledByDefault={jobEnabledByDefault}
+              continuousJob={continuousJob}
               interval={interval}
               intervalTimeunit={intervalTimeunit}
               pageSize={pageSize}
               onChangeJobEnabledByDefault={onChangeJobEnabledByDefault}
+              onChangeContinuousJob={onChangeContinuousJob}
               onChangeIntervalTime={onChangeIntervalTime}
               onChangeIntervalTimeunit={onChangeIntervalTimeunit}
               onChangePage={onChangePage}

--- a/public/pages/Transforms/containers/Transforms/TransformDetails.tsx
+++ b/public/pages/Transforms/containers/Transforms/TransformDetails.tsx
@@ -35,6 +35,7 @@ import TransformStatus from "../../components/TransformStatus";
 import { EMPTY_TRANSFORM } from "../../utils/constants";
 import TransformSettings from "./TransformSettings";
 import GeneralInformation from "../../components/GeneralInformation";
+import { buildIntervalScheduleText } from "../../../CreateRollup/utils/helpers";
 
 interface TransformDetailsProps extends RouteComponentProps {
   transformService: TransformService;
@@ -48,6 +49,7 @@ interface TransformDetailsState {
   updatedAt: number;
   pageSize: number;
   transformJson: any;
+  continuousJob: string;
   sourceIndex: string;
   targetIndex: string;
   sourceIndexFilter: string;
@@ -75,6 +77,7 @@ export default class TransformDetails extends Component<TransformDetailsProps, T
       updatedAt: 1,
       pageSize: 1000,
       transformJson: EMPTY_TRANSFORM,
+      continuousJob: "no",
       sourceIndex: "",
       targetIndex: "",
       sourceIndexFilter: "",
@@ -214,7 +217,10 @@ export default class TransformDetails extends Component<TransformDetailsProps, T
       isPopOverOpen,
     } = this.state;
 
-    let scheduleText = "Every " + interval + " " + intervalTimeUnit.toLowerCase();
+    let scheduleText = "";
+    if (transformJson.transform != null) {
+      scheduleText = buildIntervalScheduleText(transformJson.transform.continuous, interval, intervalTimeUnit);
+    }
     const actionButton = (
       <EuiButton iconType="arrowDown" iconSide="right" disabled={false} onClick={this.onActionButtonClick} data-test-subj="actionButton">
         Actions

--- a/public/pages/Transforms/containers/Transforms/Transforms.tsx
+++ b/public/pages/Transforms/containers/Transforms/Transforms.tsx
@@ -43,6 +43,7 @@ import { renderEnabled, renderStatus } from "../../utils/metadataHelper";
 import { DEFAULT_PAGE_SIZE_OPTIONS, DEFAULT_QUERY_PARAMS } from "../../../Indices/utils/constants";
 import _ from "lodash";
 import { ManagedCatIndex } from "../../../../../server/models/interfaces";
+import { renderContinuous } from "../../../Rollups/utils/helpers";
 
 interface TransformProps extends RouteComponentProps {
   transformService: TransformService;
@@ -160,6 +161,14 @@ export default class Transforms extends Component<TransformProps, TransformState
         textOnly: true,
         truncateText: true,
         render: renderEnabled,
+      },
+      {
+        field: "transform.continuous",
+        name: "Continuous",
+        sortable: true,
+        textOnly: true,
+        truncateText: true,
+        render: renderContinuous,
       },
       {
         field: "transform.updated_at",

--- a/public/pages/Transforms/containers/Transforms/__snapshots__/Transforms.test.tsx.snap
+++ b/public/pages/Transforms/containers/Transforms/__snapshots__/Transforms.test.tsx.snap
@@ -404,7 +404,37 @@ exports[`<Transforms /> spec renders the component 1`] = `
                   aria-live="polite"
                   aria-sort="none"
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_transform.updated_at_4"
+                  data-test-subj="tableHeaderCell_transform.continuous_4"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <button
+                    class="euiTableHeaderButton"
+                    data-test-subj="tableHeaderSortButton"
+                    type="button"
+                  >
+                    <span
+                      class="euiTableCellContent"
+                    >
+                      <span
+                        class="euiTableCellContent__text"
+                        title="Continuous"
+                      >
+                        Continuous
+                      </span>
+                      <span
+                        class="euiScreenReaderOnly"
+                      >
+                        Click to sort in ascending order
+                      </span>
+                    </span>
+                  </button>
+                </th>
+                <th
+                  aria-live="polite"
+                  aria-sort="none"
+                  class="euiTableHeaderCell"
+                  data-test-subj="tableHeaderCell_transform.updated_at_5"
                   role="columnheader"
                   scope="col"
                 >
@@ -432,7 +462,7 @@ exports[`<Transforms /> spec renders the component 1`] = `
                 </th>
                 <th
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_metadata_5"
+                  data-test-subj="tableHeaderCell_metadata_6"
                   role="columnheader"
                   scope="col"
                 >
@@ -455,7 +485,7 @@ exports[`<Transforms /> spec renders the component 1`] = `
               >
                 <td
                   class="euiTableRowCell euiTableRowCell--isMobileFullWidth"
-                  colspan="7"
+                  colspan="8"
                 >
                   <div
                     class="euiTableCellContent euiTableCellContent--alignCenter"

--- a/public/pages/Transforms/utils/metadataHelper.tsx
+++ b/public/pages/Transforms/utils/metadataHelper.tsx
@@ -43,9 +43,13 @@ export const renderStatus = (metadata: TransformMetadata | undefined): JSX.Eleme
       iconColor = "success";
       text = "Complete";
       break;
-    case "init" || "started":
+    case "init":
       iconColor = "subdued";
       text = "Initializing...";
+      break;
+    case "started":
+      iconColor = "success";
+      text = "Started";
       break;
     case "stopped":
       iconColor = "#DDDDDD";

--- a/release-notes/opensearch-index-management-dashboards-plugin.release-notes-1.3.0.0.md
+++ b/release-notes/opensearch-index-management-dashboards-plugin.release-notes-1.3.0.0.md
@@ -4,6 +4,7 @@ Compatible with OpenSearchDashboards 1.3.0
 
 ### Enhancement
 * Add refresh button to rollup page ([#132](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/132))
+* Adds support for creating and displaying the transform continuous mode ([#153](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/153))
 
 ### Bug fixes
 


### PR DESCRIPTION
Signed-off-by: Robert Downs <downsrob@amazon.com>

### Description
This change adds support for the continuous mode for transforms in the front end, following the backend introduction in this PR https://github.com/opensearch-project/index-management/pull/206
The changes consist of:
- Adding a radio button to set the continuous mode for transforms
![ContinuousRadio](https://user-images.githubusercontent.com/89109232/156043841-6c4f583e-7a3b-40e2-992c-fb2251a6c1f8.png)

- Displays the continuous mode when confirming the transform details before issuing the final create
![ContinuousConfirm](https://user-images.githubusercontent.com/89109232/156044484-5242336b-c793-4685-9e3d-a4604647be71.png)

- Displays the continuous mode of transforms in the transform details page
![TransformDetails](https://user-images.githubusercontent.com/89109232/156044878-0cf50826-0b56-435c-8506-74db61f4c2f3.png)

- Displays the continuous mode of transforms in the transforms job page
![TransformsJobPage](https://user-images.githubusercontent.com/89109232/156044659-7c35f026-2b5c-4b27-bab3-1144b6d6d13a.png)

- Separates init and started status for transforms. Previously transforms would show as initializing until they finished, now they show as started when running in continuous mode.

### Issues Resolved
https://github.com/opensearch-project/index-management/issues/152

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
