### PR TITLE
fix index query not take user input

### DIFF
--- a/public/services/IndexService.ts
+++ b/public/services/IndexService.ts
@@ -38,7 +38,15 @@ export default class IndexService {
 
   getDataStreamsAndIndicesNames = async (searchValue: string): Promise<ServerResponse<GetDataStreamsAndIndicesNamesResponse>> => {
     const [getIndicesResponse, getDataStreamsResponse] = await Promise.all([
-      this.getIndices({ from: 0, size: 10, search: searchValue, sortDirection: "desc", sortField: "index", showDataStreams: true }),
+      this.getIndices({
+        from: 0,
+        size: 10,
+        search: searchValue,
+        terms: [searchValue],
+        sortDirection: "desc",
+        sortField: "index",
+        showDataStreams: true,
+      }),
       this.getDataStreams({ search: searchValue }),
     ]);
 


### PR DESCRIPTION
### Description

`getDataStreamsAndIndicesNames` this method take searchValue as parameter, but the actual call `cat indices` api call use another parameter `terms` as query criteria and ignore the `search` parameter, that makes 

```
const params = {
        index: getSearchString(terms, indices, dataStreams),
        format: "json",
        s: `${sortField}:${sortDirection}`,
      };
callWithRequest("cat.indices", params),
```

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
