### PR TITLE
specify _all as target in ClearCacheModal

### DIFF
--- a/public/containers/ClearCacheModal/ClearCacheModal.tsx
+++ b/public/containers/ClearCacheModal/ClearCacheModal.tsx
@@ -113,7 +113,7 @@ export default function ClearCacheModal(props: ClearCacheModalProps) {
         const result = await services.commonService.apiCaller({
           endpoint: "indices.clearCache",
           data: {
-            index: unBlockedItems.join(","),
+            index: unBlockedItems.join(",") || "_all",
           },
         });
         if (result && result.ok) {

--- a/public/pages/Indices/containers/IndicesActions/IndicesActions.test.tsx
+++ b/public/pages/Indices/containers/IndicesActions/IndicesActions.test.tsx
@@ -185,7 +185,7 @@ describe("<IndicesActions /> spec", () => {
       expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         endpoint: "indices.clearCache",
         data: {
-          index: "",
+          index: "_all",
         },
       });
       expect(coreServicesMock.notifications.toasts.addSuccess).toHaveBeenCalledTimes(1);
@@ -238,7 +238,7 @@ describe("<IndicesActions /> spec", () => {
       expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         endpoint: "indices.clearCache",
         data: {
-          index: "",
+          index: "_all",
         },
       });
       expect(coreServicesMock.notifications.toasts.addError).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### Description

When none of the indices are selected, ClearCacheModal makes call to `//_cache/clear` path. Here, the intention is to clear the cache for all indices, let's make it explicit by passing `_all` as target.

New call: `/_all/_cache/clear`

### Issues Resolved

N/A

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
