### PR TITLE
Fixed Transform job create flow where indices won't reset after changing datasource

### DIFF
--- a/public/pages/CreateRollup/containers/CreateRollup/CreateRollup.tsx
+++ b/public/pages/CreateRollup/containers/CreateRollup/CreateRollup.tsx
@@ -13,7 +13,6 @@ import CreateRollupSteps from "../../components/CreateRollupSteps";
 import IndexService from "../../../../services/IndexService";
 import { IndexItem } from "../../../../../models/interfaces";
 import { DataSourceMenuContext, DataSourceMenuProperties } from "../../../../services/DataSourceMenuContext";
-import { useUpdateUrlWithDataSourceProperties } from "../../../../components/MDSEnabledComponent";
 
 interface CreateRollupProps extends RouteComponentProps, DataSourceMenuProperties {
   rollupService: RollupService;

--- a/public/pages/CreateTransform/containers/CreateTransformForm/CreateTransformForm.tsx
+++ b/public/pages/CreateTransform/containers/CreateTransformForm/CreateTransformForm.tsx
@@ -89,52 +89,54 @@ export class CreateTransformForm extends Component<CreateTransformFormProps, Cre
   static contextType = CoreServicesContext;
   _isMount: boolean;
 
+  static baseState = {
+    currentStep: 1,
+    transformSeqNo: null,
+    transformPrimaryTerm: null,
+    transformId: "",
+    transformIdError: "",
+    submitError: "",
+    isSubmitting: false,
+    hasSubmitted: false,
+    loadingIndices: true,
+    indices: [],
+    totalIndices: 0,
+    previewTransform: [],
+
+    mappings: "",
+    allMappings: [],
+    fields: [],
+    fieldSelectedOption: "",
+    selectedFields: [],
+    selectedGroupField: [],
+    selectedAggregations: {},
+    aggList: [],
+    description: "",
+
+    sourceIndex: [],
+    sourceIndexError: "",
+    sourceIndexFilter: "",
+    sourceIndexFilterError: "",
+    targetIndex: [],
+    targetIndexError: "",
+
+    intervalError: "",
+
+    jobEnabledByDefault: true,
+    continuousJob: "no",
+    interval: 1,
+    intervalTimeunit: "MINUTES",
+    pageSize: 1000,
+    transformJSON: JSON.parse(EMPTY_TRANSFORM),
+
+    beenWarned: false,
+    isLoading: false,
+  };
+
   constructor(props: CreateTransformFormProps) {
     super(props);
 
-    this.state = {
-      currentStep: 1,
-      transformSeqNo: null,
-      transformPrimaryTerm: null,
-      transformId: "",
-      transformIdError: "",
-      submitError: "",
-      isSubmitting: false,
-      hasSubmitted: false,
-      loadingIndices: true,
-      indices: [],
-      totalIndices: 0,
-      previewTransform: [],
-
-      mappings: "",
-      allMappings: [],
-      fields: [],
-      fieldSelectedOption: "",
-      selectedFields: [],
-      selectedGroupField: [],
-      selectedAggregations: {},
-      aggList: [],
-      description: "",
-
-      sourceIndex: [],
-      sourceIndexError: "",
-      sourceIndexFilter: "",
-      sourceIndexFilterError: "",
-      targetIndex: [],
-      targetIndexError: "",
-
-      intervalError: "",
-
-      jobEnabledByDefault: true,
-      continuousJob: "no",
-      interval: 1,
-      intervalTimeunit: "MINUTES",
-      pageSize: 1000,
-      transformJSON: JSON.parse(EMPTY_TRANSFORM),
-
-      beenWarned: false,
-      isLoading: false,
-    };
+    this.state = CreateTransformForm.baseState;
     this._next = this._next.bind(this);
     this._prev = this._prev.bind(this);
     this._isMount = true;
@@ -143,6 +145,17 @@ export class CreateTransformForm extends Component<CreateTransformFormProps, Cre
   componentDidMount = async (): Promise<void> => {
     this.context.chrome.setBreadcrumbs([BREADCRUMBS.INDEX_MANAGEMENT, BREADCRUMBS.TRANSFORMS, BREADCRUMBS.CREATE_TRANSFORM]);
   };
+
+  componentDidUpdate(prevProps: CreateTransformFormProps, prevState: Readonly<CreateTransformFormState>) {
+    if (prevProps.dataSourceId !== this.props.dataSourceId) {
+      // reset the state, if dataSourceId changes, i.e., clear state
+      this.setState({
+        ...CreateTransformForm.baseState,
+        transformId: this.state.transformId,
+        description: this.state.description,
+      });
+    }
+  }
 
   componentWillUnmount() {
     this._isMount = false;

--- a/public/pages/CreateTransform/containers/SetUpIndicesStep/SetUpIndicesStep.tsx
+++ b/public/pages/CreateTransform/containers/SetUpIndicesStep/SetUpIndicesStep.tsx
@@ -12,8 +12,9 @@ import TransformIndices from "../../components/TransformIndices";
 import CreateTransformSteps from "../../components/CreateTransformSteps";
 import IndexService from "../../../../services/IndexService";
 import { FieldItem, IndexItem } from "../../../../../models/interfaces";
+import { DataSourceMenuContext, DataSourceMenuProperties } from "../../../../services/DataSourceMenuContext";
 
-interface SetUpIndicesStepProps extends RouteComponentProps {
+interface SetUpIndicesStepProps extends RouteComponentProps, DataSourceMenuProperties {
   transformService: TransformService;
   indexService: IndexService;
   transformId: string;
@@ -59,7 +60,7 @@ export default class SetUpIndicesStep extends Component<SetUpIndicesStepProps> {
             <EuiSpacer />
             <ConfigureTransform isEdit={false} {...this.props} />
             <EuiSpacer />
-            <TransformIndices {...this.props} />
+            <TransformIndices key={this.props.dataSourceId} {...this.props} />
           </EuiFlexItem>
         </EuiFlexGroup>
         <EuiSpacer />


### PR DESCRIPTION
### Description
In Transform job create flows, user is able to select target and source index but indices belong to a particular datsource and needs to be reset on change of datasource. This PR does that


https://github.com/opensearch-project/index-management-dashboards-plugin/assets/20185657/616e90f7-2216-45e6-9829-d8cfad0ce636


### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
