### PR TITLE
Pass data stream to actions

### DIFF
--- a/public/pages/CreateDataStream/containers/DataStreamDetail/DataStreamDetail.tsx
+++ b/public/pages/CreateDataStream/containers/DataStreamDetail/DataStreamDetail.tsx
@@ -145,7 +145,7 @@ const DataStreamDetail = (props: DataStreamDetailProps, ref: Ref<FieldInstance>)
               View JSON
             </EuiButton>
             <DataStreamsActions
-              selectedItems={[values]}
+              selectedItems={values ? [values] : []}
               history={props.history}
               onDelete={() => props.history.replace(ROUTES.DATA_STREAMS)}
             />

--- a/public/pages/CreateDataStream/containers/DataStreamDetail/DataStreamDetail.tsx
+++ b/public/pages/CreateDataStream/containers/DataStreamDetail/DataStreamDetail.tsx
@@ -145,7 +145,7 @@ const DataStreamDetail = (props: DataStreamDetailProps, ref: Ref<FieldInstance>)
               View JSON
             </EuiButton>
             <DataStreamsActions
-              selectedItems={[values?.name]}
+              selectedItems={[values]}
               history={props.history}
               onDelete={() => props.history.replace(ROUTES.DATA_STREAMS)}
             />

--- a/public/pages/DataStreams/containers/DataStreams/DataStreams.tsx
+++ b/public/pages/DataStreams/containers/DataStreams/DataStreams.tsx
@@ -249,7 +249,7 @@ class DataStreams extends Component<DataStreamsProps, DataStreamsState> {
                 text: "",
                 children: (
                   <DataStreamsActions
-                    selectedItems={this.state.selectedItems.map((item) => item.name)}
+                    selectedItems={this.state.selectedItems}
                     onDelete={this.getDataStreams}
                     history={this.props.history}
                   />

--- a/public/pages/DataStreams/containers/DataStreamsActions/DataStreamsActions.test.tsx
+++ b/public/pages/DataStreams/containers/DataStreamsActions/DataStreamsActions.test.tsx
@@ -75,7 +75,7 @@ describe("<DataStreamsActions /> spec", () => {
       }
     );
     const { container, getByTestId, getByPlaceholderText } = renderWithRouter({
-      selectedItems: ["test_data_stream"],
+      selectedItems: [{ name: "test_data_stream" }],
       onDelete,
     });
 

--- a/public/pages/DataStreams/containers/DataStreamsActions/index.tsx
+++ b/public/pages/DataStreams/containers/DataStreamsActions/index.tsx
@@ -8,9 +8,10 @@ import { EuiButton, EuiContextMenu } from "@elastic/eui";
 import SimplePopover from "../../../../components/SimplePopover";
 import DeleteIndexModal from "../DeleteDataStreamsModal";
 import { ROUTES } from "../../../../utils/constants";
+import { DataStream } from "../../../../../server/models/interfaces";
 
 export interface DataStreamsActionsProps {
-  selectedItems: string[];
+  selectedItems: DataStream[];
   onDelete: () => void;
   history: RouteComponentProps["history"];
 }
@@ -24,6 +25,7 @@ export default function DataStreamsActions(props: DataStreamsActionsProps) {
   };
 
   const renderKey = useMemo(() => Date.now(), [selectedItems]);
+  const selectedItemsInString = selectedItems.map((item) => item.name);
 
   return (
     <>
@@ -49,14 +51,14 @@ export default function DataStreamsActions(props: DataStreamsActionsProps) {
                   name: "Force merge",
                   "data-test-subj": "ForceMergeAction",
                   onClick: () => {
-                    props.history.push(`${ROUTES.FORCE_MERGE}/${selectedItems.join(",")}`);
+                    props.history.push(`${ROUTES.FORCE_MERGE}/${selectedItemsInString.join(",")}`);
                   },
                 },
                 {
                   name: "Roll over",
                   disabled: selectedItems.length > 1,
                   "data-test-subj": "rolloverAction",
-                  onClick: () => history.push(`${ROUTES.ROLLOVER}/${selectedItems.join(",")}`),
+                  onClick: () => history.push(`${ROUTES.ROLLOVER}/${selectedItemsInString.join(",")}`),
                 },
                 {
                   name: "Delete",
@@ -70,7 +72,7 @@ export default function DataStreamsActions(props: DataStreamsActionsProps) {
         />
       </SimplePopover>
       <DeleteIndexModal
-        selectedItems={selectedItems}
+        selectedItems={selectedItemsInString}
         visible={deleteIndexModalVisible}
         onClose={onDeleteIndexModalClose}
         onDelete={() => {


### PR DESCRIPTION
### Description
to filter blocked datastreams in DataStreamsActions page, we need to get the DataStream value, not only the name. We need to pass in the DataStream values from DataStreams page

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
