### PR TITLE
Adds UI for shrink action

### DIFF
--- a/models/interfaces.ts
+++ b/models/interfaces.ts
@@ -176,6 +176,20 @@ export interface RolloverAction extends Action {
   };
 }
 
+export interface ShrinkAction extends Action {
+  shrink: {
+    num_new_shards?: number;
+    max_shard_size?: string;
+    percentage_of_source_shards?: number;
+    target_index_name_template?: MessageTemplate;
+    aliases?: object[];
+    force_unsafe?: boolean;
+  };
+  aliases_json?: string;
+  force_unsafe_input?: string;
+  target_index_name_template_json?: string;
+}
+
 export interface UITransition {
   transition: Transition;
   id: string;

--- a/public/pages/VisualCreatePolicy/components/EuiFormCustomLabel/EuiFormCustomLabel.tsx
+++ b/public/pages/VisualCreatePolicy/components/EuiFormCustomLabel/EuiFormCustomLabel.tsx
@@ -13,6 +13,7 @@ interface EuiFormCustomLabelProps {
   textStyle?: object;
   headerStyle?: object;
   isInvalid?: boolean;
+  isOptional?: boolean;
 }
 
 // New pattern for label and help text both being above the form row instead of label above and help below.
@@ -23,10 +24,18 @@ const EuiFormCustomLabel = ({
   textStyle = { marginBottom: "5px" },
   headerStyle = { marginBottom: "2px" },
   isInvalid = false,
+  isOptional = false,
 }: EuiFormCustomLabelProps) => (
   <EuiText style={textStyle}>
     <h5 style={headerStyle} className={`euiFormLabel ${isInvalid ? "euiFormLabel-isInvalid" : ""}`}>
       {title}
+      {isOptional ? (
+        <React.Fragment>
+          <span className="euiTextColor euiTextColor--subdued">
+            <em>- optional</em>
+          </span>
+        </React.Fragment>
+      ) : null}
     </h5>
     <p>
       {" "}

--- a/public/pages/VisualCreatePolicy/components/UIActions/ShrinkUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ShrinkUIAction.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiFormRow, EuiCodeEditor, EuiFieldNumber, EuiFieldText, EuiSpacer, EuiRadioGroup, EuiCallOut } from "@elastic/eui";
+import { EuiFormRow, EuiCodeEditor, EuiFieldText, EuiSpacer, EuiRadioGroup, EuiCallOut } from "@elastic/eui";
 import { ShrinkAction, UIAction } from "../../../../../models/interfaces";
 import { makeId } from "../../../../utils/helpers";
 import { ActionType } from "../../utils/constants";
@@ -177,6 +177,7 @@ export default class ShrinkUIAction implements UIAction<ShrinkAction> {
           helpText={`The mustache template to use to form the name of the output shrunken index.
           If not provided, a default suffix of "_shrunken" will be appended.`}
           isInvalid={!this.isValidIndexNameTemplateJson()}
+          isOptional={true}
         />
         <EuiFormRow fullWidth isInvalid={!this.isValidIndexNameTemplateJson()} error={null} style={{ maxWidth: "100%" }}>
           <DarkModeConsumer>
@@ -230,6 +231,7 @@ export default class ShrinkUIAction implements UIAction<ShrinkAction> {
           title="Aliases"
           helpText={`The aliases to be applied to the output shrunken index.`}
           isInvalid={!this.isValidAliasesJson()}
+          isOptional={true}
         />
         <EuiFormRow fullWidth isInvalid={!this.isValidAliasesJson()} error={null} style={{ maxWidth: "100%" }}>
           <DarkModeConsumer>
@@ -263,8 +265,6 @@ export default class ShrinkUIAction implements UIAction<ShrinkAction> {
     const shrink = { ...this.action };
     if (shrink.aliases_json != null) {
       shrink.shrink.aliases = JSON.parse(shrink.aliases_json as string);
-      console.log(shrink.aliases_json as string);
-      console.log((shrink.shrink.aliases as Object[])[0]);
     }
     if (shrink.target_index_name_template_json != null) {
       shrink.shrink.target_index_name_template = JSON.parse(shrink.target_index_name_template_json as string);
@@ -272,7 +272,6 @@ export default class ShrinkUIAction implements UIAction<ShrinkAction> {
     delete shrink.aliases_json;
     delete shrink.force_unsafe_input;
     delete shrink.target_index_name_template_json;
-    console.log(shrink);
     return shrink;
   };
 }

--- a/public/pages/VisualCreatePolicy/components/UIActions/ShrinkUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ShrinkUIAction.tsx
@@ -202,6 +202,12 @@ export default class ShrinkUIAction implements UIAction<ShrinkAction> {
           </DarkModeConsumer>
         </EuiFormRow>
         <EuiSpacer size="s" />
+        <EuiCallOut color="warning" hidden={!this.action.shrink.force_unsafe}>
+          <p>
+            Warning: shrinking without replicas will allocate all primaries to one node, which could result in a complete loss of the index
+            in the case of a node crashing.
+          </p>
+        </EuiCallOut>
         <EuiFormCustomLabel
           title="Force unsafe"
           helpText={`If this is set to 'No' then the shrink action will fail for indices which do not have replica shards.`}

--- a/public/pages/VisualCreatePolicy/components/UIActions/ShrinkUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ShrinkUIAction.tsx
@@ -1,0 +1,278 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { ChangeEvent } from "react";
+import { EuiFormRow, EuiCodeEditor, EuiFieldNumber, EuiFieldText, EuiSpacer, EuiRadioGroup, EuiCallOut } from "@elastic/eui";
+import { ShrinkAction, UIAction } from "../../../../../models/interfaces";
+import { makeId } from "../../../../utils/helpers";
+import { ActionType } from "../../utils/constants";
+import { DarkModeConsumer } from "../../../../components/DarkMode";
+import EuiFormCustomLabel from "../EuiFormCustomLabel";
+
+const radios = [
+  {
+    id: "no",
+    label: "No",
+  },
+  {
+    id: "yes",
+    label: "Yes",
+  },
+];
+
+export default class ShrinkUIAction implements UIAction<ShrinkAction> {
+  id: string;
+  action: ShrinkAction;
+  type = ActionType.Shrink;
+
+  constructor(action: ShrinkAction, id: string = makeId(), useJsons: boolean = false) {
+    this.action = { ...action };
+    this.id = id;
+    // When the jsons are edited by the user, don't overwrite the json. When cloned elsewhere, take the actual object as source of truth
+    if (!useJsons) {
+      this.action.target_index_name_template_json = JSON.stringify(this.action.shrink.target_index_name_template, null, 4);
+      this.action.aliases_json = JSON.stringify(this.action.shrink.aliases, null, 4);
+      this.action.force_unsafe_input = this.action.shrink.force_unsafe ? "yes" : "no";
+    }
+  }
+
+  content = () => `Shrink`;
+
+  clone = (action: ShrinkAction = this.action) => new ShrinkUIAction(action, this.id);
+
+  cloneUsingString = (action: ShrinkAction) => new ShrinkUIAction(action, this.id, true);
+
+  isValid = () => {
+    return this.isValidNumShards() && this.isValidAliasesJson() && this.isValidIndexNameTemplateJson();
+  };
+
+  isValidNumShards = () => {
+    const shrink = this.action.shrink;
+    const numSet = [shrink.num_new_shards != null, shrink.percentage_of_source_shards != null, shrink.max_shard_size != null].filter(
+      (it) => it
+    ).length;
+    return numSet == 1;
+  };
+
+  isValidAliasesJson = () => {
+    if (this.action.aliases_json && this.action.aliases_json?.length > 0) {
+      try {
+        JSON.parse(this.getAliasesJsonString(this.action) as string);
+        return true;
+      } catch (err) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  getAliasesJsonString = (action: ShrinkAction) => {
+    const shrink = action.shrink;
+    return action.hasOwnProperty("aliases_json") ? action.aliases_json : JSON.stringify(shrink.aliases, null, 4);
+  };
+
+  isValidIndexNameTemplateJson = () => {
+    if (this.action.target_index_name_template_json && this.action.target_index_name_template_json?.length > 0) {
+      try {
+        JSON.parse(this.getIndexNameTemplateJsonString(this.action) as string);
+        return true;
+      } catch (err) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  getIndexNameTemplateJsonString = (action: ShrinkAction) => {
+    if (action.hasOwnProperty("target_index_name_template_json")) {
+      return action.target_index_name_template_json;
+    } else {
+      return JSON.stringify(action.shrink.target_index_name_template, null, 4);
+    }
+  };
+
+  render = (action: UIAction<ShrinkAction>, onChangeAction: (action: UIAction<ShrinkAction>) => void) => {
+    const shrink = action.action.shrink;
+    return (
+      <>
+        <EuiCallOut color="warning" hidden={this.isValidNumShards()}>
+          <p>Exactly one setting specifying the number of primary shards to shrink to must be used.</p>
+        </EuiCallOut>
+        <EuiFormCustomLabel
+          title="Number of new shards"
+          helpText={
+            "The number of primary shards to attempt to shrink the index down to. This must be a factor of the " +
+            "number of source index primary shards or else the greatest factor lower than your requested number of targeted primary shards " +
+            "will be used."
+          }
+          isInvalid={!this.isValidNumShards()}
+        />
+        <EuiFormRow fullWidth isInvalid={!this.isValidNumShards()} error={null}>
+          <EuiFieldText
+            fullWidth
+            value={typeof shrink.num_new_shards === "undefined" ? "" : shrink.num_new_shards}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              const numNewShards = e.target.value;
+              const shrinkObject = { ...action.action };
+              if (numNewShards) shrinkObject.shrink.num_new_shards = numNewShards;
+              else delete shrinkObject.shrink.num_new_shards;
+              onChangeAction(this.cloneUsingString(shrinkObject));
+            }}
+            data-test-subj="action-render-shrink-num-new-shards"
+          />
+        </EuiFormRow>
+        <EuiSpacer size="s" />
+        <EuiFormCustomLabel
+          title="Maximum shard size"
+          helpText={
+            "The maximum size of each primary shard following the shrink. This will be used to calculate the lowest factor of " +
+            "the number of source index primary shards to shrink to which satisfies the maximum shard size requirement. Accepts byte units, " +
+            'e.g. "500mb" or "50gb".'
+          }
+          isInvalid={!this.isValidNumShards()}
+        />
+        <EuiFormRow fullWidth isInvalid={!this.isValidNumShards()} error={null}>
+          <EuiFieldText
+            fullWidth
+            value={shrink.max_shard_size || ""}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              const maxShardSize = e.target.value;
+              const shrinkObject = { ...action.action };
+              if (maxShardSize) shrinkObject.shrink.max_shard_size = maxShardSize;
+              else delete shrinkObject.shrink.max_shard_size;
+              onChangeAction(this.cloneUsingString(shrinkObject));
+            }}
+            data-test-subj="action-render-shrink-max-shard-size"
+          />
+        </EuiFormRow>
+        <EuiSpacer size="s" />
+        <EuiFormCustomLabel
+          title="Percentage of source shards"
+          helpText={
+            "The percentage of source shards to shrink to. This will be used to calculate the greatest factor of " +
+            "the number of source index primary shards to shrink to which is less than the number of source shards times the percentage to shrink to. " +
+            "Accepts a percentage as a decimal, e.g. 0.5"
+          }
+          isInvalid={!this.isValidNumShards()}
+        />
+        <EuiFormRow fullWidth isInvalid={!this.isValidNumShards()} error={null}>
+          <EuiFieldText
+            fullWidth
+            value={typeof shrink.percentage_of_source_shards === "undefined" ? "" : shrink.percentage_of_source_shards}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              const percentageOfSourceShards = e.target.value;
+              const shrinkObject = { ...action.action };
+              if (percentageOfSourceShards) shrinkObject.shrink.percentage_of_source_shards = percentageOfSourceShards;
+              else delete shrinkObject.shrink.percentage_of_source_shards;
+              onChangeAction(this.cloneUsingString(shrinkObject));
+            }}
+            data-test-subj="action-render-shrink-percentage-of-source-shards"
+          />
+        </EuiFormRow>
+        <EuiSpacer size="s" />
+        <EuiFormCustomLabel
+          title="Target Index Name Template"
+          helpText={`The mustache template to use to form the name of the output shrunken index.
+          If not provided, a default suffix of "_shrunken" will be appended.`}
+          isInvalid={!this.isValidIndexNameTemplateJson()}
+        />
+        <EuiFormRow fullWidth isInvalid={!this.isValidIndexNameTemplateJson()} error={null} style={{ maxWidth: "100%" }}>
+          <DarkModeConsumer>
+            {(isDarkMode) => (
+              <EuiCodeEditor
+                mode="json"
+                theme={isDarkMode ? "sense-dark" : "github"}
+                width="100%"
+                value={action.action.target_index_name_template_json}
+                onChange={(str) => {
+                  const indexNameTemplateJSON = str;
+                  const shrinkObject = { ...action.action };
+                  if (indexNameTemplateJSON) shrinkObject.target_index_name_template_json = indexNameTemplateJSON;
+                  else delete shrinkObject.target_index_name_template_json;
+                  onChangeAction(this.cloneUsingString(shrinkObject));
+                }}
+                setOptions={{ fontSize: "14px" }}
+                aria-label="Code Editor"
+                height="100px"
+              />
+            )}
+          </DarkModeConsumer>
+        </EuiFormRow>
+        <EuiSpacer size="s" />
+        <EuiFormCustomLabel
+          title="Force unsafe"
+          helpText={`If this is set to 'No' then the shrink action will fail for indices which do not have replica shards.`}
+          isInvalid={false}
+        />
+        <EuiFormRow fullWidth isInvalid={false} error={null} style={{ maxWidth: "100%" }}>
+          <EuiRadioGroup
+            options={radios}
+            idSelected={this.action.force_unsafe_input}
+            onChange={(id) => {
+              const forceUnsafe = id === "yes";
+              const shrinkObject = { ...action.action };
+              if (forceUnsafe) {
+                shrinkObject.shrink.force_unsafe = forceUnsafe;
+                shrinkObject.force_unsafe_input = id;
+              } else {
+                shrinkObject.shrink.force_unsafe = false;
+                shrinkObject.force_unsafe_input = "no";
+              }
+              onChangeAction(this.cloneUsingString(shrinkObject));
+            }}
+            name="forceUnsafe"
+          />
+        </EuiFormRow>
+        <EuiSpacer size="s" />
+        <EuiFormCustomLabel
+          title="Aliases"
+          helpText={`The aliases to be applied to the output shrunken index.`}
+          isInvalid={!this.isValidAliasesJson()}
+        />
+        <EuiFormRow fullWidth isInvalid={!this.isValidAliasesJson()} error={null} style={{ maxWidth: "100%" }}>
+          <DarkModeConsumer>
+            {(isDarkMode) => (
+              <EuiCodeEditor
+                mode="json"
+                theme={isDarkMode ? "sense-dark" : "github"}
+                width="100%"
+                value={action.action.aliases_json}
+                onChange={(str) => {
+                  const aliasesJSON = str;
+                  const shrinkObject: ShrinkAction = { ...action.action };
+                  // const shrink = { ...action.action.shrink };
+                  if (aliasesJSON) shrinkObject.aliases_json = aliasesJSON;
+                  else delete shrinkObject.aliases_json;
+                  onChangeAction(this.cloneUsingString(shrinkObject));
+                }}
+                setOptions={{ fontSize: "14px" }}
+                aria-label="Code Editor"
+                height="100px"
+              />
+            )}
+          </DarkModeConsumer>
+        </EuiFormRow>
+      </>
+    );
+  };
+
+  toAction = () => {
+    // Use the spread operator to copy the action
+    const shrink = { ...this.action };
+    if (shrink.aliases_json != null) {
+      shrink.shrink.aliases = JSON.parse(shrink.aliases_json as string);
+      console.log(shrink.aliases_json as string);
+      console.log((shrink.shrink.aliases as Object[])[0]);
+    }
+    if (shrink.target_index_name_template_json != null) {
+      shrink.shrink.target_index_name_template = JSON.parse(shrink.target_index_name_template_json as string);
+    }
+    delete shrink.aliases_json;
+    delete shrink.force_unsafe_input;
+    delete shrink.target_index_name_template_json;
+    console.log(shrink);
+    return shrink;
+  };
+}

--- a/public/pages/VisualCreatePolicy/components/UIActions/index.ts
+++ b/public/pages/VisualCreatePolicy/components/UIActions/index.ts
@@ -15,6 +15,7 @@ import ReadWriteUIAction from "./ReadWriteUIAction";
 import ReplicaCountUIAction from "./ReplicaCountUIAction";
 import RolloverUIAction from "./RolloverUIAction";
 import RollupUIAction from "./RollupUIAction";
+import ShrinkUIAction from "./ShrinkUIAction";
 import SnapshotUIAction from "./SnapshotUIAction";
 
 export {
@@ -30,5 +31,6 @@ export {
   ReplicaCountUIAction,
   RolloverUIAction,
   RollupUIAction,
+  ShrinkUIAction,
   SnapshotUIAction,
 };

--- a/public/pages/VisualCreatePolicy/containers/CreateAction/__snapshots__/CreateAction.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateAction/__snapshots__/CreateAction.test.tsx.snap
@@ -150,6 +150,11 @@ exports[`<CreateAction /> spec renders the component 1`] = `
                   Rollup
                 </option>
                 <option
+                  value="shrink"
+                >
+                  Shrink
+                </option>
+                <option
                   value="snapshot"
                 >
                   Snapshot

--- a/public/pages/VisualCreatePolicy/utils/constants.ts
+++ b/public/pages/VisualCreatePolicy/utils/constants.ts
@@ -18,6 +18,7 @@ export enum ActionType {
   ReplicaCount = "replica_count",
   Rollover = "rollover",
   Rollup = "rollup",
+  Shrink = "shrink",
   Snapshot = "snapshot",
 }
 
@@ -170,6 +171,18 @@ export const DEFAULT_ROLLUP = {
     ),
   },
 };
+
+export const DEFAULT_SHRINK = {
+  shrink: {
+    percentage_of_source_shards: 0.5,
+    force_unsafe: false,
+    target_index_name_template: {
+      source: "{{ctx.index}}_shrunken",
+    },
+  },
+  force_unsafe_input: "no",
+};
+
 export const DEFAULT_SNAPSHOT = {
   snapshot: {
     repository: "example-repository",
@@ -190,6 +203,7 @@ export const actions = [
   DEFAULT_REPLICA_COUNT,
   DEFAULT_ROLLOVER,
   DEFAULT_ROLLUP,
+  DEFAULT_SHRINK,
   DEFAULT_SNAPSHOT,
 ];
 

--- a/public/pages/VisualCreatePolicy/utils/helpers.test.ts
+++ b/public/pages/VisualCreatePolicy/utils/helpers.test.ts
@@ -75,9 +75,9 @@ class DummyUIAction implements UIAction<DummyAction> {
 }
 
 test("action repository usage", () => {
-  expect(actionRepoSingleton.getAllActionTypes().length).toBe(13);
-  actionRepoSingleton.registerAction("dummy", DummyUIAction, DEFAULT_DUMMY);
   expect(actionRepoSingleton.getAllActionTypes().length).toBe(14);
+  actionRepoSingleton.registerAction("dummy", DummyUIAction, DEFAULT_DUMMY);
+  expect(actionRepoSingleton.getAllActionTypes().length).toBe(15);
   expect(actionRepoSingleton.getUIAction("dummy") instanceof DummyUIAction).toBe(true);
   expect(actionRepoSingleton.getUIActionFromData(DEFAULT_DUMMY) instanceof DummyUIAction).toBe(true);
 });

--- a/public/pages/VisualCreatePolicy/utils/helpers.ts
+++ b/public/pages/VisualCreatePolicy/utils/helpers.ts
@@ -18,6 +18,7 @@ import {
   DEFAULT_REPLICA_COUNT,
   DEFAULT_ROLLOVER,
   DEFAULT_ROLLUP,
+  DEFAULT_SHRINK,
   DEFAULT_SNAPSHOT,
 } from "./constants";
 import {
@@ -33,6 +34,7 @@ import {
   ReplicaCountUIAction,
   RolloverUIAction,
   RollupUIAction,
+  ShrinkUIAction,
   SnapshotUIAction,
 } from "../components/UIActions";
 
@@ -89,6 +91,8 @@ export const getUIAction = (actionType: string): UIAction<any> => {
       return new RolloverUIAction(DEFAULT_ROLLOVER);
     case ActionType.Rollup:
       return new RollupUIAction(DEFAULT_ROLLUP);
+    case ActionType.Shrink:
+      return new ShrinkUIAction(DEFAULT_SHRINK);
     case ActionType.Snapshot:
       return new SnapshotUIAction(DEFAULT_SNAPSHOT);
     default:
@@ -110,6 +114,7 @@ class ActionRepository {
     replica_count: [ReplicaCountUIAction, DEFAULT_REPLICA_COUNT],
     rollover: [RolloverUIAction, DEFAULT_ROLLOVER],
     rollup: [RollupUIAction, DEFAULT_ROLLUP],
+    shrink: [ShrinkUIAction, DEFAULT_SHRINK],
     snapshot: [SnapshotUIAction, DEFAULT_SNAPSHOT],
   };
 

--- a/server/utils/helpers.ts
+++ b/server/utils/helpers.ts
@@ -59,9 +59,9 @@ export function getSearchString(terms?: string[], indices?: string[], dataStream
   // Terms are searched with a wildcard around them.
   const searchTerms = terms ? `*${_.castArray(terms).join("*,*")}*` : "";
 
-  // Indices and data streams are searched with an exact match.
-  const searchIndices = indices ? _.castArray(indices).join(",") : "";
-  const searchDataStreams = dataStreams ? _.castArray(dataStreams).join(",") : "";
+  // Indices and data streams are searched with wildcards around them.
+  const searchIndices = indices ? `*${_.castArray(indices).join("*,*")}*` : "";
+  const searchDataStreams = dataStreams ? `*${_.castArray(dataStreams).join("*,*")}*` : "";
 
   // The overall search string is a combination of terms, indices, and data streams.
   // If the search string is blank, then '*' is used to match everything.

--- a/server/utils/helpers.ts
+++ b/server/utils/helpers.ts
@@ -67,5 +67,5 @@ export function getSearchString(terms?: string[], indices?: string[], dataStream
   // If the search string is blank, then '*' is used to match everything.
   const resolved = [searchTerms, searchIndices, searchDataStreams].filter((value) => value !== "").join(",") || "*";
   // We don't want to fetch managed datastream indices if there are not selected by caller.
-  return showDataStreams ? resolved : resolved + " -.ds"
+  return showDataStreams ? resolved : resolved + " -.ds*";
 }


### PR DESCRIPTION
Signed-off-by: Clay Downs <downsrob@amazon.com>

### Description
Adds UI for the shrink action. This PR does not contain any tests, which should be added later. Additional validation should also be added, such as not allowing percentage to shrink shards to input out of the range of 0 to 1. This is currently validated by the backend but additional validation up front would improve the user experience.
### Zoomed out overview of the visual editor:
![Screen Shot 2022-04-14 at 7 41 15 PM](https://user-images.githubusercontent.com/89109232/163511273-d9caffdc-04b1-435d-bf41-69200d30f2b6.png)

### If more than one number of shards setting is added, this error appears:
![Screen Shot 2022-04-14 at 7 41 49 PM](https://user-images.githubusercontent.com/89109232/163511278-0edd0108-8734-4dbf-83d8-b74b985512f1.png)

### When either of the JSON editors are poorly formatted it will show as red.
![Screen Shot 2022-04-14 at 7 42 25 PM](https://user-images.githubusercontent.com/89109232/163511321-355c3b6e-b744-4ba2-8909-4bb50263679c.png)
If any of the above errors are present, it will not be possible to add the action.

### Template and alias updated to say -optional
![Screen Shot 2022-04-15 at 3 46 12 PM](https://user-images.githubusercontent.com/89109232/163651439-fa2be63e-6f30-46f4-9ce8-ee3caf3c073d.png)

### Warning that appears for force unsafe option
![Screen Shot 2022-04-15 at 4 29 26 PM](https://user-images.githubusercontent.com/89109232/163652504-35053508-2cde-48c7-b1d7-2af9ce282794.png)

### Issues Resolved
https://github.com/opensearch-project/index-management/issues/40

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
