### PR TITLE
Revert "Pass data stream to actions"

### DIFF
--- a/public/pages/CreateDataStream/containers/DataStreamDetail/DataStreamDetail.tsx
+++ b/public/pages/CreateDataStream/containers/DataStreamDetail/DataStreamDetail.tsx
@@ -145,7 +145,7 @@ const DataStreamDetail = (props: DataStreamDetailProps, ref: Ref<FieldInstance>)
               View JSON
             </EuiButton>
             <DataStreamsActions
-              selectedItems={values ? [values] : []}
+              selectedItems={[values?.name]}
               history={props.history}
               onDelete={() => props.history.replace(ROUTES.DATA_STREAMS)}
             />

--- a/public/pages/DataStreams/containers/DataStreams/DataStreams.tsx
+++ b/public/pages/DataStreams/containers/DataStreams/DataStreams.tsx
@@ -249,7 +249,7 @@ class DataStreams extends Component<DataStreamsProps, DataStreamsState> {
                 text: "",
                 children: (
                   <DataStreamsActions
-                    selectedItems={this.state.selectedItems}
+                    selectedItems={this.state.selectedItems.map((item) => item.name)}
                     onDelete={this.getDataStreams}
                     history={this.props.history}
                   />

--- a/public/pages/DataStreams/containers/DataStreamsActions/DataStreamsActions.test.tsx
+++ b/public/pages/DataStreams/containers/DataStreamsActions/DataStreamsActions.test.tsx
@@ -75,7 +75,7 @@ describe("<DataStreamsActions /> spec", () => {
       }
     );
     const { container, getByTestId, getByPlaceholderText } = renderWithRouter({
-      selectedItems: [{ name: "test_data_stream" }],
+      selectedItems: ["test_data_stream"],
       onDelete,
     });
 

--- a/public/pages/DataStreams/containers/DataStreamsActions/index.tsx
+++ b/public/pages/DataStreams/containers/DataStreamsActions/index.tsx
@@ -8,10 +8,9 @@ import { EuiButton, EuiContextMenu } from "@elastic/eui";
 import SimplePopover from "../../../../components/SimplePopover";
 import DeleteIndexModal from "../DeleteDataStreamsModal";
 import { ROUTES } from "../../../../utils/constants";
-import { DataStream } from "../../../../../server/models/interfaces";
 
 export interface DataStreamsActionsProps {
-  selectedItems: DataStream[];
+  selectedItems: string[];
   onDelete: () => void;
   history: RouteComponentProps["history"];
 }
@@ -25,7 +24,6 @@ export default function DataStreamsActions(props: DataStreamsActionsProps) {
   };
 
   const renderKey = useMemo(() => Date.now(), [selectedItems]);
-  const selectedItemsInString = selectedItems.map((item) => item.name);
 
   return (
     <>
@@ -51,14 +49,14 @@ export default function DataStreamsActions(props: DataStreamsActionsProps) {
                   name: "Force merge",
                   "data-test-subj": "ForceMergeAction",
                   onClick: () => {
-                    props.history.push(`${ROUTES.FORCE_MERGE}/${selectedItemsInString.join(",")}`);
+                    props.history.push(`${ROUTES.FORCE_MERGE}/${selectedItems.join(",")}`);
                   },
                 },
                 {
                   name: "Roll over",
                   disabled: selectedItems.length > 1,
                   "data-test-subj": "rolloverAction",
-                  onClick: () => history.push(`${ROUTES.ROLLOVER}/${selectedItemsInString.join(",")}`),
+                  onClick: () => history.push(`${ROUTES.ROLLOVER}/${selectedItems.join(",")}`),
                 },
                 {
                   name: "Delete",
@@ -72,7 +70,7 @@ export default function DataStreamsActions(props: DataStreamsActionsProps) {
         />
       </SimplePopover>
       <DeleteIndexModal
-        selectedItems={selectedItemsInString}
+        selectedItems={selectedItems}
         visible={deleteIndexModalVisible}
         onClose={onDeleteIndexModalClose}
         onDelete={() => {


### PR DESCRIPTION
Revert it because of the DCO failure due to wrong github alias. will recreate it.
Reverts opensearch-project/index-management-dashboards-plugin#718