### PR TITLE
Remove extra forward slash for URL to snapshot management docs

### DIFF
--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -14,7 +14,7 @@ export const STATES_DOCUMENTATION_URL = "https://opensearch.org/docs/im-plugin/i
 export const ERROR_NOTIFICATION_DOCUMENTATION_URL = "https://opensearch.org/docs/im-plugin/ism/policies/#error-notifications";
 export const TRANSITION_DOCUMENTATION_URL = "https://opensearch.org/docs/im-plugin/ism/policies/#transitions";
 
-export const SNAPSHOT_MANAGEMENT_DOCUMENTATION_URL = "https://opensearch.org//docs/latest/opensearch/snapshots/snapshot-management/";
+export const SNAPSHOT_MANAGEMENT_DOCUMENTATION_URL = "https://opensearch.org/docs/latest/opensearch/snapshots/snapshot-management/";
 export const CRON_EXPRESSION_DOCUMENTATION_URL = "https://opensearch.org/docs/latest/monitoring-plugins/alerting/cron/";
 export const RESTORE_SNAPSHOT_DOCUMENTATION_URL =
   "https://opensearch.org/docs/latest/opensearch/snapshots/snapshot-restore/#restore-snapshots";


### PR DESCRIPTION
Removed the extra forward slash leading to a non-existing documentation page for snapshot management

Signed-off-by: Victor Nilsson <victor.nilsson@etraveligroup.com>

### Description
Simple change to remove the extra forward slash in the URL for snapshot management. Described in issue [226](https://github.com/opensearch-project/index-management-dashboards-plugin/issues/226).

### Issues Resolved
[226](https://github.com/opensearch-project/index-management-dashboards-plugin/issues/226)

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
