### PR TITLE
Fixed repo name in snapshot flyout; Use schedule from policy during edit

### DIFF
--- a/public/pages/CreateSnapshotPolicy/components/CronSchedule/CronSchedule.tsx
+++ b/public/pages/CreateSnapshotPolicy/components/CronSchedule/CronSchedule.tsx
@@ -55,6 +55,25 @@ const CronSchedule = ({
   const [dayOfWeek, setWeek] = useState(initWeek);
   const [dayOfMonth, setMonth] = useState(initMonth);
 
+  // When edit policy is clicked, during the initial render DEFAULT values get passed
+  // As a result when the actual policy details are passed, the state does not get updated and we end up
+  // showing incorrect values in schedule controls.
+  if (initHour !== hour) {
+    setHour(initHour);
+  }
+
+  if (initMin !== minute) {
+    setMinute(initMin);
+  }
+
+  if (initWeek !== dayOfWeek) {
+    setWeek(initWeek);
+  }
+
+  if (initMonth !== dayOfMonth) {
+    setMonth(initMonth);
+  }
+
   useEffect(() => {
     changeCron();
   }, [minute, hour, dayOfWeek, dayOfMonth]);

--- a/public/pages/Snapshots/components/SnapshotFlyout/SnapshotFlyout.tsx
+++ b/public/pages/Snapshots/components/SnapshotFlyout/SnapshotFlyout.tsx
@@ -67,7 +67,7 @@ export default class SnapshotFlyout extends Component<SnapshotFlyoutProps, Snaps
   };
 
   render() {
-    const { onCloseFlyout } = this.props;
+    const { onCloseFlyout, repository } = this.props;
     const { snapshot } = this.state;
 
     const items1 = [
@@ -78,7 +78,7 @@ export default class SnapshotFlyout extends Component<SnapshotFlyoutProps, Snaps
     const items2 = [
       { term: "Start time", value: snapshot?.start_time },
       { term: "End time", value: snapshot?.end_time },
-      { term: "Repository", value: snapshot?.snapshot },
+      { term: "Repository", value: repository },
       {
         term: "Policy",
         value: (


### PR DESCRIPTION
### Description
This PR fixes below issues:
1. Snapshot flyout showing incorrect repository name
2. When editing a snapshot policy, the schedule input gets populated with default values instead of the policy schedule details.

### Issues Resolved
#823 , #822 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
