### PR TITLE
[Backport 2.x] Version increment 2.2.1

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -8,7 +8,7 @@ on:
       - "*"
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '2.2'
-  OPENSEARCH_VERSION: '2.2.0-SNAPSHOT'
+  OPENSEARCH_VERSION: '2.2.1-SNAPSHOT'
 jobs:
   tests:
     name: Run Cypress E2E tests

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "indexManagementDashboards",
-  "version": "2.2.0.0",
-  "opensearchDashboardsVersion": "2.2.0",
+  "version": "2.2.1.0",
+  "opensearchDashboardsVersion": "2.2.1",
   "configPath": ["opensearch_index_management"],
   "requiredPlugins": ["navigation"],
   "server": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch_index_management_dashboards",
-  "version": "2.2.0.0",
+  "version": "2.2.1.0",
   "description": "Opensearch Dashboards plugin for Index Management",
   "main": "index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Description
Manual backport of https://github.com/opensearch-project/index-management-dashboards-plugin/pull/235.
Closing https://github.com/opensearch-project/index-management-dashboards-plugin/pull/237 and https://github.com/opensearch-project/index-management-dashboards-plugin/pull/238 in favor of this PR.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
