### PR TITLE
Removes rc1 version qualifier [BACKPORT]

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -3,10 +3,12 @@ on:
   pull_request:
     branches:
       - main
+      - 2.0
   push:
     branches:
       - main
       - development-*
+      - 2.0
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '2.0'
   OPENSEARCH_VERSION: '2.0.0-SNAPSHOT'
@@ -30,7 +32,7 @@ jobs:
         with:
           path: index-management
           repository: opensearch-project/index-management
-          ref: 'main'
+          ref: '2.0'
       - name: Run opensearch with plugin
         run: |
           cd index-management

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -8,8 +8,8 @@ on:
       - main
       - development-*
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: 'main'
-  OPENSEARCH_VERSION: '2.0.0-rc1-SNAPSHOT'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.0'
+  OPENSEARCH_VERSION: '2.0.0-SNAPSHOT'
 jobs:
   tests:
     name: Run Cypress E2E tests

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -3,9 +3,11 @@ on:
   pull_request:
     branches:
       - main
+      - 2.0
   push:
     branches:
       - main
+      - 2.0
       - development-*
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '2.0'

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -8,7 +8,7 @@ on:
       - main
       - development-*
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: 'main'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.0'
 jobs:
   tests:
     name: Run unit tests

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,6 +1,6 @@
 {
   "id": "indexManagementDashboards",
-  "version": "2.0.0.0-rc1",
+  "version": "2.0.0.0",
   "opensearchDashboardsVersion": "2.0.0",
   "configPath": ["opensearch_index_management"],
   "requiredPlugins": ["navigation"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch_index_management_dashboards",
-  "version": "2.0.0.0-rc1",
+  "version": "2.0.0.0",
   "description": "Opensearch Dashboards plugin for Index Management",
   "main": "index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Description
Backport of https://github.com/opensearch-project/index-management-dashboards-plugin/pull/192 to remove the rc1 version qualifier from the 2.0 branch. The backport workflow failed me as I merged while the workflow was in progress.

### Issues Resolved
https://github.com/opensearch-project/index-management-dashboards-plugin/issues/190

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
