### PR TITLE
cypress: modify test to check for inequality

### DIFF
--- a/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
@@ -167,7 +167,7 @@ describe("Aliases", () => {
       }).then((response) => {
         let response_obj = JSON.parse(response["allRequestResponses"][0]["Response Body"]);
         let num = response_obj["_all"]["total"]["translog"]["uncommitted_operations"];
-        expect(num).to.equal(1);
+        expect(num).not.equal(0);
       });
 
       // Flush btn should be disabled if no items selected

--- a/cypress/integration/plugins/index-management-dashboards-plugin/data_streams.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/data_streams.js
@@ -99,7 +99,7 @@ describe("Data stream", () => {
       }).then((response) => {
         let response_obj = JSON.parse(response["allRequestResponses"][0]["Response Body"]);
         let num = response_obj["_all"]["total"]["translog"]["uncommitted_operations"];
-        expect(num).to.equal(1);
+        expect(num).not.equal(0);
       });
 
       cy.get('[data-test-subj="moreAction"]').click();

--- a/cypress/integration/plugins/index-management-dashboards-plugin/indices_spec.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/indices_spec.js
@@ -550,7 +550,7 @@ describe("Indexes", () => {
       }).then((response) => {
         let response_obj = JSON.parse(response["allRequestResponses"][0]["Response Body"]);
         let num = response_obj["_all"]["total"]["translog"]["uncommitted_operations"];
-        expect(num).to.equal(1);
+        expect(num).not.equal(0);
       });
 
       // Select an index
@@ -601,7 +601,7 @@ describe("Indexes", () => {
       }).then((response) => {
         let response_obj = JSON.parse(response["allRequestResponses"][0]["Response Body"]);
         let num = response_obj["_all"]["total"]["translog"]["uncommitted_operations"];
-        expect(num).to.equal(1);
+        expect(num).not.equal(0);
       });
 
       cy.get('[data-test-subj="moreAction"]').click();


### PR DESCRIPTION
### Description

When testing against cluster with more than one node, we encounter that this check fails as total number of uncommitted operations will be as per replica configuration. Eg. for a 1:1 pri:rep case, total number of uncommitted operations will be two (one for primary, one for replica). Let's change the check to check for inequality instead.

### Issues Resolved

N/A

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
