### PR TITLE
feat: enable inheritting from template function when creating index

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -129,6 +129,14 @@ Cypress.Commands.add("createIndexTemplate", (name, template) => {
   cy.request("PUT", `${Cypress.env("opensearch")}${API.INDEX_TEMPLATE_BASE}/${name}`, template);
 });
 
+Cypress.Commands.add("deleteTemplate", (name) => {
+  cy.request({
+    url: `${Cypress.env("opensearch")}${API.INDEX_TEMPLATE_BASE}/${name}`,
+    failOnStatusCode: false,
+    method: "DELETE",
+  });
+});
+
 Cypress.Commands.add("createDataStream", (name) => {
   cy.request("PUT", `${Cypress.env("opensearch")}${API.DATA_STREAM_BASE}/${name}`);
 });

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -104,5 +104,12 @@ declare namespace Cypress {
      * cy.disableJitter()
      */
     disableJitter(): Chainable<any>;
+
+    /**
+     * Delete template
+     * @example
+     * cy.deleteTemplate("some_template")
+     */
+    deleteTemplate(name: string);
   }
 }

--- a/models/interfaces.ts
+++ b/models/interfaces.ts
@@ -53,6 +53,12 @@ export interface IndexItem {
   };
 }
 
+export interface IndexItemRemote extends Omit<IndexItem, "mappings"> {
+  mappings?: {
+    properties?: MappingsPropertiesObject;
+  };
+}
+
 /**
  * ManagedIndex item shown in the Managed Indices table
  */

--- a/public/pages/CreateIndex/components/AliasSelect/AliasSelect.test.tsx
+++ b/public/pages/CreateIndex/components/AliasSelect/AliasSelect.test.tsx
@@ -4,12 +4,14 @@
  */
 
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import AliasSelect from "./index";
 
 describe("<AliasSelect /> spec", () => {
-  it("renders the component", () => {
+  it("renders the component", async () => {
     const { container } = render(<AliasSelect refreshOptions={() => Promise.resolve({ ok: true, response: [] })} onChange={() => {}} />);
-    expect(container.firstChild).toMatchSnapshot();
+    await waitFor(() => {
+      expect(container.firstChild).toMatchSnapshot();
+    });
   });
 });

--- a/public/pages/CreateIndex/containers/CreateIndex/CreateIndex.tsx
+++ b/public/pages/CreateIndex/containers/CreateIndex/CreateIndex.tsx
@@ -9,7 +9,7 @@ import { RouteComponentProps } from "react-router-dom";
 import { get, pick, set } from "lodash";
 import { diffArrays } from "diff";
 import IndexDetail from "../../components/IndexDetail";
-import { IAliasAction, IndexItem, MappingsProperties } from "../../../../../models/interfaces";
+import { IAliasAction, IndexItem, IndexItemRemote, MappingsProperties } from "../../../../../models/interfaces";
 import { BREADCRUMBS, INDEX_DYNAMIC_SETTINGS, IndicesUpdateMode, ROUTES } from "../../../../utils/constants";
 import { CoreServicesContext } from "../../../../components/core_services";
 import { IIndexDetailRef, IndexDetailProps } from "../../components/IndexDetail/IndexDetail";
@@ -273,6 +273,27 @@ export default class CreateIndex extends Component<CreateIndexProps, CreateIndex
     this.setState({ isSubmitting: false });
   };
 
+  onSimulateIndexTemplate = (indexName: string) => {
+    return this.props.commonService
+      .apiCaller<{ template: IndexItemRemote }>({
+        endpoint: "transport.request",
+        data: {
+          path: `/_index_template/_simulate_index/${indexName}`,
+          method: "POST",
+        },
+      })
+      .then((res) => {
+        if (res.ok) {
+          return {
+            ...res,
+            response: res.response.template,
+          };
+        }
+
+        return res;
+      });
+  };
+
   render() {
     const isEdit = this.isEdit;
     const { indexDetail, isSubmitting, oldIndexDetail } = this.state;
@@ -290,6 +311,7 @@ export default class CreateIndex extends Component<CreateIndexProps, CreateIndex
           value={indexDetail}
           oldValue={oldIndexDetail}
           onChange={this.onDetailChange}
+          onSimulateIndexTemplate={this.onSimulateIndexTemplate}
           refreshOptions={(aliasName) =>
             this.props.commonService.apiCaller({
               endpoint: "cat.aliases",

--- a/public/pages/Indices/components/IndexDetail/index.tsx
+++ b/public/pages/Indices/components/IndexDetail/index.tsx
@@ -158,7 +158,7 @@ export default function IndexDetail(props: IndexDetailModalProps) {
                           valueContent = <ValueComponent detail={finalDetail} />;
                         }
                         return (
-                          <EuiFlexItem data-test-subj={`index-detail-overview-item-${item.label}`}>
+                          <EuiFlexItem key={item.label} data-test-subj={`index-detail-overview-item-${item.label}`}>
                             <EuiDescriptionListTitle>{item.label}</EuiDescriptionListTitle>
                             <EuiDescriptionListDescription>{valueContent}</EuiDescriptionListDescription>
                           </EuiFlexItem>


### PR DESCRIPTION
### Description
1. By leveraging the API of https://www.elastic.co/guide/en/elasticsearch/reference/7.10/indices-simulate-index.html to copy settings/mappings from v2 template.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
