### PR TITLE
[flaky test]solution for aliases.js 

### DIFF
--- a/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
@@ -25,24 +25,6 @@ describe("Aliases", () => {
     cy.addIndexAlias(`${SAMPLE_ALIAS_PREFIX}-0`, `${SAMPLE_INDEX_PREFIX}-*`);
   });
 
-  Cypress.Commands.add("waitForAliasWithRetry", (alias, retryCount = 3, timeout = 240000) => {
-    const tryWait = (currentAttempt) => {
-      cy.wait(alias, { timeout: timeout }).then(
-        () => true, // If successful, do nothing
-        (error) => {
-          if (currentAttempt < retryCount) {
-            cy.log(`Retry attempt ${currentAttempt + 1} for ${alias}`);
-            tryWait(currentAttempt + 1); // Retry
-          } else {
-            throw error; // If retries are exhausted, throw the error
-          }
-        }
-      );
-    };
-
-    tryWait(0); // Initial call to tryWait
-  });
-
   beforeEach(() => {
     // Intercept the specific POST request
     cy.intercept("POST", "/api/ism/apiCaller", (req) => {
@@ -58,8 +40,8 @@ describe("Aliases", () => {
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(120000);
 
-    // Use the custom command for waiting with retries
-    cy.waitForAliasWithRetry("@apiCaller");
+    // Wait for the API call to complete
+    cy.wait("@apiCaller", { timeout: 240000 });
 
     // Common text to wait for to confirm page loaded, give up to 120 seconds for initial load
     cy.contains("Rows per page", { timeout: 120000 }).should("be.visible");

--- a/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
@@ -33,12 +33,12 @@ describe("Aliases", () => {
       }
     });
 
-    // Wait for 10 seconds for OSD to start.
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(10000);
-
     // Visit ISM OSD
     cy.visit(`${BASE_PATH}/app/${IM_PLUGIN_NAME}#/aliases`);
+
+    // Wait for 30 seconds for OSD to start.
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(30000);
 
     // Wait for the API call to complete
     cy.wait("@apiCaller", { timeout: 120000 });

--- a/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
@@ -38,10 +38,17 @@ describe("Aliases", () => {
 
     // Wait for 120 seconds for OSD to start.
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(120000);
+    // cy.wait(120000);
+
+    const startTime = new Date().getTime();
 
     // Wait for the API call to complete
-    cy.wait("@apiCaller", { timeout: 240000 });
+    cy.wait("@apiCaller", { timeout: 240000 }).then(() => {
+      // Log the calculated duration
+      const endTime = new Date().getTime();
+      const duration = endTime - startTime; // Duration in milliseconds
+      cy.log(`@apiCaller completed in ${duration} milliseconds`);
+    });
 
     // Common text to wait for to confirm page loaded, give up to 120 seconds for initial load
     cy.contains("Rows per page", { timeout: 120000 }).should("be.visible");

--- a/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
@@ -33,6 +33,10 @@ describe("Aliases", () => {
       }
     });
 
+    // Wait for 10 seconds for OSD to start.
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(10000);
+
     // Visit ISM OSD
     cy.visit(`${BASE_PATH}/app/${IM_PLUGIN_NAME}#/aliases`);
 

--- a/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
@@ -26,11 +26,21 @@ describe("Aliases", () => {
   });
 
   beforeEach(() => {
+    // Intercept the specific POST request
+    cy.intercept("POST", "/api/ism/apiCaller", (req) => {
+      if (req.body.data && req.body.data.name === "**" && req.body.data.s === "alias:desc" && req.body.endpoint === "cat.aliases") {
+        req.alias = "apiCaller"; // Assign an alias directly if the condition is met
+      }
+    });
+
     // Visit ISM OSD
     cy.visit(`${BASE_PATH}/app/${IM_PLUGIN_NAME}#/aliases`);
 
+    // Wait for the API call to complete
+    cy.wait("@apiCaller", { timeout: 120000 });
+
     // Common text to wait for to confirm page loaded, give up to 60 seconds for initial load
-    cy.contains("Rows per page", { timeout: 60000 });
+    cy.contains("Rows per page", { timeout: 60000 }).should("be.visible");
   });
 
   describe("can be searched / sorted / paginated", () => {


### PR DESCRIPTION
### Description
Solution: 
Intercepting the apiCaller POST call and waiting for the call to complete before moving on to check if the "Rows per page" is present.

The reason for it being flaky is that the `apiCaller` sometimes takes exteremely long time to return data as the number of elements are high and if the network tab is open in `cypress` while the test is being conducted the `API calls` take a very long time.

If the flaky test reoccurs then:
1. Change the number of POST calls in the `before` in `aliases.js`
2. Increase the timeout in the line below:
```bash
cy.wait("@apiCaller", { timeout: 120000 });
```

### Issues Resolved
#910 

### Check List
- [x] Commits are signed per the DCO using --signoff
- [x] All test cases are pasing for `aliases.js`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
