### PR TITLE
Add refresh index as one of the index operations user can trigger fro…

### DIFF
--- a/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
@@ -182,6 +182,32 @@ describe("Aliases", () => {
     });
   });
 
+  describe("can refresh aliases", () => {
+    it("successfully", () => {
+      cy.get('[placeholder="Search..."]').type(`${SAMPLE_ALIAS_PREFIX}-1{enter}`);
+      cy.contains(`${SAMPLE_ALIAS_PREFIX}-10`);
+      cy.contains(`${SAMPLE_ALIAS_PREFIX}-11`);
+
+      // If no alias is selected, refresh button is disabled
+      cy.get('[data-test-subj="moreAction"] button').click().get('[data-test-subj="refreshAction"]').should("be.disabled").end();
+
+      // Refresh multiple aliases
+      cy.get(`#_selection_column_${SAMPLE_ALIAS_PREFIX}-10-checkbox`)
+        .click()
+        .get(`#_selection_column_${SAMPLE_ALIAS_PREFIX}-11-checkbox`)
+        .click()
+        .get('[data-test-subj="moreAction"] button')
+        .click()
+        .get('[data-test-subj="refreshAction"]')
+        .click()
+        .get('[data-test-subj="refreshConfirmButton"]')
+        .click()
+        .end();
+
+      cy.contains(`2 aliases [${SAMPLE_ALIAS_PREFIX}-10, ${SAMPLE_ALIAS_PREFIX}-11] have been successfully refreshed.`).end();
+    });
+  });
+
   after(() => {
     cy.deleteAllIndices();
     for (let i = 0; i < 30; i++) {

--- a/cypress/integration/plugins/index-management-dashboards-plugin/data_streams.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/data_streams.js
@@ -135,6 +135,26 @@ describe("Data stream", () => {
     });
   });
 
+  describe("can refresh data streams", () => {
+    it("successfully", () => {
+      cy.get('[data-test-subj="moreAction"] button')
+        .click()
+        .get('[data-test-subj="refreshAction"]')
+        .should("be.disabled")
+        .get(`#_selection_column_ds--checkbox`)
+        .click()
+        .get('[data-test-subj="moreAction"]')
+        .click()
+        .get('[data-test-subj="refreshAction"]')
+        .click()
+        .get('[data-test-subj="refreshConfirmButton"]')
+        .click()
+        .end();
+
+      cy.contains(`The data stream [ds-] has been successfully refreshed.`).end();
+    });
+  });
+
   describe("can delete a data stream", () => {
     it("successfully", () => {
       cy.get('[data-test-subj="moreAction"] button')

--- a/cypress/integration/plugins/index-management-dashboards-plugin/refresh_index.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/refresh_index.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { IM_PLUGIN_NAME, BASE_PATH } from "../../../utils/constants";
+
+const sampleIndex = "index-refresh";
+
+describe("Refresh Index", () => {
+  before(() => {
+    // Set welcome screen tracking to false
+    localStorage.setItem("home:welcome:show", "false");
+    cy.deleteAllIndices();
+    for (let i = 0; i < 2; i++) {
+      cy.createIndex(`${sampleIndex}-${i}`, null);
+    }
+  });
+
+  describe("can be refreshed", () => {
+    beforeEach(() => {
+      // Visit ISM OSD
+      cy.visit(`${BASE_PATH}/app/${IM_PLUGIN_NAME}#/indices`);
+      cy.contains("Rows per page", { timeout: 60000 });
+    });
+
+    it("Refresh all indexes successfully", () => {
+      cy.get('[data-test-subj="moreAction"] button')
+        .click()
+        .get('[data-test-subj="Refresh Index Action"]')
+        .click()
+        .get('[data-test-subj="refreshConfirmButton"]')
+        .click()
+        .end();
+
+      cy.contains(`All open indexes have been successfully refreshed.`).end();
+    });
+
+    it("Refresh selected index successfully", () => {
+      cy.get(`[data-test-subj="checkboxSelectRow-${sampleIndex}-0"]`)
+        .click()
+        .get(`[data-test-subj="checkboxSelectRow-${sampleIndex}-1"]`)
+        .click()
+        .get('[data-test-subj="moreAction"] button')
+        .click()
+        .get('[data-test-subj="Refresh Index Action"]')
+        .click()
+        .get('[data-test-subj="refreshConfirmButton"]')
+        .click()
+        .end();
+
+      cy.contains(`2 indexes [${sampleIndex}-0, ${sampleIndex}-1] have been successfully refreshed.`).end();
+    });
+  });
+
+  after(() => {
+    cy.deleteAllIndices();
+  });
+});

--- a/public/containers/RefreshAction/index.tsx
+++ b/public/containers/RefreshAction/index.tsx
@@ -1,0 +1,215 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useCallback, useContext, useEffect, useState } from "react";
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSpacer,
+} from "@elastic/eui";
+import { CoreStart } from "opensearch-dashboards/public";
+import { ServicesContext } from "../../services";
+import { CoreServicesContext } from "../../components/core_services";
+import { filterBlockedItems } from "../../utils/helpers";
+import { INDEX_OP_BLOCKS_TYPE, INDEX_OP_TARGET_TYPE } from "../../utils/constants";
+import { CatIndex, DataStream } from "../../../server/models/interfaces";
+import { IAlias } from "../../pages/Aliases/interface";
+
+interface RefreshActionModalProps<T> {
+  selectedItems: T[];
+  visible: boolean;
+  onClose: () => void;
+  type: INDEX_OP_TARGET_TYPE;
+}
+
+export default function RefreshActionModal<T>(props: RefreshActionModalProps<T>) {
+  const { onClose, visible, selectedItems, type } = props;
+  const services = useContext(ServicesContext);
+  const coreServices = useContext(CoreServicesContext) as CoreStart;
+  const [unBlockedItems, setUnBlockedItems] = useState([] as string[]);
+  const [blockedItems, setBlockedItems] = useState([] as string[]);
+  const [unblockedWording, setUnblockedWording] = useState("" as string);
+  const [blockedWording, setBlockedWording] = useState("" as string);
+  const [toastWording, setToastWording] = useState("" as string);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!!services && visible) {
+      const filterRedStatus = true;
+      let singleTypeWording = "";
+      let closedTypeWording = "";
+
+      switch (type) {
+        case INDEX_OP_TARGET_TYPE.ALIAS:
+          singleTypeWording = "alias";
+          closedTypeWording = "each alias has one or more indexes that";
+          break;
+        case INDEX_OP_TARGET_TYPE.DATA_STREAM:
+          singleTypeWording = "data stream";
+          closedTypeWording = "each data stream has one or more indexes that";
+          break;
+        default:
+          singleTypeWording = "index";
+          closedTypeWording = "they";
+          break;
+      }
+
+      filterBlockedItems(services, selectedItems, INDEX_OP_BLOCKS_TYPE.CLOSED, type, filterRedStatus)
+        .then((filteredStreamsResult) => {
+          const unBlocked = filteredStreamsResult.unBlockedItems;
+          const blocked = filteredStreamsResult.blockedItems;
+          if (unBlocked.length === 1) {
+            setUnblockedWording(`The following ${singleTypeWording}`);
+            setToastWording(`The ${singleTypeWording} [${unBlocked.join(", ")}] has been successfully refreshed.`);
+          } else if (unBlocked.length > 1) {
+            setUnblockedWording(`The following ${type}`);
+            setToastWording(`${unBlocked.length} ${type} [${unBlocked.join(", ")}] have been successfully refreshed.`);
+          }
+
+          if (blocked.length === 1) {
+            setBlockedWording(
+              `The following ${singleTypeWording} cannot be refreshed because ${closedTypeWording} are either closed or in red status.`
+            );
+          } else if (blocked.length > 1) {
+            setBlockedWording(`The following ${type} cannot be refreshed because ${closedTypeWording} are either closed or in red status.`);
+          }
+
+          if (!selectedItems.length) {
+            if (!blocked.length) {
+              setToastWording(`All open indexes have been successfully refreshed.`);
+              setLoading(false);
+            } else {
+              coreServices.notifications.toasts.addDanger({
+                title: `Unable to refresh indexes.`,
+                text: `Cannot refresh all open indexes because one or more indexes are in red status.`,
+              });
+              onClose();
+            }
+          } else if (selectedItems.length != 0 && unBlocked.length == 0) {
+            coreServices.notifications.toasts.addDanger({
+              title: `Unable to refresh ${type}.`,
+              text: `All selected ${type} cannot be refreshed because ${closedTypeWording} are either closed or in red status.`,
+            });
+            onClose();
+          } else {
+            setUnBlockedItems(unBlocked);
+            setBlockedItems(blocked);
+            setLoading(false);
+          }
+        })
+        .catch(() => {
+          /*
+      It's not a critical error although if it fails unlikely other call will succeed,
+      set unblocked items to all, so we won't filter any of the selected items.
+       */
+          if (selectedItems.length > 0) {
+            let unBlocked;
+            switch (type) {
+              case INDEX_OP_TARGET_TYPE.ALIAS:
+                unBlocked = selectedItems.map((item: IAlias) => item.alias);
+                break;
+              case INDEX_OP_TARGET_TYPE.DATA_STREAM:
+                unBlocked = selectedItems.map((item: DataStream) => item.name);
+                break;
+              default:
+                unBlocked = selectedItems.map((item: CatIndex) => item.index);
+                break;
+            }
+            if (unBlocked.length === 1) {
+              setUnblockedWording(`The following ${singleTypeWording}`);
+              setToastWording(`The ${singleTypeWording} [${unBlocked.join(", ")}] has been successfully refreshed.`);
+            } else if (unBlocked.length > 1) {
+              setUnblockedWording(`The following ${type}`);
+              setToastWording(`${unBlocked.length} ${type} [${unBlocked.join(", ")}] have been successfully refreshed.`);
+            }
+            setUnBlockedItems(unBlocked);
+          }
+          setLoading(false);
+        });
+    } else {
+      setUnBlockedItems([]);
+      setBlockedItems([]);
+    }
+  }, [visible, services, type, selectedItems, onClose]);
+
+  const onConfirm = useCallback(async () => {
+    if (!!services) {
+      const result = await services.commonService.apiCaller({
+        endpoint: "indices.refresh",
+        data: {
+          index: unBlockedItems.join(","),
+        },
+      });
+      if (result && result.ok) {
+        coreServices.notifications.toasts.addSuccess(toastWording);
+        onClose();
+      } else {
+        coreServices.notifications.toasts.addDanger(result?.error || "");
+      }
+    }
+  }, [unBlockedItems, toastWording, services, coreServices, onClose]);
+
+  if (!visible || loading) {
+    return null;
+  }
+
+  return (
+    <EuiModal onClose={onClose}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>Refresh {type}</EuiModalHeaderTitle>
+      </EuiModalHeader>
+
+      <EuiModalBody>
+        <div style={{ lineHeight: 1.5 }}>
+          {selectedItems.length === 0 && blockedItems.length === 0 && (
+            <>
+              <p>All open indexes will be refreshed.</p>
+            </>
+          )}
+          {!!unBlockedItems.length && (
+            <>
+              <p>{unblockedWording} will be refreshed.</p>
+              <ul style={{ listStyleType: "disc", listStylePosition: "inside" }}>
+                {unBlockedItems.map((item) => (
+                  <li key={item} data-test-subj={`UnblockedItem-${item}`}>
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+          <EuiSpacer />
+          {!!blockedItems.length && (
+            <>
+              <EuiCallOut color="warning" iconType="alert" size="s" title={`${blockedWording}`}>
+                <p />
+                <ul style={{ listStyleType: "disc", listStylePosition: "inside" }}>
+                  {blockedItems.map((item) => (
+                    <li key={item} data-test-subj={`BlockedItem-${item}`}>
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </EuiCallOut>
+            </>
+          )}
+        </div>
+      </EuiModalBody>
+
+      <EuiModalFooter>
+        <EuiButtonEmpty onClick={onClose}>Cancel</EuiButtonEmpty>
+        <EuiButton data-test-subj="refreshConfirmButton" onClick={onConfirm} fill>
+          Refresh
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+}

--- a/public/pages/Aliases/containers/AliasActions/__snapshots__/AliasActions.test.tsx.snap
+++ b/public/pages/Aliases/containers/AliasActions/__snapshots__/AliasActions.test.tsx.snap
@@ -108,6 +108,333 @@ exports[`<AliasesActions /> spec filter aliases failed when clearing caches for 
 </div>
 `;
 
+exports[`<AliasesActions /> spec refresh alias by calling commonService 1`] = `
+<body
+  class="euiBody-hasOverlayMask"
+>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
+    <div
+      class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
+      data-test-subj="moreAction"
+    >
+      <div
+        class="euiPopover__anchor"
+      >
+        <button
+          class="euiButton euiButton--primary"
+          type="button"
+        >
+          <span
+            class="euiButtonContent euiButtonContent--iconRight euiButton__content"
+          >
+            EuiIconMock
+            <span
+              class="euiButton__text"
+            >
+              Actions
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiOverlayMask euiOverlayMask--aboveHeader"
+  >
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+    <div
+      data-focus-lock-disabled="false"
+    >
+      <div
+        class="euiModal euiModal--maxWidth-default"
+        tabindex="0"
+      >
+        <button
+          aria-label="Closes this modal window"
+          class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
+          type="button"
+        >
+          EuiIconMock
+        </button>
+        <div
+          class="euiModal__flex"
+        >
+          <div
+            class="euiModalHeader"
+          >
+            <div
+              class="euiModalHeader__title"
+            >
+              Refresh 
+              aliases
+            </div>
+          </div>
+          <div
+            class="euiModalBody"
+          >
+            <div
+              class="euiModalBody__overflow"
+            >
+              <div
+                style="line-height: 1.5;"
+              >
+                <p>
+                  The following alias
+                   will be refreshed.
+                </p>
+                <ul
+                  style="list-style-type: disc; list-style-position: inside;"
+                >
+                  <li
+                    data-test-subj="UnblockedItem-2"
+                  >
+                    2
+                  </li>
+                </ul>
+                <div
+                  class="euiSpacer euiSpacer--l"
+                />
+                <div
+                  class="euiCallOut euiCallOut--warning euiCallOut--small"
+                >
+                  <div
+                    class="euiCallOutHeader"
+                  >
+                    EuiIconMock
+                    <span
+                      class="euiCallOutHeader__title"
+                    >
+                      The following alias cannot be refreshed because each alias has one or more indexes that are either closed or in red status.
+                    </span>
+                  </div>
+                  <div
+                    class="euiText euiText--extraSmall"
+                  >
+                    <div
+                      class="euiTextColor euiTextColor--default"
+                    >
+                      <p />
+                      <ul
+                        style="list-style-type: disc; list-style-position: inside;"
+                      >
+                        <li
+                          data-test-subj="BlockedItem-1"
+                        >
+                          1
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="euiModalFooter"
+          >
+            <button
+              class="euiButtonEmpty euiButtonEmpty--primary"
+              type="button"
+            >
+              <span
+                class="euiButtonContent euiButtonEmpty__content"
+              >
+                <span
+                  class="euiButtonEmpty__text"
+                >
+                  Cancel
+                </span>
+              </span>
+            </button>
+            <button
+              class="euiButton euiButton--primary euiButton--fill"
+              data-test-subj="refreshConfirmButton"
+              type="button"
+            >
+              <span
+                class="euiButtonContent euiButton__content"
+              >
+                <span
+                  class="euiButton__text"
+                >
+                  Refresh
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;
+
+exports[`<AliasesActions /> spec refresh multi alias even failed to get index status 1`] = `
+<body
+  class="euiBody-hasOverlayMask"
+>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
+    <div
+      class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
+      data-test-subj="moreAction"
+    >
+      <div
+        class="euiPopover__anchor"
+      >
+        <button
+          class="euiButton euiButton--primary"
+          type="button"
+        >
+          <span
+            class="euiButtonContent euiButtonContent--iconRight euiButton__content"
+          >
+            EuiIconMock
+            <span
+              class="euiButton__text"
+            >
+              Actions
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiOverlayMask euiOverlayMask--aboveHeader"
+  >
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+    <div
+      data-focus-lock-disabled="false"
+    >
+      <div
+        class="euiModal euiModal--maxWidth-default"
+        tabindex="0"
+      >
+        <button
+          aria-label="Closes this modal window"
+          class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
+          type="button"
+        >
+          EuiIconMock
+        </button>
+        <div
+          class="euiModal__flex"
+        >
+          <div
+            class="euiModalHeader"
+          >
+            <div
+              class="euiModalHeader__title"
+            >
+              Refresh 
+              aliases
+            </div>
+          </div>
+          <div
+            class="euiModalBody"
+          >
+            <div
+              class="euiModalBody__overflow"
+            >
+              <div
+                style="line-height: 1.5;"
+              >
+                <p>
+                  The following aliases
+                   will be refreshed.
+                </p>
+                <ul
+                  style="list-style-type: disc; list-style-position: inside;"
+                >
+                  <li
+                    data-test-subj="UnblockedItem-1"
+                  >
+                    1
+                  </li>
+                  <li
+                    data-test-subj="UnblockedItem-2"
+                  >
+                    2
+                  </li>
+                </ul>
+                <div
+                  class="euiSpacer euiSpacer--l"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="euiModalFooter"
+          >
+            <button
+              class="euiButtonEmpty euiButtonEmpty--primary"
+              type="button"
+            >
+              <span
+                class="euiButtonContent euiButtonEmpty__content"
+              >
+                <span
+                  class="euiButtonEmpty__text"
+                >
+                  Cancel
+                </span>
+              </span>
+            </button>
+            <button
+              class="euiButton euiButton--primary euiButton--fill"
+              data-test-subj="refreshConfirmButton"
+              type="button"
+            >
+              <span
+                class="euiButtonContent euiButton__content"
+              >
+                <span
+                  class="euiButton__text"
+                >
+                  Refresh
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;
+
 exports[`<AliasesActions /> spec renders flush component 1`] = `
 HTMLCollection [
   <div
@@ -198,21 +525,9 @@ HTMLCollection [
                       </span>
                     </span>
                   </button>
-                  <button
-                    class="euiContextMenuItem"
-                    data-test-subj="ClearCacheAction"
-                    type="button"
-                  >
-                    <span
-                      class="euiContextMenu__itemLayout"
-                    >
-                      <span
-                        class="euiContextMenuItem__text"
-                      >
-                        Clear cache
-                      </span>
-                    </span>
-                  </button>
+                  <hr
+                    class="euiHorizontalRule euiHorizontalRule--full"
+                  />
                   <button
                     class="euiContextMenuItem"
                     data-test-subj="ForceMergeAction"
@@ -244,6 +559,24 @@ HTMLCollection [
                       </span>
                     </span>
                   </button>
+                  <hr
+                    class="euiHorizontalRule euiHorizontalRule--full"
+                  />
+                  <button
+                    class="euiContextMenuItem"
+                    data-test-subj="ClearCacheAction"
+                    type="button"
+                  >
+                    <span
+                      class="euiContextMenu__itemLayout"
+                    >
+                      <span
+                        class="euiContextMenuItem__text"
+                      >
+                        Clear cache
+                      </span>
+                    </span>
+                  </button>
                   <button
                     class="euiContextMenuItem"
                     data-test-subj="Flush Action"
@@ -259,6 +592,24 @@ HTMLCollection [
                       </span>
                     </span>
                   </button>
+                  <button
+                    class="euiContextMenuItem"
+                    data-test-subj="refreshAction"
+                    type="button"
+                  >
+                    <span
+                      class="euiContextMenu__itemLayout"
+                    >
+                      <span
+                        class="euiContextMenuItem__text"
+                      >
+                        Refresh
+                      </span>
+                    </span>
+                  </button>
+                  <hr
+                    class="euiHorizontalRule euiHorizontalRule--full"
+                  />
                   <button
                     class="euiContextMenuItem"
                     data-test-subj="deleteAction"

--- a/public/pages/Aliases/containers/AliasActions/index.tsx
+++ b/public/pages/Aliases/containers/AliasActions/index.tsx
@@ -9,6 +9,7 @@ import SimplePopover from "../../../../components/SimplePopover";
 import DeleteIndexModal from "../DeleteAliasModal";
 import ClearCacheModal from "../../../../containers/ClearCacheModal";
 import FlushIndexModal from "../../../../containers/FlushIndexModal";
+import RefreshActionModal from "../../../../containers/RefreshAction";
 import { IAlias } from "../../interface";
 import { ROUTES, INDEX_OP_TARGET_TYPE } from "../../../../utils/constants";
 
@@ -24,6 +25,7 @@ export default function AliasesActions(props: AliasesActionsProps) {
   const [deleteIndexModalVisible, setDeleteIndexModalVisible] = useState(false);
   const [clearCacheModalVisible, setClearCacheModalVisible] = useState(false);
   const [flushAliasModalVisible, setFlushAliasModalVisible] = useState(false);
+  const [refreshModalVisible, setRefreshModalVisible] = useState(false);
 
   const onDeleteIndexModalClose = () => {
     setDeleteIndexModalVisible(false);
@@ -35,6 +37,10 @@ export default function AliasesActions(props: AliasesActionsProps) {
 
   const onFlushAliasModalClose = () => {
     setFlushAliasModalVisible(false);
+  };
+
+  const onRefreshModalClose = () => {
+    setRefreshModalVisible(false);
   };
 
   const renderKey = useMemo(() => Date.now(), [selectedItems]);
@@ -66,10 +72,7 @@ export default function AliasesActions(props: AliasesActionsProps) {
                   onClick: onUpdateAlias,
                 },
                 {
-                  name: "Clear cache",
-                  disabled: selectedItems.length < 1,
-                  "data-test-subj": "ClearCacheAction",
-                  onClick: () => setClearCacheModalVisible(true),
+                  isSeparator: true,
                 },
                 {
                   name: "Force merge",
@@ -85,10 +88,28 @@ export default function AliasesActions(props: AliasesActionsProps) {
                   onClick: () => history.push(selectedItems.length ? `${ROUTES.ROLLOVER}/${selectedItems[0].alias}` : ROUTES.ROLLOVER),
                 },
                 {
+                  isSeparator: true,
+                },
+                {
+                  name: "Clear cache",
+                  disabled: selectedItems.length < 1,
+                  "data-test-subj": "ClearCacheAction",
+                  onClick: () => setClearCacheModalVisible(true),
+                },
+                {
                   name: "Flush",
                   disabled: !selectedItems.length,
                   "data-test-subj": "Flush Action",
                   onClick: () => setFlushAliasModalVisible(true),
+                },
+                {
+                  name: "Refresh",
+                  disabled: !selectedItems.length,
+                  "data-test-subj": "refreshAction",
+                  onClick: () => setRefreshModalVisible(true),
+                },
+                {
+                  isSeparator: true,
                 },
                 {
                   name: "Delete",
@@ -121,6 +142,12 @@ export default function AliasesActions(props: AliasesActionsProps) {
         visible={flushAliasModalVisible}
         onClose={onFlushAliasModalClose}
         flushTarget={INDEX_OP_TARGET_TYPE.ALIAS}
+      />
+      <RefreshActionModal
+        selectedItems={selectedItems}
+        visible={refreshModalVisible}
+        onClose={onRefreshModalClose}
+        type={INDEX_OP_TARGET_TYPE.ALIAS}
       />
     </>
   );

--- a/public/pages/DataStreams/containers/DataStreamsActions/__snapshots__/DataStreamsActions.test.tsx.snap
+++ b/public/pages/DataStreams/containers/DataStreamsActions/__snapshots__/DataStreamsActions.test.tsx.snap
@@ -108,6 +108,183 @@ exports[`<DataStreamsActions /> spec filter data streams failed when clearing ca
 </div>
 `;
 
+exports[`<DataStreamsActions /> spec refresh data streams by calling commonService 1`] = `
+<body
+  class="euiBody-hasOverlayMask"
+>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
+    <div
+      class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
+      data-test-subj="moreAction"
+    >
+      <div
+        class="euiPopover__anchor"
+      >
+        <button
+          class="euiButton euiButton--primary"
+          type="button"
+        >
+          <span
+            class="euiButtonContent euiButtonContent--iconRight euiButton__content"
+          >
+            EuiIconMock
+            <span
+              class="euiButton__text"
+            >
+              Actions
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiOverlayMask euiOverlayMask--aboveHeader"
+  >
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+    <div
+      data-focus-lock-disabled="false"
+    >
+      <div
+        class="euiModal euiModal--maxWidth-default"
+        tabindex="0"
+      >
+        <button
+          aria-label="Closes this modal window"
+          class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
+          type="button"
+        >
+          EuiIconMock
+        </button>
+        <div
+          class="euiModal__flex"
+        >
+          <div
+            class="euiModalHeader"
+          >
+            <div
+              class="euiModalHeader__title"
+            >
+              Refresh 
+              data streams
+            </div>
+          </div>
+          <div
+            class="euiModalBody"
+          >
+            <div
+              class="euiModalBody__overflow"
+            >
+              <div
+                style="line-height: 1.5;"
+              >
+                <p>
+                  The following data stream
+                   will be refreshed.
+                </p>
+                <ul
+                  style="list-style-type: disc; list-style-position: inside;"
+                >
+                  <li
+                    data-test-subj="UnblockedItem-unblocked_data_stream"
+                  >
+                    unblocked_data_stream
+                  </li>
+                </ul>
+                <div
+                  class="euiSpacer euiSpacer--l"
+                />
+                <div
+                  class="euiCallOut euiCallOut--warning euiCallOut--small"
+                >
+                  <div
+                    class="euiCallOutHeader"
+                  >
+                    EuiIconMock
+                    <span
+                      class="euiCallOutHeader__title"
+                    >
+                      The following data stream cannot be refreshed because each data stream has one or more indexes that are either closed or in red status.
+                    </span>
+                  </div>
+                  <div
+                    class="euiText euiText--extraSmall"
+                  >
+                    <div
+                      class="euiTextColor euiTextColor--default"
+                    >
+                      <p />
+                      <ul
+                        style="list-style-type: disc; list-style-position: inside;"
+                      >
+                        <li
+                          data-test-subj="BlockedItem-blocked_data_stream"
+                        >
+                          blocked_data_stream
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="euiModalFooter"
+          >
+            <button
+              class="euiButtonEmpty euiButtonEmpty--primary"
+              type="button"
+            >
+              <span
+                class="euiButtonContent euiButtonEmpty__content"
+              >
+                <span
+                  class="euiButtonEmpty__text"
+                >
+                  Cancel
+                </span>
+              </span>
+            </button>
+            <button
+              class="euiButton euiButton--primary euiButton--fill"
+              data-test-subj="refreshConfirmButton"
+              type="button"
+            >
+              <span
+                class="euiButtonContent euiButton__content"
+              >
+                <span
+                  class="euiButton__text"
+                >
+                  Refresh
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;
+
 exports[`<DataStreamsActions /> spec renders flush component 1`] = `
 HTMLCollection [
   <div
@@ -184,21 +361,6 @@ HTMLCollection [
                 <div>
                   <button
                     class="euiContextMenuItem"
-                    data-test-subj="ClearCacheAction"
-                    type="button"
-                  >
-                    <span
-                      class="euiContextMenu__itemLayout"
-                    >
-                      <span
-                        class="euiContextMenuItem__text"
-                      >
-                        Clear cache
-                      </span>
-                    </span>
-                  </button>
-                  <button
-                    class="euiContextMenuItem"
                     data-test-subj="ForceMergeAction"
                     type="button"
                   >
@@ -228,6 +390,24 @@ HTMLCollection [
                       </span>
                     </span>
                   </button>
+                  <hr
+                    class="euiHorizontalRule euiHorizontalRule--full"
+                  />
+                  <button
+                    class="euiContextMenuItem"
+                    data-test-subj="ClearCacheAction"
+                    type="button"
+                  >
+                    <span
+                      class="euiContextMenu__itemLayout"
+                    >
+                      <span
+                        class="euiContextMenuItem__text"
+                      >
+                        Clear cache
+                      </span>
+                    </span>
+                  </button>
                   <button
                     class="euiContextMenuItem"
                     data-test-subj="Flush Action"
@@ -243,6 +423,24 @@ HTMLCollection [
                       </span>
                     </span>
                   </button>
+                  <button
+                    class="euiContextMenuItem"
+                    data-test-subj="refreshAction"
+                    type="button"
+                  >
+                    <span
+                      class="euiContextMenu__itemLayout"
+                    >
+                      <span
+                        class="euiContextMenuItem__text"
+                      >
+                        Refresh
+                      </span>
+                    </span>
+                  </button>
+                  <hr
+                    class="euiHorizontalRule euiHorizontalRule--full"
+                  />
                   <button
                     class="euiContextMenuItem"
                     data-test-subj="deleteAction"

--- a/public/pages/DataStreams/containers/DataStreamsActions/index.tsx
+++ b/public/pages/DataStreams/containers/DataStreamsActions/index.tsx
@@ -10,6 +10,7 @@ import ClearCacheModal from "../../../../containers/ClearCacheModal";
 import FlushIndexModal from "../../../../containers/FlushIndexModal";
 import DeleteIndexModal from "../DeleteDataStreamsModal";
 import { ROUTES, INDEX_OP_TARGET_TYPE } from "../../../../utils/constants";
+import RefreshActionModal from "../../../../containers/RefreshAction";
 import { DataStream } from "../../../../../server/models/interfaces";
 
 export interface DataStreamsActionsProps {
@@ -23,6 +24,7 @@ export default function DataStreamsActions(props: DataStreamsActionsProps) {
   const [deleteIndexModalVisible, setDeleteIndexModalVisible] = useState(false);
   const [clearCacheModalVisible, setClearCacheModalVisible] = useState(false);
   const [flushDataStreamModalVisible, setFlushDataStreamModalVisible] = useState(false);
+  const [refreshModalVisible, setRefreshModalVisible] = useState(false);
 
   const onDeleteIndexModalClose = () => {
     setDeleteIndexModalVisible(false);
@@ -34,6 +36,10 @@ export default function DataStreamsActions(props: DataStreamsActionsProps) {
 
   const onFlushDataStreamModalClose = () => {
     setFlushDataStreamModalVisible(false);
+  };
+
+  const onRefreshModalClose = () => {
+    setRefreshModalVisible(false);
   };
 
   const renderKey = useMemo(() => Date.now(), [selectedItems]);
@@ -60,12 +66,6 @@ export default function DataStreamsActions(props: DataStreamsActionsProps) {
               id: 0,
               items: [
                 {
-                  name: "Clear cache",
-                  disabled: selectedItems.length < 1,
-                  "data-test-subj": "ClearCacheAction",
-                  onClick: () => setClearCacheModalVisible(true),
-                },
-                {
                   name: "Force merge",
                   "data-test-subj": "ForceMergeAction",
                   onClick: () => {
@@ -79,10 +79,28 @@ export default function DataStreamsActions(props: DataStreamsActionsProps) {
                   onClick: () => history.push(`${ROUTES.ROLLOVER}/${selectedItemsInString.join(",")}`),
                 },
                 {
+                  isSeparator: true,
+                },
+                {
+                  name: "Clear cache",
+                  disabled: selectedItems.length < 1,
+                  "data-test-subj": "ClearCacheAction",
+                  onClick: () => setClearCacheModalVisible(true),
+                },
+                {
                   name: "Flush",
                   disabled: !selectedItems.length,
                   "data-test-subj": "Flush Action",
                   onClick: () => setFlushDataStreamModalVisible(true),
+                },
+                {
+                  name: "Refresh",
+                  disabled: !selectedItems.length,
+                  "data-test-subj": "refreshAction",
+                  onClick: () => setRefreshModalVisible(true),
+                },
+                {
+                  isSeparator: true,
                 },
                 {
                   name: "Delete",
@@ -115,6 +133,12 @@ export default function DataStreamsActions(props: DataStreamsActionsProps) {
         visible={flushDataStreamModalVisible}
         onClose={onFlushDataStreamModalClose}
         flushTarget={INDEX_OP_TARGET_TYPE.DATA_STREAM}
+      />
+      <RefreshActionModal
+        selectedItems={selectedItems}
+        visible={refreshModalVisible}
+        onClose={onRefreshModalClose}
+        type={INDEX_OP_TARGET_TYPE.DATA_STREAM}
       />
     </>
   );

--- a/public/pages/Indices/containers/IndicesActions/__snapshots__/IndicesActions.test.tsx.snap
+++ b/public/pages/Indices/containers/IndicesActions/__snapshots__/IndicesActions.test.tsx.snap
@@ -243,6 +243,183 @@ exports[`<IndicesActions /> spec open index by calling commonService 1`] = `
 </div>
 `;
 
+exports[`<IndicesActions /> spec refresh selected indexes by calling commonService 1`] = `
+<body
+  class="euiBody-hasOverlayMask"
+>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
+    <div
+      class="euiPopover euiPopover--anchorDownCenter"
+      data-test-subj="moreAction"
+    >
+      <div
+        class="euiPopover__anchor"
+      >
+        <button
+          class="euiButton euiButton--primary"
+          type="button"
+        >
+          <span
+            class="euiButtonContent euiButtonContent--iconRight euiButton__content"
+          >
+            EuiIconMock
+            <span
+              class="euiButton__text"
+            >
+              Actions
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiOverlayMask euiOverlayMask--aboveHeader"
+  >
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+    <div
+      data-focus-lock-disabled="false"
+    >
+      <div
+        class="euiModal euiModal--maxWidth-default"
+        tabindex="0"
+      >
+        <button
+          aria-label="Closes this modal window"
+          class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
+          type="button"
+        >
+          EuiIconMock
+        </button>
+        <div
+          class="euiModal__flex"
+        >
+          <div
+            class="euiModalHeader"
+          >
+            <div
+              class="euiModalHeader__title"
+            >
+              Refresh 
+              indexes
+            </div>
+          </div>
+          <div
+            class="euiModalBody"
+          >
+            <div
+              class="euiModalBody__overflow"
+            >
+              <div
+                style="line-height: 1.5;"
+              >
+                <p>
+                  The following index
+                   will be refreshed.
+                </p>
+                <ul
+                  style="list-style-type: disc; list-style-position: inside;"
+                >
+                  <li
+                    data-test-subj="UnblockedItem-unblocked_index"
+                  >
+                    unblocked_index
+                  </li>
+                </ul>
+                <div
+                  class="euiSpacer euiSpacer--l"
+                />
+                <div
+                  class="euiCallOut euiCallOut--warning euiCallOut--small"
+                >
+                  <div
+                    class="euiCallOutHeader"
+                  >
+                    EuiIconMock
+                    <span
+                      class="euiCallOutHeader__title"
+                    >
+                      The following index cannot be refreshed because they are either closed or in red status.
+                    </span>
+                  </div>
+                  <div
+                    class="euiText euiText--extraSmall"
+                  >
+                    <div
+                      class="euiTextColor euiTextColor--default"
+                    >
+                      <p />
+                      <ul
+                        style="list-style-type: disc; list-style-position: inside;"
+                      >
+                        <li
+                          data-test-subj="BlockedItem-blocked_index"
+                        >
+                          blocked_index
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="euiModalFooter"
+          >
+            <button
+              class="euiButtonEmpty euiButtonEmpty--primary"
+              type="button"
+            >
+              <span
+                class="euiButtonContent euiButtonEmpty__content"
+              >
+                <span
+                  class="euiButtonEmpty__text"
+                >
+                  Cancel
+                </span>
+              </span>
+            </button>
+            <button
+              class="euiButton euiButton--primary euiButton--fill"
+              data-test-subj="refreshConfirmButton"
+              type="button"
+            >
+              <span
+                class="euiButtonContent euiButton__content"
+              >
+                <span
+                  class="euiButton__text"
+                >
+                  Refresh
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;
+
 exports[`<IndicesActions /> spec renders flush component 1`] = `
 HTMLCollection [
   <div
@@ -250,7 +427,7 @@ HTMLCollection [
     data-aria-hidden="true"
   >
     <div
-      class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
+      class="euiPopover euiPopover--anchorDownCenter"
       data-test-subj="moreAction"
     >
       <div
@@ -290,7 +467,7 @@ HTMLCollection [
         aria-describedby="some_html_id"
         aria-live="off"
         aria-modal="true"
-        class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
+        class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--bottom"
         data-autofocus="true"
         role="dialog"
         style="top: 16px; left: -22px; z-index: 2000;"
@@ -335,21 +512,6 @@ HTMLCollection [
                   <hr
                     class="euiHorizontalRule euiHorizontalRule--full"
                   />
-                  <button
-                    class="euiContextMenuItem"
-                    data-test-subj="Clear cache Action"
-                    type="button"
-                  >
-                    <span
-                      class="euiContextMenu__itemLayout"
-                    >
-                      <span
-                        class="euiContextMenuItem__text"
-                      >
-                        Clear cache
-                      </span>
-                    </span>
-                  </button>
                   <button
                     class="euiContextMenuItem"
                     data-test-subj="Close Action"
@@ -445,6 +607,24 @@ HTMLCollection [
                       </span>
                     </span>
                   </button>
+                  <hr
+                    class="euiHorizontalRule euiHorizontalRule--full"
+                  />
+                  <button
+                    class="euiContextMenuItem"
+                    data-test-subj="Clear cache Action"
+                    type="button"
+                  >
+                    <span
+                      class="euiContextMenu__itemLayout"
+                    >
+                      <span
+                        class="euiContextMenuItem__text"
+                      >
+                        Clear cache
+                      </span>
+                    </span>
+                  </button>
                   <button
                     class="euiContextMenuItem"
                     data-test-subj="Flush Action"
@@ -457,6 +637,21 @@ HTMLCollection [
                         class="euiContextMenuItem__text"
                       >
                         Flush
+                      </span>
+                    </span>
+                  </button>
+                  <button
+                    class="euiContextMenuItem"
+                    data-test-subj="Refresh Index Action"
+                    type="button"
+                  >
+                    <span
+                      class="euiContextMenu__itemLayout"
+                    >
+                      <span
+                        class="euiContextMenuItem__text"
+                      >
+                        Refresh
                       </span>
                     </span>
                   </button>

--- a/public/pages/Indices/containers/IndicesActions/index.tsx
+++ b/public/pages/Indices/containers/IndicesActions/index.tsx
@@ -21,13 +21,13 @@ import FlushIndexModal from "../../../../containers/FlushIndexModal";
 import { getErrorMessage } from "../../../../utils/helpers";
 import { ROUTES, INDEX_OP_TARGET_TYPE } from "../../../../utils/constants";
 import { RouteComponentProps } from "react-router-dom";
+import RefreshActionModal from "../../../../containers/RefreshAction";
 
 export interface IndicesActionsProps extends Pick<RouteComponentProps, "history"> {
   selectedItems: ManagedCatIndex[];
   onDelete: () => void;
   onOpen: () => void;
   onClose: () => void;
-  onShrink: () => void;
   getIndices: () => Promise<void>;
 }
 
@@ -38,6 +38,7 @@ export default function IndicesActions(props: IndicesActionsProps) {
   const [clearCacheModalVisible, setClearCacheModalVisible] = useState(false);
   const [openIndexModalVisible, setOpenIndexModalVisible] = useState(false);
   const [flushIndexModalVisible, setFlushIndexModalVisible] = useState(false);
+  const [refreshModalVisible, setRefreshModalVisible] = useState(false);
   const coreServices = useContext(CoreServicesContext) as CoreStart;
   const services = useContext(ServicesContext) as BrowserServices;
 
@@ -129,6 +130,10 @@ export default function IndicesActions(props: IndicesActionsProps) {
     setFlushIndexModalVisible(false);
   };
 
+  const onRefreshModalClose = () => {
+    setRefreshModalVisible(false);
+  };
+
   const renderKey = useMemo(() => Date.now(), [selectedItems]);
 
   return (
@@ -165,11 +170,6 @@ export default function IndicesActions(props: IndicesActionsProps) {
                     },
                     {
                       isSeparator: true,
-                    },
-                    {
-                      name: "Clear cache",
-                      "data-test-subj": "Clear cache Action",
-                      onClick: () => setClearCacheModalVisible(true),
                     },
                     {
                       name: "Close",
@@ -226,9 +226,22 @@ export default function IndicesActions(props: IndicesActionsProps) {
                       },
                     },
                     {
+                      isSeparator: true,
+                    },
+                    {
+                      name: "Clear cache",
+                      "data-test-subj": "Clear cache Action",
+                      onClick: () => setClearCacheModalVisible(true),
+                    },
+                    {
                       name: "Flush",
                       "data-test-subj": "Flush Action",
                       onClick: () => setFlushIndexModalVisible(true),
+                    },
+                    {
+                      name: "Refresh",
+                      "data-test-subj": "Refresh Index Action",
+                      onClick: () => setRefreshModalVisible(true),
                     },
                     {
                       isSeparator: true,
@@ -273,11 +286,19 @@ export default function IndicesActions(props: IndicesActionsProps) {
         onClose={onClearCacheModalClose}
         type={INDEX_OP_TARGET_TYPE.INDEX}
       />
+
       <FlushIndexModal
         selectedItems={selectedItems}
         visible={flushIndexModalVisible}
         onClose={onFlushIndexModalClose}
         flushTarget={INDEX_OP_TARGET_TYPE.INDEX}
+      />
+
+      <RefreshActionModal
+        selectedItems={selectedItems}
+        visible={refreshModalVisible}
+        onClose={onRefreshModalClose}
+        type={INDEX_OP_TARGET_TYPE.INDEX}
       />
     </>
   );

--- a/public/pages/Templates/containers/AssociatedComponentsModal/__snapshots__/AssociatedComponentsModal.test.tsx.snap
+++ b/public/pages/Templates/containers/AssociatedComponentsModal/__snapshots__/AssociatedComponentsModal.test.tsx.snap
@@ -82,7 +82,9 @@ HTMLCollection [
                   >
                     <caption
                       class="euiScreenReaderOnly euiTableCaption"
-                    />
+                    >
+                      This table contains 1 rows out of 1 rows; Page 1 of 1.
+                    </caption>
                     <thead>
                       <tr>
                         <th

--- a/test/setup.jest.ts
+++ b/test/setup.jest.ts
@@ -3,11 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from "react";
 import "@testing-library/jest-dom/extend-expect";
 import { configure } from "@testing-library/react";
 
-configure({ testIdAttribute: "data-test-subj" });
+configure({
+  testIdAttribute: "data-test-subj",
+  asyncUtilTimeout: 10000,
+});
 
 jest.mock("@elastic/eui/lib/eui_components/form/form_row/make_id", () => () => "some_make_id");
 


### PR DESCRIPTION
### Description
[Add refresh index as one of the index operations user can trigger from UI]

### Issues Resolved
https://github.com/opensearch-project/index-management-dashboards-plugin/issues/699

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
