### PR TITLE
Narrow import of `DEFAULT_APP_CATEGORIES` to avoid bundling unnecessary code

### DIFF
--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -9,10 +9,10 @@ import {
   AppMountParameters,
   CoreSetup,
   CoreStart,
-  DEFAULT_APP_CATEGORIES,
   Plugin,
   PluginInitializerContext,
 } from "../../../src/core/public";
+import { DEFAULT_APP_CATEGORIES } from "../../../src/core/utils/default_app_categories";
 import { actionRepoSingleton } from "./pages/VisualCreatePolicy/utils/helpers";
 import { ROUTES } from "./utils/constants";
 import { JobHandlerRegister } from "./JobHandler";


### PR DESCRIPTION
### Description
https://github.com/opensearch-project/index-management-dashboards-plugin/pull/741 introduced an import of `DEFAULT_APP_CATEGORIES` which results in the importing of everything under `@osd/std` which invokes the `typeof` transformer that confuses babel/webpack/babel plugins/osd-optimizer into incorrectly identifying the `exportsArgument` and that results in `exports` being used in a context that isn't aware of it, resulting in `export is not defined` when OSD is accessed.

I believe this is a better solution than #826 since it prevents the bundling of @osd/std and ... .

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
