### PR TITLE
fixed alias3 contains error

### DIFF
--- a/cypress/integration/plugins/index-management-dashboards-plugin/policies_spec.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/policies_spec.js
@@ -215,7 +215,7 @@ describe("Policies", () => {
       // Click on the test alias to navigate to the details page
       const testInputs = {
         add: ["alias4", "alias6"],
-        remove: ["alias1", "alias2", "alias3", "alias7"],
+        remove: ["alias1", "alias2", "alias7"],
       };
       /* Edit the policy */
 


### PR DESCRIPTION
### Description
alias3 gets removed as per instructions from `sample_policy_alias_action.json`. In the final contains verification we do not need to check for alias3.

### Issues Resolved
#911 

### Check List
- [x] Commits are signed per the DCO using --signoff
- [x] Tested on Cypress for policies_spec.js

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
