### PR TITLE
Fix rendering in transforms UI

### DIFF
--- a/models/interfaces.ts
+++ b/models/interfaces.ts
@@ -379,6 +379,7 @@ export interface MetricItem {
 export interface FieldItem {
   label: string;
   type: string | undefined;
+  path: string | undefined;
 }
 
 interface DateHistogramItem {

--- a/public/pages/CreateRollup/utils/helpers.ts
+++ b/public/pages/CreateRollup/utils/helpers.ts
@@ -114,7 +114,7 @@ export const isNumericMapping = (fieldType: string | undefined): boolean => {
 };
 
 export const compareFieldItem = (itemA: FieldItem, itemB: FieldItem): boolean => {
-  return itemB.label == itemA.label && itemA.type == itemB.type;
+  return itemB.label == itemA.label && itemA.type == itemB.type && itemA.path == itemB.path;
 };
 
 export const parseFieldOptions = (prefix: string, mappings: any): FieldItem[] => {

--- a/public/pages/CreateTransform/components/DefineTransforms/DefineTransforms.tsx
+++ b/public/pages/CreateTransform/components/DefineTransforms/DefineTransforms.tsx
@@ -51,36 +51,38 @@ export default function DefineTransforms({
   let columns: EuiDataGridColumn[] = [];
 
   fields.map((field: FieldItem) => {
-    columns.push({
-      id: field.label,
-      display: isReadOnly ? (
-        <div>
-          <EuiToolTip content={field.label}>
-            <EuiText size="s">
-              <b>{field.label}</b>
-            </EuiText>
-          </EuiToolTip>
-        </div>
-      ) : (
-        <TransformOptions
-          name={field.label}
-          type={field.type}
-          selectedGroupField={selectedGroupField}
-          onGroupSelectionChange={onGroupSelectionChange}
-          aggList={aggList}
-          selectedAggregations={selectedAggregations}
-          onAggregationSelectionChange={onAggregationSelectionChange}
-        />
-      ),
-      schema: field.type,
-      actions: {
-        showHide: false,
-        showMoveLeft: false,
-        showMoveRight: false,
-        showSortAsc: false,
-        showSortDesc: false,
-      },
-    });
+      if (field.type !== "alias") {
+          columns.push({
+              id: field.label,
+              display: isReadOnly ? (
+                  <div>
+                      <EuiToolTip content={field.label}>
+                          <EuiText size="s">
+                              <b>{field.label}</b>
+                          </EuiText>
+                      </EuiToolTip>
+                  </div>
+              ) : (
+                  <TransformOptions
+                      name={field.label}
+                      type={field.type}
+                      selectedGroupField={selectedGroupField}
+                      onGroupSelectionChange={onGroupSelectionChange}
+                      aggList={aggList}
+                      selectedAggregations={selectedAggregations}
+                      onAggregationSelectionChange={onAggregationSelectionChange}
+                  />
+              ),
+              schema: field.type,
+              actions: {
+                  showHide: false,
+                  showMoveLeft: false,
+                  showMoveRight: false,
+                  showSortAsc: false,
+                  showSortDesc: false,
+              },
+          });
+      };
   });
 
   const [loading, setLoading] = useState<boolean>(true);
@@ -146,12 +148,11 @@ export default function DefineTransforms({
         return data[rowIndex]._source[correspondingTextColumnId] ? data[rowIndex]._source[correspondingTextColumnId] : "-";
       } else if (columns?.find((column) => column.id == columnId).schema == "date") {
         return data[rowIndex]._source[columnId] ? renderTime(data[rowIndex]._source[columnId]) : "-";
-      } else if (columns?.find((column) => column.id == columnId).schema == "geo_point") {
-        return data[rowIndex].source[columndId] ? data[rowIndex]._source[columnId].lat + ", " + data[rowIndex]._source[columnId].lon : "-";
       } else if (columns?.find((column) => column.id == columnId).schema == "boolean") {
         return data[rowIndex]._source[columnId] == null ? "-" : data[rowIndex]._source[columnId] ? "true" : "false";
       }
-      return data[rowIndex]._source[columnId] !== null ? JSON.stringify(data[rowIndex]._source[columnId]) : "-";
+      const val = data[rowIndex]._source[columnId];
+      return val !== undefined ? JSON.stringify(val) : "-";
     }
     return "-";
   };

--- a/public/pages/CreateTransform/components/DefineTransforms/DefineTransforms.tsx
+++ b/public/pages/CreateTransform/components/DefineTransforms/DefineTransforms.tsx
@@ -51,38 +51,36 @@ export default function DefineTransforms({
   let columns: EuiDataGridColumn[] = [];
 
   fields.map((field: FieldItem) => {
-      if (field.type !== "alias") {
-          columns.push({
-              id: field.label,
-              display: isReadOnly ? (
-                  <div>
-                      <EuiToolTip content={field.label}>
-                          <EuiText size="s">
-                              <b>{field.label}</b>
-                          </EuiText>
-                      </EuiToolTip>
-                  </div>
-              ) : (
-                  <TransformOptions
-                      name={field.label}
-                      type={field.type}
-                      selectedGroupField={selectedGroupField}
-                      onGroupSelectionChange={onGroupSelectionChange}
-                      aggList={aggList}
-                      selectedAggregations={selectedAggregations}
-                      onAggregationSelectionChange={onAggregationSelectionChange}
-                  />
-              ),
-              schema: field.type,
-              actions: {
-                  showHide: false,
-                  showMoveLeft: false,
-                  showMoveRight: false,
-                  showSortAsc: false,
-                  showSortDesc: false,
-              },
-          });
-      };
+    columns.push({
+      id: field.label,
+      display: isReadOnly ? (
+        <div>
+          <EuiToolTip content={field.label}>
+            <EuiText size="s">
+              <b>{field.label}</b>
+            </EuiText>
+          </EuiToolTip>
+        </div>
+      ) : (
+        <TransformOptions
+          name={field.label}
+          type={field.type}
+          selectedGroupField={selectedGroupField}
+          onGroupSelectionChange={onGroupSelectionChange}
+          aggList={aggList}
+          selectedAggregations={selectedAggregations}
+          onAggregationSelectionChange={onAggregationSelectionChange}
+        />
+      ),
+      schema: field.type,
+      actions: {
+        showHide: false,
+        showMoveLeft: false,
+        showMoveRight: false,
+        showSortAsc: false,
+        showSortDesc: false,
+      },
+    });
   });
 
   const [loading, setLoading] = useState<boolean>(true);
@@ -142,20 +140,28 @@ export default function DefineTransforms({
 
   const renderCellValue = ({ rowIndex, columnId }) => {
     if (!loading && data.hasOwnProperty(rowIndex)) {
-      if (columns?.find((column) => column.id == columnId).schema == "keyword") {
-        // Remove the keyword postfix for getting correct data from array
-        const correspondingTextColumnId = columnId.replace(".keyword", "");
-        return data[rowIndex]._source[correspondingTextColumnId] ? data[rowIndex]._source[correspondingTextColumnId] : "-";
-      } else if (columns?.find((column) => column.id == columnId).schema == "date") {
-        return data[rowIndex]._source[columnId] ? renderTime(data[rowIndex]._source[columnId]) : "-";
-      } else if (columns?.find((column) => column.id == columnId).schema == "boolean") {
-        return data[rowIndex]._source[columnId] == null ? "-" : data[rowIndex]._source[columnId] ? "true" : "false";
+      let lookupId = columnId;
+      if (columns?.find((column) => column.id == columnId).schema == "alias") {
+        lookupId = columns?.find((column) => column.id == columnId).path;
       }
-      const val = data[rowIndex]._source[columnId];
-      return val !== undefined ? JSON.stringify(val) : "-";
+      return getColumnValue(rowIndex, lookupId);
     }
     return "-";
   };
+
+  const getColumnValue = (rowIndex, columnId) => {
+    if (columns?.find((column) => column.id == columnId).schema == "keyword") {
+      // Remove the keyword postfix for getting correct data from array
+      const correspondingTextColumnId = columnId.replace(".keyword", "");
+      return data[rowIndex]._source[correspondingTextColumnId] ? data[rowIndex]._source[correspondingTextColumnId] : "-";
+    } else if (columns?.find((column) => column.id == columnId).schema == "date") {
+      return data[rowIndex]._source[columnId] ? renderTime(data[rowIndex]._source[columnId]) : "-";
+    } else if (columns?.find((column) => column.id == columnId).schema == "boolean") {
+      return data[rowIndex]._source[columnId] == null ? "-" : data[rowIndex]._source[columnId] ? "true" : "false";
+    }
+    const val = data[rowIndex]._source[columnId];
+    return val !== undefined ? JSON.stringify(val) : "-";
+  }
 
   //TODO: remove duplicate code here after extracting the first table as separate component
   if (isReadOnly)

--- a/public/pages/CreateTransform/utils/helpers.ts
+++ b/public/pages/CreateTransform/utils/helpers.ts
@@ -43,7 +43,7 @@ export const parseFieldOptions = (prefix: string, mappings: any): FieldItem[] =>
   for (let field in mappings) {
     if (mappings.hasOwnProperty(field)) {
       if (mappings[field].type != "object" && mappings[field].type != null && mappings[field].type != "nested")
-        fieldsOption.push({ label: prefix + field, type: mappings[field].type });
+        fieldsOption.push({ label: prefix + field, type: mappings[field].type, path: mappings[field].path});
       if (mappings[field].fields != null)
         fieldsOption = fieldsOption.concat(parseFieldOptions(prefix + field + ".", mappings[field].fields));
       if (mappings[field].properties != null)


### PR DESCRIPTION
Signed-off-by: Ravi Thaluru <thalurur@users.noreply.github.com>

### Description
Fix geopoint rendering issue
Earlier if geopoint data type is selected in opensearch sample flight data for example when geopoint data type e.g `DestLocation` is selected then whole page crashes

![image](https://user-images.githubusercontent.com/6005951/163875498-0123e125-4e02-4ad2-a32a-88f0774bd808.png)
![image](https://user-images.githubusercontent.com/6005951/163875558-0de6f01f-b78b-4625-9805-85a2aa6735d5.png)


After fix the geopoint is rendered as a string
![image](https://user-images.githubusercontent.com/6005951/163875885-df805472-4c91-458d-8e24-6a6a73dc6fb3.png)
![image](https://user-images.githubusercontent.com/6005951/163875919-3c9a6bd3-8819-447e-9cbd-81113254d651.png)

render alias fields correctly
![image](https://user-images.githubusercontent.com/6005951/164065098-1d0e2ce1-932f-49d0-8979-6359645a73b1.png)<img width="463" alt="image" src="https://user-images.githubusercontent.com/6005951/163954803-5f57d690-6576-4035-aa73-d5d9f727ffe4.png">


Rendering sparse data correctly
<img width="1282" alt="image" src="https://user-images.githubusercontent.com/6005951/163954572-20b6a3b4-94b9-4d72-820e-cbd4c5426c21.png">



### Issues Resolved
https://github.com/opensearch-project/index-management-dashboards-plugin/issues/141
https://github.com/opensearch-project/index-management-dashboards-plugin/issues/134

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
