### PR TITLE
add open index button & aliases to ShrinkIndexFlyout

### DIFF
--- a/cypress/integration/indices_spec.js
+++ b/cypress/integration/indices_spec.js
@@ -364,7 +364,7 @@ describe("Indices", () => {
       cy.get(`input[data-test-subj="targetIndexNameInput"]`).type(`${SAMPLE_INDEX}_shrunken`);
 
       // Click shrink index button
-      cy.get("button").contains("Shrink index").click({ force: true });
+      cy.get("button").contains("Shrink").click({ force: true });
 
       // Check for success toast
       cy.contains("Shrink index successfully");

--- a/public/pages/Indices/components/ShrinkIndexFlyout/ShrinkIndexFlyout.test.tsx
+++ b/public/pages/Indices/components/ShrinkIndexFlyout/ShrinkIndexFlyout.test.tsx
@@ -26,6 +26,10 @@ describe("<ShrinkIndexFlyout /> spec", () => {
         getIndexSettings={async () => {
           return {};
         }}
+        openIndex={() => {}}
+        getAlias={async () => {
+          return {};
+        }}
       />
     );
 
@@ -49,6 +53,11 @@ describe("<ShrinkIndexFlyout /> spec", () => {
         onConfirm={() => {}}
         onClose={onClose}
         getIndexSettings={async () => {
+          return {};
+        }}
+        setIndexSettings={() => {}}
+        openIndex={() => {}}
+        getAlias={async () => {
           return {};
         }}
       />
@@ -79,6 +88,10 @@ describe("<ShrinkIndexFlyout /> spec", () => {
           return {};
         }}
         setIndexSettings={setIndexSettings}
+        openIndex={() => {}}
+        getAlias={async () => {
+          return {};
+        }}
       />
     );
 
@@ -114,6 +127,11 @@ describe("<ShrinkIndexFlyout /> spec", () => {
         onConfirm={() => {}}
         onClose={onClose}
         getIndexSettings={getIndexSettings}
+        setIndexSettings={() => {}}
+        openIndex={() => {}}
+        getAlias={async () => {
+          return {};
+        }}
       />
     );
 
@@ -163,6 +181,11 @@ describe("<ShrinkIndexFlyout /> spec", () => {
         onConfirm={() => {}}
         onClose={onClose}
         getIndexSettings={getIndexSettings}
+        setIndexSettings={() => {}}
+        openIndex={() => {}}
+        getAlias={async () => {
+          return {};
+        }}
       />
     );
 
@@ -207,6 +230,11 @@ describe("<ShrinkIndexFlyout /> spec", () => {
         onConfirm={() => {}}
         onClose={() => {}}
         getIndexSettings={getIndexSettings}
+        setIndexSettings={() => {}}
+        openIndex={() => {}}
+        getAlias={async () => {
+          return {};
+        }}
       />
     );
 
@@ -214,8 +242,60 @@ describe("<ShrinkIndexFlyout /> spec", () => {
       expect(queryByText("The source index cannot shrink, due to the following reasons:")).not.toBeNull();
       expect(queryByText("The source index's health status is [red]!")).not.toBeNull();
       expect(queryByText("The source index has only one primary shard!")).not.toBeNull();
-      expect(queryByText("The source index must be in open status!")).not.toBeNull();
       expect(getByTestId("shrinkIndexConfirmButton")).toHaveAttribute("disabled");
+    });
+  });
+
+  it("shows button when source index cannot shrink", async () => {
+    const testIndexSettings = {
+      test_index: {
+        settings: {},
+      },
+    };
+    const getIndexSettings = jest.fn().mockResolvedValue(testIndexSettings);
+    const setIndexSettings = jest.fn();
+    const openIndex = jest.fn();
+    const getAlias = jest.fn();
+    const { getByTestId, queryByText } = render(
+      <ShrinkIndexFlyout
+        sourceIndex={{
+          health: "green",
+          index: "test_index",
+          pri: "10",
+          rep: "1",
+          status: "close",
+        }}
+        visible
+        onConfirm={() => {}}
+        onClose={() => {}}
+        getIndexSettings={getIndexSettings}
+        setIndexSettings={setIndexSettings}
+        openIndex={openIndex}
+        getAlias={getAlias}
+      />
+    );
+
+    await waitFor(() => {
+      expect(queryByText("The source index cannot shrink, due to the following reasons:")).not.toBeNull();
+      expect(queryByText("The source index must not be in close status!")).not.toBeNull();
+      expect(queryByText("The source index's write operations must be blocked.")).not.toBeNull();
+      expect(getByTestId("shrinkIndexConfirmButton")).toHaveAttribute("disabled");
+      expect(getByTestId("onOpenIndexButton")).not.toBeNull();
+      expect(getByTestId("onSetIndexWriteBlockButton")).not.toBeNull();
+    });
+
+    await act(async () => {
+      fireEvent.click(getByTestId("onOpenIndexButton"));
+    });
+    await waitFor(() => {
+      expect(openIndex).toHaveBeenCalled();
+    });
+
+    await act(async () => {
+      fireEvent.click(getByTestId("onSetIndexWriteBlockButton"));
+    });
+    await waitFor(() => {
+      expect(setIndexSettings).toHaveBeenCalled();
     });
   });
 
@@ -241,6 +321,11 @@ describe("<ShrinkIndexFlyout /> spec", () => {
         onConfirm={() => {}}
         onClose={() => {}}
         getIndexSettings={getIndexSettings}
+        setIndexSettings={() => {}}
+        openIndex={() => {}}
+        getAlias={async () => {
+          return {};
+        }}
       />
     );
 
@@ -278,6 +363,11 @@ describe("<ShrinkIndexFlyout /> spec", () => {
         onConfirm={onConfirm}
         onClose={() => {}}
         getIndexSettings={getIndexSettings}
+        setIndexSettings={() => {}}
+        openIndex={() => {}}
+        getAlias={async () => {
+          return {};
+        }}
       />
     );
 
@@ -288,7 +378,9 @@ describe("<ShrinkIndexFlyout /> spec", () => {
 
     await act(async () => {
       userEvent.type(getByTestId("targetIndexNameInput"), "test_index_shrunken");
+      userEvent.type(getByTestId("aliasesInput"), "test_index_alias");
     });
+
     await act(async () => {
       fireEvent.click(getByTestId("shrinkIndexConfirmButton"));
     });

--- a/public/pages/Indices/components/ShrinkIndexFlyout/__snapshots__/ShrinkIndexFlyout.test.tsx.snap
+++ b/public/pages/Indices/components/ShrinkIndexFlyout/__snapshots__/ShrinkIndexFlyout.test.tsx.snap
@@ -238,7 +238,7 @@ HTMLCollection [
                   <span
                     class="euiButton__text"
                   >
-                    Shrink index
+                    Shrink
                   </span>
                 </span>
               </button>

--- a/public/pages/Indices/components/ShrinkIndexFlyout/constants.ts
+++ b/public/pages/Indices/components/ShrinkIndexFlyout/constants.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export const DEDAULT_ADVANCED_INDEX_SETTINGS = {
+export const DEFAULT_INDEX_SETTINGS = {
   "index.number_of_shards": "1",
   "index.number_of_replicas": "1",
 };

--- a/public/pages/Indices/containers/IndicesActions/IndicesActions.test.tsx
+++ b/public/pages/Indices/containers/IndicesActions/IndicesActions.test.tsx
@@ -255,6 +255,20 @@ describe("<IndicesActions /> spec", () => {
                 },
               },
             };
+          case "cat.aliases":
+            return {
+              ok: true,
+              response: [
+                {
+                  alias: "a1",
+                  index: "acvxcvxc",
+                  filter: "-",
+                  "routing.index": "-",
+                  "routing.search": "-",
+                  is_write_index: "-",
+                },
+              ],
+            };
           case "indices.shrink":
             return {
               ok: true,
@@ -268,7 +282,7 @@ describe("<IndicesActions /> spec", () => {
       }
     );
 
-    const { container, getByTestId, findByTestId } = renderWithRouter({
+    const { container, getByTestId } = renderWithRouter({
       selectedItems: [
         {
           "docs.count": "5",
@@ -301,7 +315,7 @@ describe("<IndicesActions /> spec", () => {
     });
 
     await waitFor(() => {
-      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(3);
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(4);
       expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         endpoint: "indices.getSettings",
         data: {
@@ -314,6 +328,15 @@ describe("<IndicesActions /> spec", () => {
         data: {
           index: ["test_index"],
           format: "json",
+        },
+      });
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
+        endpoint: "cat.aliases",
+        method: "GET",
+        data: {
+          format: "json",
+          name: "*",
+          expand_wildcards: "open",
         },
       });
       expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({

--- a/public/pages/Indices/containers/IndicesActions/index.tsx
+++ b/public/pages/Indices/containers/IndicesActions/index.tsx
@@ -159,18 +159,21 @@ export default function IndicesActions(props: IndicesActionsProps) {
   };
 
   const onShrinkIndexFlyoutConfirm = useCallback(
-    async (sourceIndexName: string, targetIndexName: string, indexSettings: {}) => {
+    async (sourceIndexName: string, targetIndexName: string, requestPayload: Required<IndexItem>["settings"]) => {
       try {
-        const requestBody = {
-          settings: indexSettings,
-        };
+        const { aliases, ...settings } = requestPayload;
 
         const result = await services.commonService.apiCaller({
           endpoint: "indices.shrink",
           data: {
             index: sourceIndexName,
             target: targetIndexName,
-            body: requestBody,
+            body: {
+              settings: {
+                ...settings,
+              },
+              aliases,
+            },
           },
         });
         if (result && result.ok) {
@@ -350,6 +353,8 @@ export default function IndicesActions(props: IndicesActionsProps) {
           onConfirm={onShrinkIndexFlyoutConfirm}
           getIndexSettings={getIndexSettings}
           setIndexSettings={setIndexSettings}
+          openIndex={onOpenIndexModalConfirm}
+          getAlias={getAlias}
         />
       )}
 


### PR DESCRIPTION
Signed-off-by: Binlong Gao <gbinlong@amazon.com>

### Description
The main changes are:
1. Add open index button to the Shrink index flyout.
2. Add aliases input form to the Shrink index flyout.
3. Add more test cases.

### Issues Resolved

https://github.com/opensearch-project/index-management-dashboards-plugin/issues/397

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
