### PR TITLE
Fixed bug: Readonly DataSourceMenu should be in read only state in create rollup and create transform workflows

### DIFF
--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -391,6 +391,33 @@ export default class Main extends Component<MainProps, MainState> {
                         {this.props.multiDataSourceEnabled && DataSourceMenu && DataSourceViewer && (
                           <Switch>
                             <Route
+                              path={[ROUTES.CREATE_ROLLUP, ROUTES.CREATE_TRANSFORM]}
+                              render={() =>
+                                this.state.dataSourceReadOnly ? (
+                                  <DataSourceViewer
+                                    setMenuMountPoint={this.props.setActionMenu}
+                                    componentType={"DataSourceView"}
+                                    componentConfig={{
+                                      activeOption,
+                                      fullWidth: false,
+                                    }}
+                                  />
+                                ) : (
+                                  <DataSourceMenu
+                                    setMenuMountPoint={this.props.setActionMenu}
+                                    componentType={"DataSourceSelectable"}
+                                    componentConfig={{
+                                      savedObjects: core?.savedObjects.client,
+                                      notifications: core?.notifications,
+                                      fullWidth: false,
+                                      activeOption,
+                                      onSelectedDataSources: this.onSelectedDataSources,
+                                    }}
+                                  />
+                                )
+                              }
+                            />
+                            <Route
                               path={[
                                 `${ROUTES.CREATE_DATA_STREAM}/:dataStream`,
                                 `${ROUTES.CREATE_TEMPLATE}/:template`,
@@ -450,33 +477,6 @@ export default class Main extends Component<MainProps, MainState> {
                                   }}
                                 />
                               )}
-                            />
-                            <Route
-                              path={[ROUTES.CREATE_ROLLUP, ROUTES.CREATE_TRANSFORM]}
-                              render={() =>
-                                this.state.dataSourceReadOnly ? (
-                                  <DataSourceViewer
-                                    setMenuMountPoint={this.props.setActionMenu}
-                                    componentType={"DataSourceView"}
-                                    componentConfig={{
-                                      activeOption,
-                                      fullWidth: false,
-                                    }}
-                                  />
-                                ) : (
-                                  <DataSourceMenu
-                                    setMenuMountPoint={this.props.setActionMenu}
-                                    componentType={"DataSourceSelectable"}
-                                    componentConfig={{
-                                      savedObjects: core?.savedObjects.client,
-                                      notifications: core?.notifications,
-                                      fullWidth: false,
-                                      activeOption,
-                                      onSelectedDataSources: this.onSelectedDataSources,
-                                    }}
-                                  />
-                                )
-                              }
                             />
                           </Switch>
                         )}


### PR DESCRIPTION
### Description
This PR resolves create rollup and transform bug

![image](https://github.com/opensearch-project/index-management-dashboards-plugin/assets/20185657/9c6a379f-f768-47bd-96fe-65b5597f7465)

### Issues Resolved
Resolves #1045
### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
