### PR TITLE
Adds support on UI for min primary shard size rollover condition and min rollover age transition condition

### DIFF
--- a/models/interfaces.ts
+++ b/models/interfaces.ts
@@ -190,6 +190,7 @@ export interface Condition {
   min_index_age?: string;
   min_doc_count?: number | undefined;
   min_size?: string;
+  min_rollover_age?: string;
   cron?: Cron;
 }
 

--- a/models/interfaces.ts
+++ b/models/interfaces.ts
@@ -172,6 +172,7 @@ export interface RolloverAction extends Action {
     min_size?: string;
     min_doc_count?: number;
     min_index_age?: string;
+    min_primary_shard_size?: string;
   };
 }
 

--- a/public/pages/VisualCreatePolicy/components/Transition/Transition.tsx
+++ b/public/pages/VisualCreatePolicy/components/Transition/Transition.tsx
@@ -17,6 +17,7 @@ const conditionTypeOptions = [
   { value: "min_index_age", text: "Minimum index age" },
   { value: "min_doc_count", text: "Minimum doc count" },
   { value: "min_size", text: "Minimum size" },
+  { value: "min_rollover_age", text: "Minimum rollover age" },
   { value: "cron", text: "Cron expression" },
 ];
 
@@ -46,6 +47,7 @@ const Transition = ({ uiTransition, onChangeTransition }: TransitionProps) => {
             if (selectedConditionType === "min_index_age") transition.conditions = { min_index_age: "30d" };
             if (selectedConditionType === "min_doc_count") transition.conditions = { min_doc_count: 1000000 };
             if (selectedConditionType === "min_size") transition.conditions = { min_size: "50gb" };
+            if (selectedConditionType === "min_rollover_age") transition.conditions = { min_rollover_age: "7d" };
             if (selectedConditionType === "cron")
               transition.conditions = { cron: { cron: { expression: "* 17 * * SAT", timezone: "America/Los_Angeles" } } };
             onChangeTransition({
@@ -137,6 +139,34 @@ const Transition = ({ uiTransition, onChangeTransition }: TransitionProps) => {
                 });
               }}
               data-test-subj="transition-render-conditions-min-size"
+            />
+          </EuiFormRow>
+        </>
+      )}
+
+      {conditionType === "min_rollover_age" && (
+        <>
+          <EuiFormCustomLabel
+            title="Minimum rollover age"
+            helpText="The minimum age after a rollover has occurred that is required to transition to the next state."
+          />
+          <EuiFormRow fullWidth isInvalid={false} error={null}>
+            <EuiFieldText
+              fullWidth
+              value={conditions?.min_rollover_age}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                const minRolloverAge = e.target.value;
+                onChangeTransition({
+                  ...uiTransition,
+                  transition: {
+                    ...uiTransition.transition,
+                    conditions: {
+                      min_rollover_age: minRolloverAge,
+                    },
+                  },
+                });
+              }}
+              data-test-subj="transition-render-conditions-min-rollover-age"
             />
           </EuiFormRow>
         </>

--- a/public/pages/VisualCreatePolicy/components/UIActions/RolloverUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/RolloverUIAction.tsx
@@ -100,6 +100,26 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
             data-test-subj="action-render-rollover-min-size"
           />
         </EuiFormRow>
+        <EuiSpacer size="s" />
+        <EuiFormCustomLabel
+          title="Minimum primary shard size"
+          helpText={`The minimum size of a single primary shard required to roll over the index. Accepts byte units, e.g. "500mb" or "50gb".`}
+          isInvalid={!this.isValid()}
+        />
+        <EuiFormRow fullWidth isInvalid={false} error={null}>
+          <EuiFieldText
+            fullWidth
+            value={rollover.min_primary_shard_size || ""}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              const minPrimaryShardSize = e.target.value;
+              const rollover = { ...action.action.rollover };
+              if (minPrimaryShardSize) rollover.min_primary_shard_size = minPrimaryShardSize;
+              else delete rollover.min_primary_shard_size;
+              onChangeAction(this.clone({ rollover }));
+            }}
+            data-test-subj="action-render-rollover-min-primary-shard-size"
+          />
+        </EuiFormRow>
       </>
     );
   };

--- a/public/pages/VisualCreatePolicy/components/UIActions/RolloverUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/RolloverUIAction.tsx
@@ -28,13 +28,14 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
     const minIndexAge = this.action.rollover.min_index_age;
     const minDocCount = this.action.rollover.min_doc_count;
     const minSize = this.action.rollover.min_size;
+    const minPrimaryShardSize = this.action.rollover.min_primary_shard_size;
     if (typeof minDocCount !== "undefined") {
       if (minDocCount <= 0) return false;
     }
 
-    // for minIndexAge and minSize just let them through and backend will fail the validation
+    // for minIndexAge and minSize and minPrimaryShardSize just let them through and backend will fail the validation
     // TODO -> add validation for index age and size.. but involves replicating checks for byte strings and time strings
-    return !!minIndexAge || minDocCount === 0 || !!minDocCount || !!minSize;
+    return true;
   };
 
   render = (action: UIAction<RolloverAction>, onChangeAction: (action: UIAction<RolloverAction>) => void) => {

--- a/public/pages/VisualCreatePolicy/containers/CreateAction/__snapshots__/CreateAction.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateAction/__snapshots__/CreateAction.test.tsx.snap
@@ -303,6 +303,53 @@ exports[`<CreateAction /> spec renders the component 1`] = `
         </div>
       </div>
       <div
+        class="euiSpacer euiSpacer--s"
+      />
+      <div
+        class="euiText euiText--medium"
+        style="margin-bottom: 5px;"
+      >
+        <h5
+          class="euiFormLabel "
+          style="margin-bottom: 2px;"
+        >
+          Minimum primary shard size
+        </h5>
+        <p>
+           
+          <span
+            style="font-weight: 200; font-size: 12px;"
+          >
+            The minimum size of a single primary shard required to roll over the index. Accepts byte units, e.g. "500mb" or "50gb".
+             
+          </span>
+        </p>
+      </div>
+      <div
+        class="euiFormRow euiFormRow--fullWidth"
+        id="some_html_id-row"
+      >
+        <div
+          class="euiFormRow__fieldWrapper"
+        >
+          <div
+            class="euiFormControlLayout euiFormControlLayout--fullWidth"
+          >
+            <div
+              class="euiFormControlLayout__childrenWrapper"
+            >
+              <input
+                class="euiFieldText euiFieldText--fullWidth"
+                data-test-subj="action-render-rollover-min-primary-shard-size"
+                id="some_html_id"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
         class="euiSpacer euiSpacer--l"
       />
       <div

--- a/public/pages/VisualCreatePolicy/containers/CreateTransition/__snapshots__/CreateTransition.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateTransition/__snapshots__/CreateTransition.test.tsx.snap
@@ -180,6 +180,11 @@ exports[`<CreateTransition /> spec renders the component 1`] = `
                   Minimum size
                 </option>
                 <option
+                  value="min_rollover_age"
+                >
+                  Minimum rollover age
+                </option>
+                <option
                   value="cron"
                 >
                   Cron expression

--- a/public/pages/VisualCreatePolicy/utils/constants.ts
+++ b/public/pages/VisualCreatePolicy/utils/constants.ts
@@ -115,9 +115,7 @@ export const DEFAULT_REPLICA_COUNT = {
 };
 export const DEFAULT_ROLLOVER = {
   rollover: {
-    min_size: "",
     min_doc_count: 5,
-    min_index_age: "",
   },
 };
 export const DEFAULT_ROLLUP = {

--- a/public/pages/VisualCreatePolicy/utils/helpers.ts
+++ b/public/pages/VisualCreatePolicy/utils/helpers.ts
@@ -42,12 +42,14 @@ export const getConditionContent = (transition: Transition): string => {
       min_doc_count: minDocCount = undefined,
       min_index_age: minIndexAge = undefined,
       min_size: minSize = undefined,
+      min_rollover_age: minRolloverAge = undefined,
       cron = undefined,
     } = {},
   } = transition;
   if (minSize != undefined) return `Minimum index size is ${minSize}`;
   if (minDocCount != undefined) return `Minimum index doc count is ${minDocCount}`;
   if (minIndexAge != undefined) return `Minimum index age is ${minIndexAge}`;
+  if (minRolloverAge != undefined) return `Minimum rollover age is ${minRolloverAge}`;
   if (cron != undefined) return `After cron expression "${cron.cron.expression}" in ${cron.cron.timezone}`;
   return "No condition";
 };


### PR DESCRIPTION
### Description
Adds support on UI for min primary shard size rollover condition and min rollover age transition condition
Updates jest snapshot tests
Removes validation for rollover action that was requiring on the UI at least one condition since backend supports no conditions.
Removes the empty rollover conditions in the default rollover action as it was causing it to be sent to backend which was then failing.

Backend PRs:
https://github.com/opensearch-project/index-management/pull/220
https://github.com/opensearch-project/index-management/pull/215

Seems like the visual part just has jest snapshot tests w/ and not functional tests. I see we have [this](https://github.com/opensearch-project/index-management-dashboards-plugin/issues/126) issue to add some cypress ones, but would also be good to have some functional jest tests too. Will rename the issue to cover both test types and pick it up separately as it's going to be a longer item.

### Issues Resolved
https://github.com/opensearch-project/index-management-dashboards-plugin/issues/158

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
