### PR TITLE
fix common funcs: status filter, empty response

### DIFF
--- a/public/utils/helpers.test.ts
+++ b/public/utils/helpers.test.ts
@@ -10,6 +10,7 @@ import {
   dataStreamBlockedPredicate,
   filterBlockedItems,
   getBlockedIndicesSetWithBlocksType,
+  getRedIndicesInOpenStatus,
 } from "./helpers";
 import { browserServicesMock } from "../../test/mocks";
 import { INDEX_OP_BLOCKS_TYPE, INDEX_OP_TARGET_TYPE } from "./constants";
@@ -128,6 +129,32 @@ describe("helpers spec", () => {
     expect(
       getBlockedIndicesSetWithBlocksType(browserServicesMock, [INDEX_OP_BLOCKS_TYPE.META_DATA, INDEX_OP_BLOCKS_TYPE.READ_ONLY_ALLOW_DELETE])
     ).resolves.toEqual(new Set([]));
+  });
+
+  it(`filter open red indices`, async () => {
+    browserServicesMock.commonService.apiCaller = jest.fn().mockResolvedValue({
+      ok: true,
+      response: "a1 open\na2 close\na3 open\n",
+    });
+    expect(getRedIndicesInOpenStatus(browserServicesMock)).resolves.toEqual(["a1", "a3"]);
+
+    browserServicesMock.commonService.apiCaller = jest.fn().mockResolvedValue({
+      ok: true,
+      response: null,
+    });
+    expect(getRedIndicesInOpenStatus(browserServicesMock)).resolves.toEqual([]);
+
+    browserServicesMock.commonService.apiCaller = jest.fn().mockResolvedValue({
+      ok: true,
+      response: "\n",
+    });
+    expect(getRedIndicesInOpenStatus(browserServicesMock)).resolves.toEqual([]);
+
+    browserServicesMock.commonService.apiCaller = jest.fn().mockResolvedValue({
+      ok: true,
+      response: undefined,
+    });
+    expect(getRedIndicesInOpenStatus(browserServicesMock)).resolves.toEqual([]);
   });
 
   it(`indexBlockedPredicate`, async () => {

--- a/public/utils/helpers.ts
+++ b/public/utils/helpers.ts
@@ -68,7 +68,7 @@ interface ClusterBlocksStateResponse {
   };
 }
 
-async function getRedIndicesInOpenStatus(browserServices: BrowserServices): Promise<string[]> {
+export async function getRedIndicesInOpenStatus(browserServices: BrowserServices): Promise<string[]> {
   const result = await browserServices.commonService.apiCaller<string>({
     endpoint: "cat.indices",
     data: {
@@ -82,7 +82,8 @@ async function getRedIndicesInOpenStatus(browserServices: BrowserServices): Prom
   if (!result.ok) {
     throw result.error;
   }
-  if (typeof result.response === "undefined") {
+  /* in case result.response is undefined or null */
+  if (!result.response) {
     return [];
   }
   return result.response

--- a/public/utils/helpers.ts
+++ b/public/utils/helpers.ts
@@ -68,21 +68,27 @@ interface ClusterBlocksStateResponse {
   };
 }
 
-export async function getRedIndices(browserServices: BrowserServices, filterRedIndices: boolean = false): Promise<string[]> {
+async function getRedIndicesInOpenStatus(browserServices: BrowserServices): Promise<string[]> {
   const result = await browserServices.commonService.apiCaller<string>({
     endpoint: "cat.indices",
     data: {
       /* only return index_names and "\n" 
-      e.g. {"ok":true,"response":"index1\nindex2\n"}
+      e.g. {"ok":true,"response":"index1 open\nindex2 close\n"}
       */
-      h: "i",
+      h: "i,s",
       health: "red",
     },
   });
   if (!result.ok) {
     throw result.error;
   }
-  return result.response.split("\n").filter((s) => s !== "");
+  if (typeof result.response === "undefined") {
+    return [];
+  }
+  return result.response
+    .split("\n")
+    .filter((s) => s !== "" && s.endsWith("open"))
+    .map((s) => s.split(" ")[0]);
 }
 
 export async function getBlockedIndices(browserServices: BrowserServices): Promise<BlockedIndices> {
@@ -162,7 +168,7 @@ export async function filterBlockedItems(
     if (!originInputItems.length && indexOpTargetType !== INDEX_OP_TARGET_TYPE.INDEX) {
       throw new Error("Can only filter red indexes for type index.");
     }
-    redIndices = await getRedIndices(browserServices);
+    redIndices = await getRedIndicesInOpenStatus(browserServices);
   }
   if (!originInputItems.length) {
     /* for refresh all or flush all indices, we need to find all indices in red status,


### PR DESCRIPTION
### Description
Fix the problem when reponse is `undefined`; only filter out red indices in `open status`

### Issues Resolved
see #751 

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
