### PR TITLE
Add a space before the learn more link in shrink index page

### DIFF
--- a/public/pages/ShrinkIndex/container/ShrinkIndex/ShrinkIndex.tsx
+++ b/public/pages/ShrinkIndex/container/ShrinkIndex/ShrinkIndex.tsx
@@ -604,7 +604,7 @@ export default class ShrinkIndex extends Component<ShrinkIndexProps, ShrinkIndex
                 label: "Specify advanced index settings",
                 helpText: (
                   <>
-                    Specify a comma-delimited list of settings.
+                    Specify a comma-delimited list of settings.&nbsp;
                     <EuiLink href={INDEX_SETTINGS_URL} target="_blank">
                       View index settings.
                     </EuiLink>

--- a/public/pages/ShrinkIndex/container/ShrinkIndex/__snapshots__/ShrinkIndex.test.tsx.snap
+++ b/public/pages/ShrinkIndex/container/ShrinkIndex/__snapshots__/ShrinkIndex.test.tsx.snap
@@ -503,7 +503,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
                         class="euiFormHelpText euiFormRow__text"
                         style="padding-top: 0px; padding-bottom: 4px;"
                       >
-                        Specify a comma-delimited list of settings.
+                        Specify a comma-delimited list of settings. 
                         <a
                           class="euiLink euiLink--primary"
                           href="https://opensearch.org/docs/latest/api-reference/index-apis/create-index#index-settings"


### PR DESCRIPTION
Signed-off-by: gaobinlong <gbinlong@amazon.com>

### Description
Add a space before the learn more link in shrink index page.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
