### PR TITLE
Fix bug for shrink&close operation

### DIFF
--- a/public/pages/Indices/components/CloseIndexModal/CloseIndexModal.test.tsx
+++ b/public/pages/Indices/components/CloseIndexModal/CloseIndexModal.test.tsx
@@ -28,4 +28,14 @@ describe("<CloseIndexModal /> spec", () => {
     userEvent.type(getByPlaceholderText("close"), "close");
     expect(document.querySelector(".euiButton")).not.toHaveAttribute("disabled");
   });
+
+  it("Show warning when system indices are selected", async () => {
+    render(<CloseIndexModal selectedItems={[".kibana", ".tasks", "test-index"]} visible onConfirm={() => {}} onClose={() => {}} />);
+    expect(document.querySelector(".euiCallOut")).not.toHaveAttribute("hidden");
+  });
+
+  it("No warning if no system indices are selected", async () => {
+    render(<CloseIndexModal selectedItems={["test-index1", "test-index2"]} visible onConfirm={() => {}} onClose={() => {}} />);
+    expect(document.querySelector(".euiCallOut")).toHaveAttribute("hidden");
+  });
 });

--- a/public/pages/Indices/components/CloseIndexModal/CloseIndexModal.tsx
+++ b/public/pages/Indices/components/CloseIndexModal/CloseIndexModal.tsx
@@ -14,8 +14,11 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiSpacer,
+  EuiCallOut,
   EuiText,
 } from "@elastic/eui";
+import { filterByMinimatch } from "../../../../../utils/helper";
+import { SYSTEM_INDEX } from "../../../../../utils/constants";
 
 interface CloseIndexModalProps {
   selectedItems: string[];
@@ -36,6 +39,8 @@ export default function CloseIndexModal(props: CloseIndexModalProps) {
     return null;
   }
 
+  const showWarning = selectedItems.map((item) => filterByMinimatch(item as string, SYSTEM_INDEX)).filter((it) => it).length > 0;
+
   return (
     <EuiModal onClose={onClose}>
       <EuiModalHeader>
@@ -43,6 +48,12 @@ export default function CloseIndexModal(props: CloseIndexModalProps) {
       </EuiModalHeader>
 
       <EuiModalBody>
+        <>
+          <EuiCallOut color="warning" hidden={!showWarning}>
+            You are closing system-like index, please be careful before you do any change to it.
+          </EuiCallOut>
+          <EuiSpacer />
+        </>
         <div style={{ lineHeight: 1.5 }}>
           <p>The following index will be closed. It is not possible to index documents or to search for documents in a closed index.</p>
           <ul style={{ listStyleType: "disc", listStylePosition: "inside" }}>

--- a/public/pages/Indices/components/CloseIndexModal/CloseIndexModal.tsx
+++ b/public/pages/Indices/components/CloseIndexModal/CloseIndexModal.tsx
@@ -39,7 +39,7 @@ export default function CloseIndexModal(props: CloseIndexModalProps) {
     return null;
   }
 
-  const showWarning = selectedItems.map((item) => filterByMinimatch(item as string, SYSTEM_INDEX)).filter((it) => it).length > 0;
+  const showWarning = selectedItems.filter((item) => filterByMinimatch(item as string, SYSTEM_INDEX)).length > 0;
 
   return (
     <EuiModal onClose={onClose}>

--- a/public/pages/Indices/components/CloseIndexModal/__snapshots__/CloseIndexModal.test.tsx.snap
+++ b/public/pages/Indices/components/CloseIndexModal/__snapshots__/CloseIndexModal.test.tsx.snap
@@ -49,6 +49,23 @@ HTMLCollection [
               class="euiModalBody__overflow"
             >
               <div
+                class="euiCallOut euiCallOut--warning"
+                hidden=""
+              >
+                <div
+                  class="euiText euiText--small"
+                >
+                  <div
+                    class="euiTextColor euiTextColor--default"
+                  >
+                    You are closing system-like index, please be careful before you do any change to it.
+                  </div>
+                </div>
+              </div>
+              <div
+                class="euiSpacer euiSpacer--l"
+              />
+              <div
                 style="line-height: 1.5;"
               >
                 <p>

--- a/public/pages/Indices/components/ShrinkIndexFlyout/ShrinkIndexFlyout.test.tsx
+++ b/public/pages/Indices/components/ShrinkIndexFlyout/ShrinkIndexFlyout.test.tsx
@@ -69,9 +69,52 @@ describe("<ShrinkIndexFlyout /> spec", () => {
     });
   });
 
-  it("shows error when source index cannot shrink", async () => {
+  it("shows error when source index's setting index.blocks.write is null", async () => {
     const onClose = jest.fn();
     const setIndexSettings = jest.fn();
+    const { getByTestId, queryByText } = render(
+      <ShrinkIndexFlyout
+        sourceIndex={{
+          health: "green",
+          index: "test_index",
+          pri: "3",
+          rep: "0",
+          status: "open",
+        }}
+        visible
+        onConfirm={() => {}}
+        onClose={onClose}
+        getIndexSettings={async () => {
+          return {};
+        }}
+        setIndexSettings={setIndexSettings}
+        openIndex={() => {}}
+        getAlias={async () => {
+          return {};
+        }}
+      />
+    );
+
+    await waitFor(async () => {
+      expect(queryByText("The source index cannot shrink, due to the following reasons:")).not.toBeNull();
+      expect(queryByText("The source index's write operations must be blocked.")).not.toBeNull();
+      fireEvent.click(getByTestId("onSetIndexWriteBlockButton"));
+      expect(setIndexSettings).toHaveBeenCalled();
+    });
+  });
+
+  it("shows error when source index's setting index.blocks.write is false", async () => {
+    const onClose = jest.fn();
+    const setIndexSettings = jest.fn();
+    const testIndexSettings = {
+      test_index: {
+        settings: {
+          "index.blocks.write": false,
+          "index.routing.allocation.require._name": "node1",
+        },
+      },
+    };
+    const getIndexSettings = jest.fn().mockResolvedValue(testIndexSettings);
     const { getByTestId, queryByText } = render(
       <ShrinkIndexFlyout
         sourceIndex={{

--- a/public/pages/Indices/components/ShrinkIndexFlyout/ShrinkIndexFlyout.tsx
+++ b/public/pages/Indices/components/ShrinkIndexFlyout/ShrinkIndexFlyout.tsx
@@ -145,7 +145,7 @@ export default class ShrinkIndexFlyout extends Component<ShrinkIndexProps, Shrin
       }
 
       const indexWriteBlock = get(sourceIndexSettings, [sourceIndex.index, "settings", INDEX_BLOCKS_WRITE_SETTING]);
-      if (!indexWriteBlock) {
+      if (indexWriteBlock != "true" && indexWriteBlock != true) {
         const indexWriteBlockSettings = {
           "index.blocks.write": true,
         };
@@ -174,7 +174,7 @@ export default class ShrinkIndexFlyout extends Component<ShrinkIndexProps, Shrin
       // Check whether `index.blocks.read_only` is set to `true`,
       // because shrink operation will timeout and then the new shrunken index's shards cannot be allocated.
       const indexReadOnlyBlock = get(sourceIndexSettings, [sourceIndex.index, "settings", INDEX_BLOCKS_READONLY_SETTING]);
-      if (!!indexReadOnlyBlock) {
+      if (indexReadOnlyBlock == "true" || indexReadOnlyBlock == true) {
         sourceIndexNotReadyReasons.push(
           "Index setting [index.blocks.read_only] is [true], this will cause the new shrunken index's shards to be unassigned."
         );
@@ -368,7 +368,7 @@ export default class ShrinkIndexFlyout extends Component<ShrinkIndexProps, Shrin
     );
 
     return (
-      <EuiFlyout ownFocus={true} onClose={() => {}} maxWidth={600} size="m" hideCloseButton>
+      <EuiFlyout ownFocus={true} onClose={() => {}} size="m" hideCloseButton>
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="m">
             <h2 id="flyoutTitle"> Shrink index</h2>

--- a/public/pages/Indices/components/ShrinkIndexFlyout/ShrinkIndexFlyout.tsx
+++ b/public/pages/Indices/components/ShrinkIndexFlyout/ShrinkIndexFlyout.tsx
@@ -117,16 +117,16 @@ export default class ShrinkIndexFlyout extends Component<ShrinkIndexProps, Shrin
     const sourceIndexNotReadyReasons = [];
     const blockNameList = ["targetIndex"];
 
-    if (sourceIndex.health == "red") {
+    if (sourceIndex.health === "red") {
       sourceIndexCannotShrinkErrors.push(<>The source index's health status is [red]!</>);
     }
 
-    if (sourceIndex.pri == "1") {
+    if (sourceIndex.pri === "1") {
       sourceIndexCannotShrinkErrors.push(<>The source index has only one primary shard!</>);
     }
 
     if (sourceIndexCannotShrinkErrors.length == 0) {
-      if (sourceIndex.status == "close") {
+      if (sourceIndex.status === "close") {
         sourceIndexCannotShrinkErrors.push(
           <>
             The source index must not be in close status!
@@ -145,7 +145,7 @@ export default class ShrinkIndexFlyout extends Component<ShrinkIndexProps, Shrin
       }
 
       const indexWriteBlock = get(sourceIndexSettings, [sourceIndex.index, "settings", INDEX_BLOCKS_WRITE_SETTING]);
-      if (indexWriteBlock != "true" && indexWriteBlock != true) {
+      if (indexWriteBlock !== "true" && indexWriteBlock !== true) {
         const indexWriteBlockSettings = {
           "index.blocks.write": true,
         };
@@ -167,14 +167,14 @@ export default class ShrinkIndexFlyout extends Component<ShrinkIndexProps, Shrin
       }
 
       // It's better to do shrink when the source index is green.
-      if (sourceIndex.health != "green") {
+      if (sourceIndex.health !== "green") {
         sourceIndexNotReadyReasons.push("The source index's health is not green.");
       }
 
       // Check whether `index.blocks.read_only` is set to `true`,
       // because shrink operation will timeout and then the new shrunken index's shards cannot be allocated.
       const indexReadOnlyBlock = get(sourceIndexSettings, [sourceIndex.index, "settings", INDEX_BLOCKS_READONLY_SETTING]);
-      if (indexReadOnlyBlock == "true" || indexReadOnlyBlock == true) {
+      if (indexReadOnlyBlock === "true" || indexReadOnlyBlock === true) {
         sourceIndexNotReadyReasons.push(
           "Index setting [index.blocks.read_only] is [true], this will cause the new shrunken index's shards to be unassigned."
         );
@@ -205,7 +205,7 @@ export default class ShrinkIndexFlyout extends Component<ShrinkIndexProps, Shrin
     const numberOfShardsSelectOptions = [];
     const sourceIndexSharsNum = Number(sourceIndex.pri);
     for (let i = 1; i <= sourceIndexSharsNum; i++) {
-      if (sourceIndexSharsNum % i == 0) {
+      if (sourceIndexSharsNum % i === 0) {
         numberOfShardsSelectOptions.push({
           value: i.toString(),
           text: i,
@@ -296,7 +296,7 @@ export default class ShrinkIndexFlyout extends Component<ShrinkIndexProps, Shrin
     const indices = [this.props.sourceIndex.index];
     const indexDetailChildren = (
       <>
-        <EuiCallOut color="danger" hidden={sourceIndexCannotShrinkErrors.length == 0}>
+        <EuiCallOut color="danger" hidden={sourceIndexCannotShrinkErrors.length === 0}>
           <div style={{ lineHeight: 1.5 }}>
             <p>The source index cannot shrink, due to the following reasons:</p>
             <ul key="error">
@@ -309,7 +309,7 @@ export default class ShrinkIndexFlyout extends Component<ShrinkIndexProps, Shrin
             </EuiLink>
           </div>
         </EuiCallOut>
-        <EuiCallOut color="warning" hidden={sourceIndexCannotShrinkErrors.length != 0 || sourceIndexNotReadyReasons.length == 0}>
+        <EuiCallOut color="warning" hidden={sourceIndexCannotShrinkErrors.length !== 0 || sourceIndexNotReadyReasons.length === 0}>
           <div style={{ lineHeight: 1.5 }}>
             <p>The source index is not ready to shrink, may due to the following reasons:</p>
             <ul key="reason">

--- a/public/pages/Indices/components/ShrinkIndexFlyout/__snapshots__/ShrinkIndexFlyout.test.tsx.snap
+++ b/public/pages/Indices/components/ShrinkIndexFlyout/__snapshots__/ShrinkIndexFlyout.test.tsx.snap
@@ -22,7 +22,6 @@ HTMLCollection [
       <div
         class="euiFlyout euiFlyout--medium euiFlyout--paddingLarge"
         role="dialog"
-        style="max-width: 600px;"
         tabindex="-1"
       >
         <div


### PR DESCRIPTION
Signed-off-by: Binlong Gao <gbinlong@amazon.com>

### Description
1. Fix bug for shrink index operation, shown `set write block` button when the source index' `index.blocks.write` setting is `false`.
2. Show warning when one or more system indices are selected to do close operation.
3. Add more unit tests for the change.

### Issues Resolved
#450 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
