### PR TITLE
Bumping main to 2.2, address dependabot alert, enable test workflows on all PRs, fix snapshot tests.

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -9,7 +9,7 @@ on:
       - development-*
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '2.x'
-  OPENSEARCH_VERSION: '2.1.0-SNAPSHOT'
+  OPENSEARCH_VERSION: '2.2.0-SNAPSHOT'
 jobs:
   tests:
     name: Run Cypress E2E tests

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -2,13 +2,12 @@ name: E2E tests workflow
 on:
   pull_request:
     branches:
-      - main
+      - "*"
   push:
     branches:
-      - main
-      - development-*
+      - "*"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '2.x'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.2'
   OPENSEARCH_VERSION: '2.2.0-SNAPSHOT'
 jobs:
   tests:

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -2,13 +2,12 @@ name: Unit tests workflow
 on:
   pull_request:
     branches:
-      - main
+      - "*"
   push:
     branches:
-      - main
-      - development-*
+      - "*"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '2.x'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.2'
 jobs:
   tests:
     name: Run unit tests

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Integration tests](https://github.com/opensearch-project/index-management-dashboards-plugin/workflows/E2E%20tests%20workflow/badge.svg)](https://github.com/opensearch-project/index-management-dashboards-plugin/actions?query=workflow%3A%22E2E+tests+workflow%22)
 [![codecov](https://codecov.io/gh/opensearch-project/index-management-dashboards-plugin/branch/main/graph/badge.svg)](https://codecov.io/gh/opensearch-project/index-management-dashboards-plugin)
 [![Documentation](https://img.shields.io/badge/doc-reference-blue)](https://opensearch.org/docs/im-plugin/index/)
-[![Forum](https://img.shields.io/badge/chat-on%20forums-blue)](https://discuss.opendistrocommunity.dev/c/Use-this-category-for-all-questions-around-machine-learning-plugins)
+[![Forum](https://img.shields.io/badge/chat-on%20forums-blue)](https://forum.opensearch.org/c/plugins/index-management)
 ![PRs welcome!](https://img.shields.io/badge/PRs-welcome!-success)
 
 <img src="https://opensearch.org/assets/img/opensearch-logo-themed.svg" height="64px">

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "indexManagementDashboards",
-  "version": "2.1.0.0",
-  "opensearchDashboardsVersion": "2.1.0",
+  "version": "2.2.0.0",
+  "opensearchDashboardsVersion": "2.2.0",
   "configPath": ["opensearch_index_management"],
   "requiredPlugins": ["navigation"],
   "server": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch_index_management_dashboards",
-  "version": "2.1.0.0",
+  "version": "2.2.0.0",
   "description": "Opensearch Dashboards plugin for Index Management",
   "main": "index.js",
   "license": "Apache-2.0",
@@ -44,7 +44,8 @@
     "ansi-regex": "^5.0.1",
     "minimist": "^1.2.6",
     "moment": "^2.29.2",
-    "async": "^3.2.3"
+    "async": "^3.2.3",
+    "terser": "^4.8.1"
   },
   "devDependencies": {
     "@elastic/elastic-eslint-config-kibana": "link:../../packages/opensearch-eslint-config-opensearch-dashboards",

--- a/release-notes/opensearch-index-management-dashboards-plugin.release-notes-2.2.0.0.md
+++ b/release-notes/opensearch-index-management-dashboards-plugin.release-notes-2.2.0.0.md
@@ -3,4 +3,8 @@
 Compatible with OpenSearch 2.2.0
 
 ### Maintenance
-* Bumping 2.x branch from version 2.1 to 2.2. Bumped terser version to 4.8.1 to address CVE. Drafted 2.2 release notes. ([#218](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/218))
+* Bumping 2.x branch from version 2.1 to 2.2. ([#218](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/218))
+
+### Documentation
+* Updated rollup help text. ([#220](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/220))
+* Added to 2.2 release notes. ([#222](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/222))

--- a/release-notes/opensearch-index-management-dashboards-plugin.release-notes-2.2.0.0.md
+++ b/release-notes/opensearch-index-management-dashboards-plugin.release-notes-2.2.0.0.md
@@ -1,0 +1,6 @@
+## Version 2.2.0.0 2022-08-04
+
+Compatible with OpenSearch 2.2.0
+
+### Maintenance
+* Bumping 2.x branch from version 2.1 to 2.2. Bumped terser version to 4.8.1 to address CVE. Drafted 2.2 release notes. ([#218](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/218))

--- a/test/setup.jest.ts
+++ b/test/setup.jest.ts
@@ -9,7 +9,7 @@ import { configure } from "@testing-library/react";
 
 configure({ testIdAttribute: "data-test-subj" });
 
-jest.mock("@elastic/eui/lib/components/form/form_row/make_id", () => () => "some_make_id");
+jest.mock("@elastic/eui/lib/eui_components/form/form_row/make_id", () => () => "some_make_id");
 
 jest.mock("@elastic/eui/lib/services/accessibility/html_id_generator", () => ({
   htmlIdGenerator: () => {
@@ -32,13 +32,13 @@ window.URL = {
 };
 
 // https://github.com/elastic/eui/issues/2530
-jest.mock("@elastic/eui/lib/components/icon", () => ({
+jest.mock("@elastic/eui/lib/eui_components/icon", () => ({
   EuiIcon: () => "EuiIconMock",
   __esModule: true,
-  IconPropType: require("@elastic/eui/lib/components/icon/icon").IconPropType,
-  ICON_TYPES: require("@elastic/eui/lib/components/icon/icon").TYPES,
-  ICON_SIZES: require("@elastic/eui/lib/components/icon/icon").SIZES,
-  ICON_COLORS: require("@elastic/eui/lib/components/icon/icon").COLORS,
+  IconPropType: require("@elastic/eui/lib/eui_components/icon/icon").IconPropType,
+  ICON_TYPES: require("@elastic/eui/lib/eui_components/icon/icon").TYPES,
+  ICON_SIZES: require("@elastic/eui/lib/eui_components/icon/icon").SIZES,
+  ICON_COLORS: require("@elastic/eui/lib/eui_components/icon/icon").COLORS,
 }));
 
 jest.setTimeout(10000); // in milliseconds

--- a/yarn.lock
+++ b/yarn.lock
@@ -4115,10 +4115,10 @@ terser-webpack-plugin@^1.4.3:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
-terser@^4.1.2:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
-  integrity sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==
+terser@^4.1.2, terser@^4.8.1:
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.1.tgz#a00e5634562de2239fd404c649051bf6fc21144f"
+  integrity sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"


### PR DESCRIPTION
### Description
1. Cherry-picked `2.1` to `2.2` version bump commit.
2. Cherry-picked `terser` version bump commit to address dependabot alert.
3. Cherry-picked release notes commit.
4. Enabled unit and cypress test workflows on all PRs.
5. Adjusted OSD version used by unit and cypress tests to align with OSD branching strategy.
6. Updated a website link in the `README` file that was broken when ODFE was deprecated.
7. Adjusted path for a dependency used by unit tests to align with migration from `EUI` to `OUI`.

Will be closing https://github.com/opensearch-project/index-management-dashboards-plugin/pull/224 in favor of this PR.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
