### PR TITLE
Removes local dependencies from cypress workflow

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -26,46 +26,6 @@ jobs:
         with:
           # TODO: Parse this from index management plugin
           java-version: 14
-      # dependencies: OpenSearch
-      - name: Checkout OpenSearch
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/OpenSearch'
-          path: OpenSearch
-          ref: '1.x'
-      - name: Build OpenSearch
-        working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal
-      # dependencies: common-utils
-      - name: Checkout common-utils
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/common-utils'
-          path: common-utils
-          ref: 'main'
-      - name: Build common-utils
-        working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=${{ env.OPENSEARCH_VERSION }}
-      # dependencies: job-scheduler
-      - name: Checkout job-scheduler
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/job-scheduler'
-          path: job-scheduler
-          ref: 'main'
-      - name: Build job-scheduler
-        working-directory: ./job-scheduler
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=${{ env.OPENSEARCH_VERSION }}
-      # dependencies: alerting-notification
-      - name: Checkout alerting
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/alerting'
-          path: alerting
-          ref: 'main'
-      - name: Build alerting
-        working-directory: ./alerting
-        run: ./gradlew :alerting-notification:publishToMavenLocal -Dopensearch.version=${{ env.OPENSEARCH_VERSION }}
       - name: Checkout index management
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Signed-off-by: Robert Downs <downsrob@amazon.com>

### Description
Modifies the cypress workflow to no longer use local dependencies.
This code was removed in this PR https://github.com/opensearch-project/index-management-dashboards-plugin/pull/87 and reverted in this PR https://github.com/opensearch-project/index-management-dashboards-plugin/pull/89. I am not sure why this was necessary to revert on 1.x, but the current convention is to ditch local dependencies in favor of snapshots.

### Issues Resolved
NA

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
