### PR TITLE
fix: add validation on data.method when using transport.request

### DIFF
--- a/server/services/CommonService.test.ts
+++ b/server/services/CommonService.test.ts
@@ -1,0 +1,97 @@
+import {
+  ILegacyCustomClusterClient,
+  OpenSearchDashboardsRequest,
+  OpenSearchDashboardsResponseFactory,
+  RequestHandlerContext,
+} from "opensearch-dashboards/server";
+import CommonService from "./CommonService";
+
+const contextMock = {
+  core: {},
+} as RequestHandlerContext;
+const responseMock = ({
+  custom: jest.fn((args) => args),
+} as unknown) as OpenSearchDashboardsResponseFactory;
+
+const mockedClient = {
+  callAsCurrentUser: jest.fn(),
+  callAsInternalUser: jest.fn(),
+  close: jest.fn(),
+  asScoped: jest.fn(() => ({
+    callAsCurrentUser: jest.fn((...args) => args),
+    callAsInternalUser: jest.fn(),
+  })),
+} as any;
+
+describe("CommonService spec", () => {
+  it("http method should valid when calling transport.request", async () => {
+    const commonService = new CommonService(mockedClient);
+    const result = await commonService.apiCaller(
+      contextMock,
+      {
+        body: {
+          endpoint: "transport.request",
+          data: {
+            method: "invalid method",
+          },
+        },
+      } as OpenSearchDashboardsRequest,
+      responseMock
+    );
+    expect(result).toEqual({
+      statusCode: 200,
+      body: {
+        ok: false,
+        error: `Method must be one of, case insensitive ['HEAD', 'GET', 'POST', 'PUT', 'DELETE']. Received 'invalid method'.`,
+      },
+    });
+  });
+
+  it("should return error when no endpoint is provided", async () => {
+    const commonService = new CommonService(mockedClient);
+    const result = await commonService.apiCaller(
+      contextMock,
+      {
+        body: {
+          endpoint: "",
+        },
+      } as OpenSearchDashboardsRequest,
+      responseMock
+    );
+    expect(result).toEqual({
+      statusCode: 200,
+      body: {
+        ok: false,
+        error: `Expected non-empty string on endpoint`,
+      },
+    });
+  });
+
+  it("should patch path when data.path does not start with /", async () => {
+    const commonService = new CommonService(mockedClient);
+    const result = await commonService.apiCaller(
+      contextMock,
+      {
+        body: {
+          endpoint: "transport.request",
+          data: {
+            path: "",
+          },
+        },
+      } as OpenSearchDashboardsRequest,
+      responseMock
+    );
+    expect(result).toEqual({
+      statusCode: 200,
+      body: {
+        ok: true,
+        response: [
+          "transport.request",
+          {
+            path: "/",
+          },
+        ],
+      },
+    });
+  });
+});

--- a/server/services/CommonService.ts
+++ b/server/services/CommonService.ts
@@ -38,6 +38,20 @@ export default class IndexService {
     try {
       const { callAsCurrentUser: callWithRequest } = this.osDriver.asScoped(request);
       const finalData = data;
+
+      /**
+       * The endpoint must not be an empty string, reference from proxy caller
+       */
+      if (!endpoint) {
+        return response.custom({
+          statusCode: 200,
+          body: {
+            ok: false,
+            error: `Expected non-empty string on endpoint`,
+          },
+        });
+      }
+
       /**
        * Update path parameter to follow RFC/generic HTTP convention
        */

--- a/server/services/CommonService.ts
+++ b/server/services/CommonService.ts
@@ -20,7 +20,7 @@ export interface ICommonCaller {
   <T>(arg: any): T;
 }
 
-export default class IndexService {
+export default class CommonService {
   osDriver: ILegacyCustomClusterClient;
 
   constructor(osDriver: ILegacyCustomClusterClient) {

--- a/server/services/CommonService.ts
+++ b/server/services/CommonService.ts
@@ -63,7 +63,7 @@ export default class CommonService {
        * Check valid method here
        */
       if (endpoint === "transport.request" && data?.method) {
-        if (VALID_METHODS.indexOf(data.method?.toUpperCase()) === -1) {
+        if (VALID_METHODS.indexOf(data.method.toUpperCase?.()) === -1) {
           return response.custom({
             statusCode: 200,
             body: {

--- a/server/services/CommonService.ts
+++ b/server/services/CommonService.ts
@@ -14,6 +14,8 @@ import {
 } from "../../../../src/core/server";
 import { IAPICaller } from "../../models/interfaces";
 
+const VALID_METHODS = ["HEAD", "GET", "POST", "PUT", "DELETE"];
+
 export interface ICommonCaller {
   <T>(arg: any): T;
 }
@@ -42,6 +44,22 @@ export default class IndexService {
       if (endpoint === "transport.request" && typeof finalData?.path === "string" && !/^\//.test(finalData?.path || "")) {
         finalData.path = `/${finalData.path || ""}`;
       }
+
+      /**
+       * Check valid method here
+       */
+      if (endpoint === "transport.request" && data?.method) {
+        if (VALID_METHODS.indexOf(data.method?.toUpperCase()) === -1) {
+          return response.custom({
+            statusCode: 200,
+            body: {
+              ok: false,
+              error: `Method must be one of, case insensitive ['HEAD', 'GET', 'POST', 'PUT', 'DELETE']. Received '${data.method}'.`,
+            },
+          });
+        }
+      }
+
       const payload = useQuery ? JSON.parse(finalData || "{}") : finalData;
       const commonCallerResponse = await callWithRequest(endpoint, payload || {});
       return response.custom({


### PR DESCRIPTION
### Description
[Describe what this change achieves]

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
