### PR TITLE
[Backport 2.x] fix common funcs: status filter, empty response

### DIFF
--- a/public/utils/helpers.test.ts
+++ b/public/utils/helpers.test.ts
@@ -10,10 +10,11 @@ import {
   dataStreamBlockedPredicate,
   filterBlockedItems,
   getBlockedIndicesSetWithBlocksType,
+  getRedIndicesInOpenStatus,
 } from "./helpers";
 import { browserServicesMock } from "../../test/mocks";
 import { INDEX_OP_BLOCKS_TYPE, INDEX_OP_TARGET_TYPE } from "./constants";
-import { IAPICaller } from "plugins/index-management-dashboards-plugin/models/interfaces";
+import { IAPICaller } from "../../models/interfaces";
 
 const exampleBlocksStateResponse = {
   cluster_name: "opensearch-cluster",
@@ -128,6 +129,32 @@ describe("helpers spec", () => {
     expect(
       getBlockedIndicesSetWithBlocksType(browserServicesMock, [INDEX_OP_BLOCKS_TYPE.META_DATA, INDEX_OP_BLOCKS_TYPE.READ_ONLY_ALLOW_DELETE])
     ).resolves.toEqual(new Set([]));
+  });
+
+  it(`filter open red indices`, async () => {
+    browserServicesMock.commonService.apiCaller = jest.fn().mockResolvedValue({
+      ok: true,
+      response: "a1 open\na2 close\na3 open\n",
+    });
+    expect(getRedIndicesInOpenStatus(browserServicesMock)).resolves.toEqual(["a1", "a3"]);
+
+    browserServicesMock.commonService.apiCaller = jest.fn().mockResolvedValue({
+      ok: true,
+      response: null,
+    });
+    expect(getRedIndicesInOpenStatus(browserServicesMock)).resolves.toEqual([]);
+
+    browserServicesMock.commonService.apiCaller = jest.fn().mockResolvedValue({
+      ok: true,
+      response: "\n",
+    });
+    expect(getRedIndicesInOpenStatus(browserServicesMock)).resolves.toEqual([]);
+
+    browserServicesMock.commonService.apiCaller = jest.fn().mockResolvedValue({
+      ok: true,
+      response: undefined,
+    });
+    expect(getRedIndicesInOpenStatus(browserServicesMock)).resolves.toEqual([]);
   });
 
   it(`indexBlockedPredicate`, async () => {
@@ -276,7 +303,7 @@ describe("helpers spec", () => {
       if (params.endpoint === "cluster.state") {
         return { ok: true, response: exampleBlocksStateResponse };
       } else {
-        return { ok: true, response: "test_index2\ntest_index4\n" };
+        return { ok: true, response: "test_index2 open\ntest_index4 open\ntest_index3 close\n" };
       }
     });
     const selectedItems = [{ index: "test_index1" }, { index: "test_index2" }, { index: "test_index3" }, { index: "test_index4" }];
@@ -314,6 +341,53 @@ describe("helpers spec", () => {
     });
   });
 
+  it(`filterBlockedItems index with red indices empty response`, async () => {
+    browserServicesMock.commonService.apiCaller = jest.fn().mockResolvedValue({
+      ok: true,
+      response: exampleBlocksStateResponse,
+    });
+    browserServicesMock.commonService.apiCaller = jest.fn().mockImplementation((params: IAPICaller) => {
+      if (params.endpoint === "cluster.state") {
+        return { ok: true, response: exampleBlocksStateResponse };
+      } else {
+        return { ok: true };
+      }
+    });
+    const selectedItems = [{ index: "test_index1" }, { index: "test_index2" }, { index: "test_index3" }, { index: "test_index4" }];
+    expect(
+      filterBlockedItems(browserServicesMock, selectedItems, INDEX_OP_BLOCKS_TYPE.CLOSED, INDEX_OP_TARGET_TYPE.INDEX, true)
+    ).resolves.toEqual({
+      blockedItems: ["test_index1", "test_index2"],
+      unBlockedItems: ["test_index3", "test_index4"],
+    });
+
+    expect(
+      filterBlockedItems(
+        browserServicesMock,
+        selectedItems,
+        [INDEX_OP_BLOCKS_TYPE.READ_ONLY, INDEX_OP_BLOCKS_TYPE.META_DATA],
+        INDEX_OP_TARGET_TYPE.INDEX,
+        true
+      )
+    ).resolves.toEqual({
+      blockedItems: ["test_index1"],
+      unBlockedItems: ["test_index2", "test_index3", "test_index4"],
+    });
+
+    expect(
+      filterBlockedItems(
+        browserServicesMock,
+        [],
+        [INDEX_OP_BLOCKS_TYPE.READ_ONLY, INDEX_OP_BLOCKS_TYPE.META_DATA],
+        INDEX_OP_TARGET_TYPE.INDEX,
+        true
+      )
+    ).resolves.toEqual({
+      blockedItems: [],
+      unBlockedItems: [],
+    });
+  });
+
   it(`filterBlockedItems alias with red indices`, async () => {
     browserServicesMock.commonService.apiCaller = jest.fn().mockResolvedValue({
       ok: true,
@@ -323,7 +397,7 @@ describe("helpers spec", () => {
       if (params.endpoint === "cluster.state") {
         return { ok: true, response: exampleBlocksStateResponse };
       } else {
-        return { ok: true, response: "test_index2\ntest_index4\n" };
+        return { ok: true, response: "test_index2 open\ntest_index4 open\ntest_index3 close\n" };
       }
     });
     const selectedItems = [
@@ -372,7 +446,7 @@ describe("helpers spec", () => {
       if (params.endpoint === "cluster.state") {
         return { ok: true, response: exampleBlocksStateResponse };
       } else {
-        return { ok: true, response: "test_index2\ntest_index4\n" };
+        return { ok: true, response: "test_index2 open\ntest_index4 open\ntest_index3 close\n" };
       }
     });
     const selectedItems = [

--- a/public/utils/helpers.ts
+++ b/public/utils/helpers.ts
@@ -68,21 +68,28 @@ interface ClusterBlocksStateResponse {
   };
 }
 
-export async function getRedIndices(browserServices: BrowserServices, filterRedIndices: boolean = false): Promise<string[]> {
+export async function getRedIndicesInOpenStatus(browserServices: BrowserServices): Promise<string[]> {
   const result = await browserServices.commonService.apiCaller<string>({
     endpoint: "cat.indices",
     data: {
       /* only return index_names and "\n" 
-      e.g. {"ok":true,"response":"index1\nindex2\n"}
+      e.g. {"ok":true,"response":"index1 open\nindex2 close\n"}
       */
-      h: "i",
+      h: "i,s",
       health: "red",
     },
   });
   if (!result.ok) {
     throw result.error;
   }
-  return result.response.split("\n").filter((s) => s !== "");
+  /* in case result.response is undefined or null */
+  if (!result.response) {
+    return [];
+  }
+  return result.response
+    .split("\n")
+    .filter((s) => s !== "" && s.endsWith("open"))
+    .map((s) => s.split(" ")[0]);
 }
 
 export async function getBlockedIndices(browserServices: BrowserServices): Promise<BlockedIndices> {
@@ -162,7 +169,7 @@ export async function filterBlockedItems(
     if (!originInputItems.length && indexOpTargetType !== INDEX_OP_TARGET_TYPE.INDEX) {
       throw new Error("Can only filter red indexes for type index.");
     }
-    redIndices = await getRedIndices(browserServices);
+    redIndices = await getRedIndicesInOpenStatus(browserServices);
   }
   if (!originInputItems.length) {
     /* for refresh all or flush all indices, we need to find all indices in red status,


### PR DESCRIPTION
* fix common funcs: status filter, empty response

Signed-off-by: zhichao-aws <zhichaog@amazon.com>

* also filter case null and empty string

Signed-off-by: zhichao-aws <zhichaog@amazon.com>

---------

Signed-off-by: zhichao-aws <zhichaog@amazon.com>
(cherry picked from commit 9d4cdd983a5d1212a0006781d3a8cf2125d58b43)

### Description
[Describe what this change achieves]

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
