### PR TITLE
Bumping 2.x branch from version 2.1 to 2.2.

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -9,7 +9,7 @@ on:
       - development-*
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '2.x'
-  OPENSEARCH_VERSION: '2.1.0-SNAPSHOT'
+  OPENSEARCH_VERSION: '2.2.0-SNAPSHOT'
 jobs:
   tests:
     name: Run Cypress E2E tests

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "indexManagementDashboards",
-  "version": "2.1.0.0",
-  "opensearchDashboardsVersion": "2.1.0",
+  "version": "2.2.0.0",
+  "opensearchDashboardsVersion": "2.2.0",
   "configPath": ["opensearch_index_management"],
   "requiredPlugins": ["navigation"],
   "server": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch_index_management_dashboards",
-  "version": "2.1.0.0",
+  "version": "2.2.0.0",
   "description": "Opensearch Dashboards plugin for Index Management",
   "main": "index.js",
   "license": "Apache-2.0",
@@ -44,7 +44,8 @@
     "ansi-regex": "^5.0.1",
     "minimist": "^1.2.6",
     "moment": "^2.29.2",
-    "async": "^3.2.3"
+    "async": "^3.2.3",
+    "terser": "^4.8.1"
   },
   "devDependencies": {
     "@elastic/elastic-eslint-config-kibana": "link:../../packages/opensearch-eslint-config-opensearch-dashboards",

--- a/release-notes/opensearch-index-management-dashboards-plugin.release-notes-2.2.0.0.md
+++ b/release-notes/opensearch-index-management-dashboards-plugin.release-notes-2.2.0.0.md
@@ -1,0 +1,6 @@
+## Version 2.2.0.0 2022-08-04
+
+Compatible with OpenSearch 2.2.0
+
+### Maintenance
+* Bumping 2.x branch from version 2.1 to 2.2. Bumped terser version to 4.8.1 to address CVE. Drafted 2.2 release notes. ([#]())

--- a/release-notes/opensearch-index-management-dashboards-plugin.release-notes-2.2.0.0.md
+++ b/release-notes/opensearch-index-management-dashboards-plugin.release-notes-2.2.0.0.md
@@ -3,4 +3,4 @@
 Compatible with OpenSearch 2.2.0
 
 ### Maintenance
-* Bumping 2.x branch from version 2.1 to 2.2. Bumped terser version to 4.8.1 to address CVE. Drafted 2.2 release notes. ([#]())
+* Bumping 2.x branch from version 2.1 to 2.2. Bumped terser version to 4.8.1 to address CVE. Drafted 2.2 release notes. ([#218](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/218))

--- a/yarn.lock
+++ b/yarn.lock
@@ -4115,10 +4115,10 @@ terser-webpack-plugin@^1.4.3:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
-terser@^4.1.2:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
-  integrity sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==
+terser@^4.1.2, terser@^4.8.1:
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.1.tgz#a00e5634562de2239fd404c649051bf6fc21144f"
+  integrity sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"


### PR DESCRIPTION
### Description
1. Bumping `2.x` branch from version `2.1` to `2.2`.
2. Bumped `terser` version to `4.8.1` to address this [CVE](https://github.com/opensearch-project/index-management-dashboards-plugin/security/dependabot/10).
3. Drafted `2.2` release notes.

### Issues Resolved
https://github.com/opensearch-project/index-management-dashboards-plugin/issues/217

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
