### PR TITLE
Fix the notification_setting test by giving a obedient slack url

### DIFF
--- a/cypress/integration/plugins/index-management-dashboards-plugin/notification_settings.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/notification_settings.js
@@ -60,7 +60,7 @@ describe("NotificationSettings", () => {
           config_type: "slack",
           is_enabled: true,
           slack: {
-            url: "https://sample-slack-webhook",
+            url: "https://hooks.slack.com/services/sample_url",
           },
         },
       },


### PR DESCRIPTION
### Description
Fix the notification_setting test by giving a obedient slack url
regression from https://github.com/opensearch-project/notifications/pull/814

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
