### PR TITLE
Disable shrink action if a data_stream is selected in indices page

### DIFF
--- a/public/pages/Indices/containers/IndicesActions/IndicesActions.test.tsx
+++ b/public/pages/Indices/containers/IndicesActions/IndicesActions.test.tsx
@@ -297,7 +297,7 @@ describe("<IndicesActions /> spec", () => {
           uuid: "some_uuid",
           managed: "",
           managedPolicy: "",
-          data_stream: "",
+          data_stream: null,
         },
       ],
       onShrink,
@@ -357,6 +357,87 @@ describe("<IndicesActions /> spec", () => {
       expect(onShrink).toHaveBeenCalledTimes(1);
     });
   }, 30000);
+
+  it("shrink action is disabled if multiple indices are selected", async () => {
+    const onShrink = jest.fn();
+
+    const { container, getByTestId } = renderWithRouter({
+      selectedItems: [
+        {
+          "docs.count": "5",
+          "docs.deleted": "2",
+          health: "green",
+          index: "test_index1",
+          pri: "3",
+          "pri.store.size": "100KB",
+          rep: "0",
+          status: "open",
+          "store.size": "100KB",
+          uuid: "some_uuid",
+          managed: "",
+          managedPolicy: "",
+        },
+        {
+          "docs.count": "5",
+          "docs.deleted": "2",
+          health: "green",
+          index: "test_index2",
+          pri: "3",
+          "pri.store.size": "100KB",
+          rep: "0",
+          status: "open",
+          "store.size": "100KB",
+          uuid: "some_uuid",
+          managed: "",
+          managedPolicy: "",
+        },
+      ],
+      onShrink,
+    });
+
+    await waitFor(() => {
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    userEvent.click(document.querySelector('[data-test-subj="More Action"] button') as Element);
+    await waitFor(() => {
+      expect(getByTestId("Shrink Action")).toBeDisabled();
+    });
+  });
+
+  it("shrink action is disabled if the selected index is data_stream", async () => {
+    const onShrink = jest.fn();
+
+    const { container, getByTestId } = renderWithRouter({
+      selectedItems: [
+        {
+          "docs.count": "5",
+          "docs.deleted": "2",
+          health: "green",
+          index: "test_index",
+          pri: "3",
+          "pri.store.size": "100KB",
+          rep: "0",
+          status: "open",
+          "store.size": "100KB",
+          uuid: "some_uuid",
+          managed: "",
+          managedPolicy: "",
+          data_stream: "test",
+        },
+      ],
+      onShrink,
+    });
+
+    await waitFor(() => {
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    userEvent.click(document.querySelector('[data-test-subj="More Action"] button') as Element);
+    await waitFor(() => {
+      expect(getByTestId("Shrink Action")).toBeDisabled();
+    });
+  });
 
   it("click reindex goes to new page with selected item ", async () => {
     const history = createMemoryHistory();

--- a/public/pages/Indices/containers/IndicesActions/__snapshots__/IndicesActions.test.tsx.snap
+++ b/public/pages/Indices/containers/IndicesActions/__snapshots__/IndicesActions.test.tsx.snap
@@ -108,6 +108,60 @@ exports[`<IndicesActions /> spec renders the component and all the actions shoul
 </div>
 `;
 
+exports[`<IndicesActions /> spec shrink action is disabled if multiple indices are selected 1`] = `
+<div
+  class="euiPopover euiPopover--anchorDownCenter"
+  data-test-subj="More Action"
+>
+  <div
+    class="euiPopover__anchor"
+  >
+    <button
+      class="euiButton euiButton--primary"
+      type="button"
+    >
+      <span
+        class="euiButtonContent euiButtonContent--iconRight euiButton__content"
+      >
+        EuiIconMock
+        <span
+          class="euiButton__text"
+        >
+          Actions
+        </span>
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<IndicesActions /> spec shrink action is disabled if the selected index is data_stream 1`] = `
+<div
+  class="euiPopover euiPopover--anchorDownCenter"
+  data-test-subj="More Action"
+>
+  <div
+    class="euiPopover__anchor"
+  >
+    <button
+      class="euiButton euiButton--primary"
+      type="button"
+    >
+      <span
+        class="euiButtonContent euiButtonContent--iconRight euiButton__content"
+      >
+        EuiIconMock
+        <span
+          class="euiButton__text"
+        >
+          Actions
+        </span>
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
 exports[`<IndicesActions /> spec shrink index by calling commonService 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"

--- a/public/pages/Indices/containers/IndicesActions/index.tsx
+++ b/public/pages/Indices/containers/IndicesActions/index.tsx
@@ -302,7 +302,7 @@ export default function IndicesActions(props: IndicesActionsProps) {
                     },
                     {
                       name: "Shrink",
-                      disabled: !selectedItems.length || selectedItems.length > 1 || selectedItems[0].data_stream !== null,
+                      disabled: !selectedItems.length || selectedItems.length > 1 || !!selectedItems[0].data_stream,
                       "data-test-subj": "Shrink Action",
                       onClick: () => setShrinkIndexFlyoutVisible(true),
                     },

--- a/public/pages/Indices/containers/IndicesActions/index.tsx
+++ b/public/pages/Indices/containers/IndicesActions/index.tsx
@@ -302,7 +302,7 @@ export default function IndicesActions(props: IndicesActionsProps) {
                     },
                     {
                       name: "Shrink",
-                      disabled: !selectedItems.length || selectedItems.length != 1,
+                      disabled: !selectedItems.length || selectedItems.length > 1 || selectedItems[0].data_stream !== null,
                       "data-test-subj": "Shrink Action",
                       onClick: () => setShrinkIndexFlyoutVisible(true),
                     },


### PR DESCRIPTION
Signed-off-by: Binlong Gao <gbinlong@amazon.com>

### Description
The main changes are:
1. Disable shrink item in the index operation's menu list if a `data_stream` is selected.
2. Add some unit tests.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
