### PR TITLE
Change alignment of Snapshot Management panels in pages/Main/Main.tsx

### DIFF
--- a/cypress/integration/rollups_spec.js
+++ b/cypress/integration/rollups_spec.js
@@ -16,8 +16,6 @@ describe("Rollups", () => {
     // Go to sample data page
     cy.visit(`${Cypress.env("opensearch_dashboards")}/app/home#/tutorial_directory/sampleData`);
 
-    // Click on "Sample data" tab
-    // cy.contains("Sample data").click({ force: true });
     // Load sample eCommerce data
     cy.get(`button[data-test-subj="addSampleDataSetecommerce"]`).click({ force: true });
 

--- a/cypress/integration/rollups_spec.js
+++ b/cypress/integration/rollups_spec.js
@@ -17,7 +17,7 @@ describe("Rollups", () => {
     cy.visit(`${Cypress.env("opensearch_dashboards")}/app/home#/tutorial_directory/sampleData`);
 
     // Click on "Sample data" tab
-    cy.contains("Sample data").click({ force: true });
+    // cy.contains("Sample data").click({ force: true });
     // Load sample eCommerce data
     cy.get(`button[data-test-subj="addSampleDataSetecommerce"]`).click({ force: true });
 

--- a/public/components/ContentPanel/ContentPanel.tsx
+++ b/public/components/ContentPanel/ContentPanel.tsx
@@ -40,7 +40,7 @@ const ContentPanel: React.SFC<ContentPanelProps> = ({
   children,
 }) => (
   <EuiPanel style={{ paddingLeft: "0px", paddingRight: "0px", ...panelStyles }}>
-    <EuiFlexGroup style={{ padding: "0px 10px" }} justifyContent="spaceBetween" alignItems="center">
+    <EuiFlexGroup style={{ padding: "0px 10px" }} justifyContent="spaceBetween" alignItems="flexStart">
       <EuiFlexItem>
         {typeof title === "string" ? (
           <EuiTitle size={titleSize}>

--- a/public/components/ContentPanel/__snapshots__/ContentPanel.test.tsx.snap
+++ b/public/components/ContentPanel/__snapshots__/ContentPanel.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<ContentPanel /> spec renders the component 1`] = `
   style="padding-left: 0px; padding-right: 0px;"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
     style="padding: 0px 10px;"
   >
     <div

--- a/public/pages/ChangePolicy/components/ChangeManagedIndices/__snapshots__/ChangeManagedIndices.test.tsx.snap
+++ b/public/pages/ChangePolicy/components/ChangeManagedIndices/__snapshots__/ChangeManagedIndices.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<ChangeManagedIndices /> spec renders the component 1`] = `
   style="padding-left: 0px; padding-right: 0px;"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
     style="padding: 0px 10px;"
   >
     <div

--- a/public/pages/ChangePolicy/components/NewPolicy/__snapshots__/NewPolicy.test.tsx.snap
+++ b/public/pages/ChangePolicy/components/NewPolicy/__snapshots__/NewPolicy.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<NewPolicy /> spec renders the component 1`] = `
   style="padding-left: 0px; padding-right: 0px;"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
     style="padding: 0px 10px;"
   >
     <div

--- a/public/pages/ChangePolicy/containers/ChangePolicy/__snapshots__/ChangePolicy.test.tsx.snap
+++ b/public/pages/ChangePolicy/containers/ChangePolicy/__snapshots__/ChangePolicy.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
     style="padding-left: 0px; padding-right: 0px;"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
       style="padding: 0px 10px;"
     >
       <div
@@ -211,7 +211,7 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
     style="padding-left: 0px; padding-right: 0px;"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
       style="padding: 0px 10px;"
     >
       <div

--- a/public/pages/CreatePolicy/components/ConfigurePolicy/__snapshots__/ConfigurePolicy.test.tsx.snap
+++ b/public/pages/CreatePolicy/components/ConfigurePolicy/__snapshots__/ConfigurePolicy.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<ConfigurePolicy /> spec renders the component 1`] = `
   style="padding-left: 0px; padding-right: 0px;"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
     style="padding: 0px 10px;"
   >
     <div

--- a/public/pages/CreatePolicy/components/DefinePolicy/__snapshots__/DefinePolicy.test.tsx.snap
+++ b/public/pages/CreatePolicy/components/DefinePolicy/__snapshots__/DefinePolicy.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<DefinePolicy /> spec renders the component 1`] = `
   style="padding-left: 0px; padding-right: 0px;"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
     style="padding: 0px 10px;"
   >
     <div

--- a/public/pages/CreatePolicy/containers/CreatePolicy/__snapshots__/CreatePolicy.test.tsx.snap
+++ b/public/pages/CreatePolicy/containers/CreatePolicy/__snapshots__/CreatePolicy.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`<CreatePolicy /> spec renders the create component 1`] = `
     style="padding-left: 0px; padding-right: 0px;"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
       style="padding: 0px 10px;"
     >
       <div
@@ -103,7 +103,7 @@ exports[`<CreatePolicy /> spec renders the create component 1`] = `
     style="padding-left: 0px; padding-right: 0px;"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
       style="padding: 0px 10px;"
     >
       <div
@@ -345,7 +345,7 @@ exports[`<CreatePolicy /> spec renders the edit component 1`] = `
     style="padding-left: 0px; padding-right: 0px;"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
       style="padding: 0px 10px;"
     >
       <div
@@ -431,7 +431,7 @@ exports[`<CreatePolicy /> spec renders the edit component 1`] = `
     style="padding-left: 0px; padding-right: 0px;"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
       style="padding: 0px 10px;"
     >
       <div

--- a/public/pages/CreateRollup/containers/CreateRollupForm/__snapshots__/CreateRollupForm.test.tsx.snap
+++ b/public/pages/CreateRollup/containers/CreateRollupForm/__snapshots__/CreateRollupForm.test.tsx.snap
@@ -164,7 +164,7 @@ exports[`<CreateRollupForm /> spec renders the component 1`] = `
             style="padding-left: 0px; padding-right: 0px;"
           >
             <div
-              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
               style="padding: 0px 10px;"
             >
               <div
@@ -293,7 +293,7 @@ exports[`<CreateRollupForm /> spec renders the component 1`] = `
             style="padding-left: 0px; padding-right: 0px;"
           >
             <div
-              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
               style="padding: 0px 10px;"
             >
               <div

--- a/public/pages/CreateTransform/containers/CreateTransformForm/__snapshots__/CreateTransformForm.test.tsx.snap
+++ b/public/pages/CreateTransform/containers/CreateTransformForm/__snapshots__/CreateTransformForm.test.tsx.snap
@@ -166,7 +166,7 @@ exports[`<CreateTransformForm /> spec renders the component 1`] = `
             style="padding: 20px 20px;"
           >
             <div
-              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
               style="padding: 0px 10px;"
             >
               <div
@@ -291,7 +291,7 @@ exports[`<CreateTransformForm /> spec renders the component 1`] = `
               style="padding: 20px 20px;"
             >
               <div
-                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
                 style="padding: 0px 10px;"
               >
                 <div

--- a/public/pages/EditRollup/containers/__snapshots__/EditRollup.test.tsx.snap
+++ b/public/pages/EditRollup/containers/__snapshots__/EditRollup.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`<EditRollup /> spec renders the component 1`] = `
     style="padding-left: 0px; padding-right: 0px;"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
       style="padding: 0px 10px;"
     >
       <div
@@ -147,7 +147,7 @@ exports[`<EditRollup /> spec renders the component 1`] = `
     style="padding-left: 0px; padding-right: 0px;"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
       style="padding: 0px 10px;"
     >
       <div

--- a/public/pages/Indices/containers/Indices/__snapshots__/Indices.test.tsx.snap
+++ b/public/pages/Indices/containers/Indices/__snapshots__/Indices.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<Indices /> spec renders the component 1`] = `
   style="padding-left: 0px; padding-right: 0px;"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
     style="padding: 0px 10px;"
   >
     <div

--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -171,23 +171,29 @@ export default class Main extends Component<MainProps, object> {
                           <Route
                             path={ROUTES.SNAPSHOTS}
                             render={(props: RouteComponentProps) => (
-                              <Snapshots
-                                {...props}
-                                snapshotManagementService={services.snapshotManagementService}
-                                indexService={services.indexService}
-                              />
+                              <div style={{ padding: "25px 25px" }}>
+                                <Snapshots
+                                  {...props}
+                                  snapshotManagementService={services.snapshotManagementService}
+                                  indexService={services.indexService}
+                                />
+                              </div>
                             )}
                           />
                           <Route
                             path={ROUTES.REPOSITORIES}
                             render={(props: RouteComponentProps) => (
-                              <Repositories {...props} snapshotManagementService={services.snapshotManagementService} />
+                              <div style={{ padding: "25px 25px" }}>
+                                <Repositories {...props} snapshotManagementService={services.snapshotManagementService} />
+                              </div>
                             )}
                           />
                           <Route
                             path={ROUTES.SNAPSHOT_POLICIES}
                             render={(props: RouteComponentProps) => (
-                              <SnapshotPolicies {...props} snapshotManagementService={services.snapshotManagementService} />
+                              <div style={{ padding: "25px 25px" }}>
+                                <SnapshotPolicies {...props} snapshotManagementService={services.snapshotManagementService} />
+                              </div>
                             )}
                           />
                           <Route
@@ -331,7 +337,7 @@ export default class Main extends Component<MainProps, object> {
                           <Route
                             path={ROUTES.TRANSFORMS}
                             render={(props: RouteComponentProps) => (
-                              <div>
+                              <div style={{ padding: "25px 25px" }}>
                                 <Transforms {...props} transformService={services.transformService} />
                               </div>
                             )}

--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -150,6 +150,8 @@ export default class Main extends Component<MainProps, object> {
 
     const { landingPage } = this.props;
 
+    const ROUTE_STYLE = { padding: "25px 25px" };
+
     return (
       <CoreServicesConsumer>
         {(core: CoreStart | null) =>
@@ -171,7 +173,7 @@ export default class Main extends Component<MainProps, object> {
                           <Route
                             path={ROUTES.SNAPSHOTS}
                             render={(props: RouteComponentProps) => (
-                              <div style={{ padding: "25px 25px" }}>
+                              <div style={ROUTE_STYLE}>
                                 <Snapshots
                                   {...props}
                                   snapshotManagementService={services.snapshotManagementService}
@@ -183,7 +185,7 @@ export default class Main extends Component<MainProps, object> {
                           <Route
                             path={ROUTES.REPOSITORIES}
                             render={(props: RouteComponentProps) => (
-                              <div style={{ padding: "25px 25px" }}>
+                              <div style={ROUTE_STYLE}>
                                 <Repositories {...props} snapshotManagementService={services.snapshotManagementService} />
                               </div>
                             )}
@@ -191,7 +193,7 @@ export default class Main extends Component<MainProps, object> {
                           <Route
                             path={ROUTES.SNAPSHOT_POLICIES}
                             render={(props: RouteComponentProps) => (
-                              <div style={{ padding: "25px 25px" }}>
+                              <div style={ROUTE_STYLE}>
                                 <SnapshotPolicies {...props} snapshotManagementService={services.snapshotManagementService} />
                               </div>
                             )}
@@ -273,7 +275,7 @@ export default class Main extends Component<MainProps, object> {
                           <Route
                             path={ROUTES.INDEX_POLICIES}
                             render={(props: RouteComponentProps) => (
-                              <div style={{ padding: "25px 25px" }}>
+                              <div style={ROUTE_STYLE}>
                                 <Policies {...props} policyService={services.policyService} />
                               </div>
                             )}
@@ -281,7 +283,7 @@ export default class Main extends Component<MainProps, object> {
                           <Route
                             path={ROUTES.POLICY_DETAILS}
                             render={(props: RouteComponentProps) => (
-                              <div style={{ padding: "25px 25px" }}>
+                              <div style={ROUTE_STYLE}>
                                 <PolicyDetails {...props} policyService={services.policyService} />
                               </div>
                             )}
@@ -289,7 +291,7 @@ export default class Main extends Component<MainProps, object> {
                           <Route
                             path={ROUTES.MANAGED_INDICES}
                             render={(props: RouteComponentProps) => (
-                              <div>
+                              <div style={ROUTE_STYLE}>
                                 <ManagedIndices {...props} managedIndexService={services.managedIndexService} />
                               </div>
                             )}
@@ -297,7 +299,7 @@ export default class Main extends Component<MainProps, object> {
                           <Route
                             path={ROUTES.INDICES}
                             render={(props: RouteComponentProps) => (
-                              <div style={{ padding: "25px 25px" }}>
+                              <div style={ROUTE_STYLE}>
                                 <Indices {...props} indexService={services.indexService} />
                               </div>
                             )}
@@ -305,7 +307,7 @@ export default class Main extends Component<MainProps, object> {
                           <Route
                             path={ROUTES.ROLLUPS}
                             render={(props: RouteComponentProps) => (
-                              <div style={{ padding: "25px 25px" }}>
+                              <div style={ROUTE_STYLE}>
                                 <Rollups {...props} rollupService={services.rollupService} />
                               </div>
                             )}
@@ -313,7 +315,7 @@ export default class Main extends Component<MainProps, object> {
                           <Route
                             path={ROUTES.CREATE_ROLLUP}
                             render={(props: RouteComponentProps) => (
-                              <div style={{ padding: "25px 25px" }}>
+                              <div style={ROUTE_STYLE}>
                                 <CreateRollupForm {...props} rollupService={services.rollupService} indexService={services.indexService} />
                               </div>
                             )}
@@ -321,7 +323,7 @@ export default class Main extends Component<MainProps, object> {
                           <Route
                             path={ROUTES.EDIT_ROLLUP}
                             render={(props: RouteComponentProps) => (
-                              <div style={{ padding: "25px 25px" }}>
+                              <div style={ROUTE_STYLE}>
                                 <EditRollup {...props} rollupService={services.rollupService} />
                               </div>
                             )}
@@ -329,7 +331,7 @@ export default class Main extends Component<MainProps, object> {
                           <Route
                             path={ROUTES.ROLLUP_DETAILS}
                             render={(props: RouteComponentProps) => (
-                              <div style={{ padding: "25px 25px" }}>
+                              <div style={ROUTE_STYLE}>
                                 <RollupDetails {...props} rollupService={services.rollupService} />
                               </div>
                             )}
@@ -337,7 +339,7 @@ export default class Main extends Component<MainProps, object> {
                           <Route
                             path={ROUTES.TRANSFORMS}
                             render={(props: RouteComponentProps) => (
-                              <div style={{ padding: "25px 25px" }}>
+                              <div style={ROUTE_STYLE}>
                                 <Transforms {...props} transformService={services.transformService} />
                               </div>
                             )}
@@ -345,7 +347,7 @@ export default class Main extends Component<MainProps, object> {
                           <Route
                             path={ROUTES.CREATE_TRANSFORM}
                             render={(props: RouteComponentProps) => (
-                              <div style={{ padding: "25px 25px" }}>
+                              <div style={ROUTE_STYLE}>
                                 <CreateTransformForm
                                   {...props}
                                   rollupService={services.rollupService}
@@ -358,7 +360,7 @@ export default class Main extends Component<MainProps, object> {
                           <Route
                             path={ROUTES.EDIT_TRANSFORM}
                             render={(props: RouteComponentProps) => (
-                              <div style={{ padding: "25px 25px" }}>
+                              <div style={ROUTE_STYLE}>
                                 <EditTransform {...props} transformService={services.transformService} />
                               </div>
                             )}
@@ -366,7 +368,7 @@ export default class Main extends Component<MainProps, object> {
                           <Route
                             path={ROUTES.TRANSFORM_DETAILS}
                             render={(props: RouteComponentProps) => (
-                              <div style={{ padding: "25px 25px" }}>
+                              <div style={ROUTE_STYLE}>
                                 <TransformDetails {...props} transformService={services.transformService} />
                               </div>
                             )}

--- a/public/pages/ManagedIndices/containers/ManagedIndices/__snapshots__/ManagedIndices.test.tsx.snap
+++ b/public/pages/ManagedIndices/containers/ManagedIndices/__snapshots__/ManagedIndices.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
     style="padding-left: 0px; padding-right: 0px;"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
       style="padding: 0px 10px;"
     >
       <div

--- a/public/pages/Policies/containers/Policies/__snapshots__/Policies.test.tsx.snap
+++ b/public/pages/Policies/containers/Policies/__snapshots__/Policies.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`<IndexPolicies /> spec renders the component 1`] = `
     style="padding-left: 0px; padding-right: 0px;"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
       style="padding: 0px 10px;"
     >
       <div

--- a/public/pages/PolicyDetails/components/PolicySettings/__snapshots__/PolicySettings.test.tsx.snap
+++ b/public/pages/PolicyDetails/components/PolicySettings/__snapshots__/PolicySettings.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<PolicySettings /> spec renders the component 1`] = `
   style="padding-left: 0px; padding-right: 0px;"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
     style="padding: 0px 10px;"
   >
     <div

--- a/public/pages/Snapshots/containers/Snapshots/Snapshots.tsx
+++ b/public/pages/Snapshots/containers/Snapshots/Snapshots.tsx
@@ -269,6 +269,7 @@ export default class Snapshots extends Component<SnapshotsProps, SnapshotsState>
       <EuiButton onClick={this.onClickCreate} fill={true}>
         Take snapshot
       </EuiButton>,
+      <EuiButton disabled={!selectedItems.length}>Restore</EuiButton>,
     ];
 
     const subTitleText = (

--- a/public/pages/Snapshots/containers/Snapshots/Snapshots.tsx
+++ b/public/pages/Snapshots/containers/Snapshots/Snapshots.tsx
@@ -269,7 +269,9 @@ export default class Snapshots extends Component<SnapshotsProps, SnapshotsState>
       <EuiButton onClick={this.onClickCreate} fill={true}>
         Take snapshot
       </EuiButton>,
-      <EuiButton disabled={!selectedItems.length}>Restore</EuiButton>,
+      <EuiButton disabled={!selectedItems.length} color="secondary">
+        Restore
+      </EuiButton>,
     ];
 
     const subTitleText = (

--- a/public/pages/Transforms/containers/Transforms/__snapshots__/EditTransform.test.tsx.snap
+++ b/public/pages/Transforms/containers/Transforms/__snapshots__/EditTransform.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`<EditTransform /> spec renders the component 1`] = `
     style="padding-left: 0px; padding-right: 0px;"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
       style="padding: 0px 10px;"
     >
       <div
@@ -147,7 +147,7 @@ exports[`<EditTransform /> spec renders the component 1`] = `
     style="padding-left: 0px; padding-right: 0px;"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
       style="padding: 0px 10px;"
     >
       <div
@@ -320,7 +320,7 @@ exports[`<EditTransform /> spec renders the component 1`] = `
     style="padding-left: 0px; padding-right: 0px;"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
       style="padding: 0px 10px;"
     >
       <div

--- a/public/pages/VisualCreatePolicy/components/ISMTemplates/__snapshots__/ISMTemplates.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/ISMTemplates/__snapshots__/ISMTemplates.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<ISMTemplates /> spec renders the component 1`] = `
   style="padding-left: 0px; padding-right: 0px;"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
     style="padding: 0px 10px;"
   >
     <div

--- a/public/pages/VisualCreatePolicy/components/PolicyInfo/__snapshots__/PolicyInfo.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/PolicyInfo/__snapshots__/PolicyInfo.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<PolicyInfo /> spec renders the component 1`] = `
   style="padding-left: 0px; padding-right: 0px;"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
     style="padding: 0px 10px;"
   >
     <div

--- a/public/pages/VisualCreatePolicy/components/States/__snapshots__/States.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/States/__snapshots__/States.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<States /> spec renders the component 1`] = `
   style="padding-left: 0px; padding-right: 0px;"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
     style="padding: 0px 10px;"
   >
     <div

--- a/public/pages/VisualCreatePolicy/containers/ErrorNotification/__snapshots__/ErrorNotification.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/ErrorNotification/__snapshots__/ErrorNotification.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<ErrorNotification /> spec renders the component 1`] = `
   style="padding-left: 0px; padding-right: 0px;"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
     style="padding: 0px 10px;"
   >
     <div


### PR DESCRIPTION
This was done to maintain consistent positioning across Index
Management panels and Snapshot Management panels. Also did the same
for Transform Jobs panel. Signed-off-by: Chris Hesterman
<phestech@amazon.com>

### Description
Provides visually consistent positioning of Index Management  and Snapshot Management panels.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
