### PR TITLE
Fixed cypress params for 1.3

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -2,15 +2,14 @@ name: E2E tests workflow
 on:
   pull_request:
     branches:
-      - main
-      - 1.*
+      - "*"
   push:
     branches:
-      - main
-      - 1.*
+      - "*"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '1.x'
-  OPENSEARCH_VERSION: '1.3.0-SNAPSHOT'
+  OPENSEARCH_DASHBOARDS_VERSION: '1.3'
+  OPENSEARCH_VERSION: '1.3.7-SNAPSHOT'
+  ISM_PLUGIN_VERSION: '1.3'
 jobs:
   tests:
     name: Run Cypress E2E tests
@@ -31,7 +30,7 @@ jobs:
         with:
           path: index-management
           repository: opensearch-project/index-management
-          ref: 'main'
+          ref: ${{env.ISM_PLUGIN_VERSION}}
       - name: Run opensearch with plugin
         run: |
           cd index-management


### PR DESCRIPTION
Signed-off-by: Amardeepsingh Siglani <amardeep7194@gmail.com>

### Description
Updated cypress-test runner workflow fields to use 1.3 OSD and reference the corresponding branch for ISM plugin.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
