### PR TITLE
Transform scripted popup UI improvements

### DIFF
--- a/public/app.scss
+++ b/public/app.scss
@@ -45,6 +45,7 @@ $euiTextColor: $euiColorDarkestShade !default;
   text-decoration: none;
 }
 
+// Allows script field to use full width and resize vertically
 .scripted-metrics-panel {
   &__form-row {
     overflow: auto;

--- a/public/app.scss
+++ b/public/app.scss
@@ -44,3 +44,28 @@ $euiTextColor: $euiColorDarkestShade !default;
 .state-accordion:hover {
   text-decoration: none;
 }
+
+.scripted-metrics-panel {
+  &__form-row {
+    overflow: auto;
+    resize: vertical;
+
+    .euiFormRow__fieldWrapper {
+      flex: 1 1 auto;
+      width: 100%;
+
+      .euiCodeEditorWrapper {
+        height: 100% !important;
+      }
+    }
+  }
+
+  &__code-editor {
+    width: auto !important;
+    height: 100% !important;
+
+    .ace_scroller {
+      overflow-y: auto;
+    }
+  }
+}

--- a/public/pages/CreateTransform/components/DefineTransforms/DefineTransforms.tsx
+++ b/public/pages/CreateTransform/components/DefineTransforms/DefineTransforms.tsx
@@ -25,7 +25,7 @@ interface DefineTransformsProps {
   onGroupSelectionChange: (selectedFields: TransformGroupItem[], aggItem: TransformAggItem) => void;
   selectedAggregations: any;
   aggList: TransformAggItem[];
-  onAggregationSelectionChange: (selectedFields: any, aggItem: TransformAggItem) => void;
+  onAggregationSelectionChange: (selectedFields: any, aggItem: TransformAggItem) => Promise<boolean>;
   onEditTransformation: (oldName: string, newName: string) => void;
   onRemoveTransformation: (name: string) => void;
   previewTransform: any[];
@@ -162,7 +162,7 @@ export default function DefineTransforms({
     }
     const val = data[rowIndex]._source[columnId];
     return val !== undefined ? JSON.stringify(val) : "-";
-  }
+  };
 
   //TODO: remove duplicate code here after extracting the first table as separate component
   if (isReadOnly)

--- a/public/pages/CreateTransform/components/TransformOptions/Panels/PercentilePanel/PercentilePanel.tsx
+++ b/public/pages/CreateTransform/components/TransformOptions/Panels/PercentilePanel/PercentilePanel.tsx
@@ -10,7 +10,7 @@ import { TRANSFORM_AGG_TYPE, TransformAggItem } from "../../../../../../../model
 interface PercentilePanelProps {
   name: string;
   aggSelection: any;
-  handleAggSelectionChange: (aggItem: TransformAggItem) => void;
+  handleAggSelectionChange: (aggItem: TransformAggItem) => Promise<void>;
   closePopover: () => void;
 }
 

--- a/public/pages/CreateTransform/components/TransformOptions/Panels/ScriptedMetricsPanel/ScriptedMetricsPanel.tsx
+++ b/public/pages/CreateTransform/components/TransformOptions/Panels/ScriptedMetricsPanel/ScriptedMetricsPanel.tsx
@@ -10,7 +10,7 @@ import { TRANSFORM_AGG_TYPE, TransformAggItem } from "../../../../../../../model
 interface ScriptedMetricsPanelProps {
   name: string;
   aggSelection: any;
-  handleAggSelectionChange: (aggItem: TransformAggItem) => void;
+  handleAggSelectionChange: (aggItem: TransformAggItem) => Promise<void>;
   closePopover: () => void;
 }
 
@@ -20,12 +20,14 @@ export default function ScriptedMetricsPanel({ name, aggSelection, handleAggSele
   return (
     <EuiPanel>
       <EuiForm>
-        <EuiFormRow label="Scripted metrics">
+        <EuiFormRow label="Scripted metrics" fullWidth className="scripted-metrics-panel__form-row">
           <EuiCodeEditor
-            style={{ width: 0.38 * window.innerWidth, height: 0.4 * window.innerHeight }}
+            style={{ minHeight: 0.4 * window.innerHeight }}
             value={script}
             onChange={(value: string) => setScript(value)}
             mode="json"
+            className="scripted-metrics-panel__code-editor"
+            maxLines={Infinity}
           />
         </EuiFormRow>
         <EuiSpacer />

--- a/public/pages/CreateTransform/components/TransformOptions/TransformOptions.tsx
+++ b/public/pages/CreateTransform/components/TransformOptions/TransformOptions.tsx
@@ -29,7 +29,7 @@ interface TransformOptionsProps {
   onGroupSelectionChange: (selectedFields: TransformGroupItem[], aggItem: TransformAggItem) => void;
   selectedAggregations: any;
   aggList: TransformAggItem[];
-  onAggregationSelectionChange: (selectedFields: any, aggItem: TransformAggItem) => void;
+  onAggregationSelectionChange: (selectedFields: any, aggItem: TransformAggItem) => Promise<boolean>;
 }
 
 export default function TransformOptions({
@@ -62,9 +62,18 @@ export default function TransformOptions({
     });
     closePopover();
   };
-  const handleAggSelectionChange = (aggItem: TransformAggItem): void => {
-    onAggregationSelectionChange(aggSelection, aggItem);
-    closePopover();
+  const handleAggSelectionChange = async (aggItem: TransformAggItem): Promise<void> => {
+    // For scripted metric, wait until success to close
+    if (aggItem.type === TRANSFORM_AGG_TYPE.scripted_metric) {
+      const result = await onAggregationSelectionChange(aggSelection, aggItem);
+
+      if (result) {
+        closePopover();
+      }
+    } else {
+      onAggregationSelectionChange(aggSelection, aggItem);
+      closePopover();
+    }
   };
 
   const numberPanels: EuiContextMenuPanelDescriptor[] = [

--- a/public/pages/CreateTransform/containers/CreateTransformForm/CreateTransformForm.tsx
+++ b/public/pages/CreateTransform/containers/CreateTransformForm/CreateTransformForm.tsx
@@ -341,15 +341,20 @@ export default class CreateTransformForm extends Component<CreateTransformFormPr
     else await this.onRemoveTransformation(aggItem.name);
   };
 
-  onAggregationSelectionChange = async (selectedAggregations: any, aggItem: TransformAggItem): Promise<void> => {
+  onAggregationSelectionChange = async (selectedAggregations: any, aggItem: TransformAggItem): Promise<boolean> => {
     const { aggList } = this.state;
     aggList.push(aggItem);
     this.updateAggregation();
     const previewSuccess = await this.previewTransform(this.state.transformJSON);
 
     // If preview successfully update aggregations, else remove from list of transformation
-    if (previewSuccess) this.setState({ selectedAggregations: selectedAggregations });
-    else await this.onRemoveTransformation(aggItem.name);
+    if (previewSuccess) {
+      this.setState({ selectedAggregations: selectedAggregations });
+      return true;
+    }
+
+    await this.onRemoveTransformation(aggItem.name);
+    return false;
   };
 
   onEditTransformation = async (oldName: string, newName: string): Promise<void> => {

--- a/public/pages/CreateTransform/containers/DefineTransformsStep/DefineTransformsStep.tsx
+++ b/public/pages/CreateTransform/containers/DefineTransformsStep/DefineTransformsStep.tsx
@@ -23,7 +23,7 @@ interface DefineTransformsStepProps extends RouteComponentProps {
   onGroupSelectionChange: (selectedFields: TransformGroupItem[], aggItem: TransformAggItem) => void;
   selectedAggregations: any;
   aggList: TransformAggItem[];
-  onAggregationSelectionChange: (selectedFields: any, aggItem: TransformAggItem) => void;
+  onAggregationSelectionChange: (selectedFields: any, aggItem: TransformAggItem) => Promise<boolean>;
   onEditTransformation: (oldName: string, newName: string) => void;
   onRemoveTransformation: (name: string) => void;
   previewTransform: any[];

--- a/public/pages/CreateTransform/containers/ReviewAndCreateStep/ReviewAndCreateStep.tsx
+++ b/public/pages/CreateTransform/containers/ReviewAndCreateStep/ReviewAndCreateStep.tsx
@@ -34,7 +34,7 @@ interface ReviewAndCreateStepProps extends RouteComponentProps {
   onGroupSelectionChange: (selectedFields: TransformGroupItem[], aggItem: TransformAggItem) => void;
   selectedAggregations: any;
   aggList: TransformAggItem[];
-  onAggregationSelectionChange: (selectedFields: any, aggItem: TransformAggItem) => void;
+  onAggregationSelectionChange: (selectedFields: any, aggItem: TransformAggItem) => Promise<boolean>;
   onRemoveTransformation: (name: string) => void;
   previewTransform: any[];
 


### PR DESCRIPTION
### Description
- Allow script field to take up full width of popup panel
- Allows script field to be vertically resizable
- Disable auto-close of script popup when errors detected
- Update types accordingly

### Issues Resolved
This is a partial fix for https://github.com/opensearch-project/index-management-dashboards-plugin/issues/96 , because it does not include 

> Have a more reliable mapping for supported field types to aggregations/groupings

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
