### PR TITLE
Fix transforms UI for supporting rendering of alias fields

### DIFF
--- a/public/pages/CreateTransform/components/DefineTransforms/DefineTransforms.tsx
+++ b/public/pages/CreateTransform/components/DefineTransforms/DefineTransforms.tsx
@@ -73,6 +73,7 @@ export default function DefineTransforms({
         />
       ),
       schema: field.type,
+      path: field.path,
       actions: {
         showHide: false,
         showMoveLeft: false,


### PR DESCRIPTION
Signed-off-by: Ravi Thaluru <thalurur@users.noreply.github.com>

### Description
Few of the transforms UI rendering was bugfixes were fixed in this [PR](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/179/commits) 

As part of above PR I have included `path` field in `FieldItem` datatype which is populated using the mappings data of the index. But when we render the table we use `columns` object data. At the moment the `path` field is none in the columns and as a result will fail to render the alias data type.

This PR fixes the issue by populating path field in columns object using FieldItem

![image](https://user-images.githubusercontent.com/6005951/169615383-0a476dc7-5fef-43d4-8517-dd9a469514bb.png)
![image](https://user-images.githubusercontent.com/6005951/169615397-45821fd3-cd4b-46d7-83a5-006e08ccd73d.png)


### Issues Resolved
https://github.com/opensearch-project/index-management-dashboards-plugin/issues/141
https://github.com/opensearch-project/index-management-dashboards-plugin/issues/134


### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
