### PR TITLE
Persist dataSourceId across applications under new Nav change

### DIFF
--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -212,7 +212,7 @@ export default class Main extends Component<MainProps, MainState> {
         dataSourceId: string;
         dataSourceLabel: string;
       };
-      dataSourceId = parsedDataSourceId || "";
+      dataSourceId = parsedDataSourceId;
       dataSourceLabel = parsedDataSourceLabel || "";
 
       if (dataSourceId) {
@@ -223,7 +223,12 @@ export default class Main extends Component<MainProps, MainState> {
       dataSourceId,
       dataSourceLabel,
       dataSourceReadOnly: false,
-      dataSourceLoading: props.multiDataSourceEnabled,
+      /**
+       * undefined: need data source picker to help to determine which data source to use.
+       * empty string: using the local cluster.
+       * string: using the selected data source.
+       */
+      dataSourceLoading: dataSourceId === undefined ? props.multiDataSourceEnabled : false,
     };
   }
 

--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -69,6 +69,8 @@ import {
 import { DataSourceOption } from "../../../../../src/plugins/data_source_management/public/components/data_source_menu/types";
 import * as pluginManifest from "../../../opensearch_dashboards.json";
 import { DataSourceAttributes } from "../../../../../src/plugins/data_source/common/data_sources";
+import { BehaviorSubject } from "rxjs";
+import { i18n } from "@osd/i18n";
 
 enum Navigation {
   IndexManagement = "Index Management",
@@ -189,6 +191,15 @@ const dataSourceEnabledPaths: string[] = [
   ROUTES.EDIT_REPOSITORY,
 ];
 
+const LocalCluster: DataSourceOption = {
+  label: i18n.translate("dataSource.localCluster", {
+    defaultMessage: "Local cluster",
+  }),
+  id: "",
+};
+
+export const dataSourceObservable = new BehaviorSubject<DataSourceOption>(LocalCluster);
+
 export default class Main extends Component<MainProps, MainState> {
   constructor(props: MainProps) {
     super(props);
@@ -203,6 +214,10 @@ export default class Main extends Component<MainProps, MainState> {
       };
       dataSourceId = parsedDataSourceId || "";
       dataSourceLabel = parsedDataSourceLabel || "";
+
+      if (dataSourceId) {
+        dataSourceObservable.next({ id: dataSourceId, label: dataSourceLabel });
+      }
     }
     this.state = {
       dataSourceId,
@@ -263,6 +278,7 @@ export default class Main extends Component<MainProps, MainState> {
         dataSourceId: id,
         dataSourceLabel: label,
       });
+      dataSourceObservable.next({ id, label });
     }
     if (this.state.dataSourceLoading) {
       this.setState({

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -8,6 +8,7 @@ import { IndexManagementPluginStart, IndexManagementPluginSetup } from ".";
 import {
   AppCategory,
   AppMountParameters,
+  AppUpdater,
   CoreSetup,
   CoreStart,
   DEFAULT_APP_CATEGORIES,
@@ -21,6 +22,10 @@ import { ROUTES } from "./utils/constants";
 import { JobHandlerRegister } from "./JobHandler";
 import { ManagementOverViewPluginSetup } from "../../../src/plugins/management_overview/public";
 import { DataSourceManagementPluginSetup } from "../../../src/plugins/data_source_management/public";
+import { dataSourceObservable } from "./pages/Main/Main";
+import { BehaviorSubject } from "rxjs";
+import { useLocation } from "react-router-dom";
+import { DataSourceOption } from "src/plugins/data/public";
 
 interface IndexManagementSetupDeps {
   managementOverview?: ManagementOverViewPluginSetup;
@@ -46,6 +51,27 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
   constructor(private readonly initializerContext: PluginInitializerContext) {
     // can retrieve config from initializerContext
   }
+
+  private updateDefaultRouteOfManagementApplications: AppUpdater = () => {
+    // let url = new URL(window.location.hash);
+    // console.log("current url", url);
+    // let params = new URLSearchParams(window.location.search);
+    // // replace dataSourceId with the selected data source
+    // // let dataSourceId = params.get("dataSourceId");
+    let dataSourceId = dataSourceObservable.value?.id;
+    console.log("updating dataSourceId", dataSourceId);
+    let hash = "";
+    if (dataSourceId) {
+      hash = `#/?dataSourceId=${dataSourceId}`;
+      // url.searchParams.set("dataSourceId", dataSourceId);
+    }
+    console.log("updated url", `${hash}`);
+    return {
+      defaultPath: hash,
+    };
+  };
+
+  private appStateUpdater = new BehaviorSubject<AppUpdater>(this.updateDefaultRouteOfManagementApplications);
 
   public setup(core: CoreSetup, { managementOverview, dataSourceManagement }: IndexManagementSetupDeps): IndexManagementPluginSetup {
     JobHandlerRegister(core);
@@ -130,6 +156,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.indexes,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.INDICES);
         },
@@ -142,6 +169,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.indexes,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.MANAGED_INDICES);
         },
@@ -154,6 +182,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.indexes,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.DATA_STREAMS);
         },
@@ -166,6 +195,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.indexes,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.ALIASES);
         },
@@ -178,6 +208,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.indexes,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.INDEX_POLICIES);
         },
@@ -190,6 +221,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.indexes,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.TEMPLATES);
         },
@@ -202,6 +234,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.indexes,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.NOTIFICATIONS);
         },
@@ -214,6 +247,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.indexes,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.ROLLUPS);
         },
@@ -226,6 +260,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.indexes,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.TRANSFORMS);
         },
@@ -238,6 +273,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.index_backup_and_recovery,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.SNAPSHOTS);
         },
@@ -250,6 +286,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.index_backup_and_recovery,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.SNAPSHOT_POLICIES);
         },
@@ -262,11 +299,19 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.index_backup_and_recovery,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.REPOSITORIES);
         },
       });
     }
+
+    dataSourceObservable.subscribe((dataSourceOption) => {
+      if (dataSourceOption) {
+        console.log("dataSourceOption", dataSourceOption);
+        this.appStateUpdater.next(this.updateDefaultRouteOfManagementApplications);
+      }
+    });
 
     core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.dataAdministration, [
       {

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -24,8 +24,6 @@ import { ManagementOverViewPluginSetup } from "../../../src/plugins/management_o
 import { DataSourceManagementPluginSetup } from "../../../src/plugins/data_source_management/public";
 import { dataSourceObservable } from "./pages/Main/Main";
 import { BehaviorSubject } from "rxjs";
-import { useLocation } from "react-router-dom";
-import { DataSourceOption } from "src/plugins/data/public";
 
 interface IndexManagementSetupDeps {
   managementOverview?: ManagementOverViewPluginSetup;
@@ -53,19 +51,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
   }
 
   private updateDefaultRouteOfManagementApplications: AppUpdater = () => {
-    // let url = new URL(window.location.hash);
-    // console.log("current url", url);
-    // let params = new URLSearchParams(window.location.search);
-    // // replace dataSourceId with the selected data source
-    // // let dataSourceId = params.get("dataSourceId");
-    let dataSourceId = dataSourceObservable.value?.id;
-    console.log("updating dataSourceId", dataSourceId);
-    let hash = "";
-    if (dataSourceId) {
-      hash = `#/?dataSourceId=${dataSourceId}`;
-      // url.searchParams.set("dataSourceId", dataSourceId);
-    }
-    console.log("updated url", `${hash}`);
+    const hash = `#/?dataSourceId=${dataSourceObservable.value?.id || ""}`;
     return {
       defaultPath: hash,
     };

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -117,21 +117,6 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
       },
     });
 
-    // Register with category and use case information
-    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.dataAdministration, [
-      {
-        id: imApplicationID,
-        category: DEFAULT_APP_CATEGORIES.management,
-      },
-    ]);
-
-    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.dataAdministration, [
-      {
-        id: smApplicationID,
-        category: DEFAULT_APP_CATEGORIES.management,
-      },
-    ]);
-
     // In-app navigation registration
 
     if (core.chrome.navGroup.getNavGroupEnabled()) {
@@ -294,7 +279,6 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
 
     dataSourceObservable.subscribe((dataSourceOption) => {
       if (dataSourceOption) {
-        console.log("dataSourceOption", dataSourceOption);
         this.appStateUpdater.next(this.updateDefaultRouteOfManagementApplications);
       }
     });

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -45,6 +45,51 @@ const ISM_CATEGORIES: Record<string, AppCategory> = Object.freeze({
   },
 });
 
+const ISM_FEATURE_DESCRIPTION: Record<string, string> = Object.freeze({
+  index_management: i18n.translate("indexManagement.description", {
+    defaultMessage: "Manage your indexes with state polices, templates and aliases. You can also roll up or transform your indexes.",
+  }),
+  snapshot_management: i18n.translate("snapshotManagement.description", {
+    defaultMessage: "Back up and restore your cluster's indexes and state. Setup a policy to automate snapshot creation and deletion.",
+  }),
+  indexes: i18n.translate("indexes.description", {
+    defaultMessage: "Manage your indexes",
+  }),
+  policy_managed_indexes: i18n.translate("policyManagedIndexes.description", {
+    defaultMessage: "Manage your policy managed indexes",
+  }),
+  data_streams: i18n.translate("dataStreams.description", {
+    defaultMessage: "Manage your data streams",
+  }),
+  aliases: i18n.translate("aliases.description", {
+    defaultMessage: "Manage your index aliases",
+  }),
+  index_state_management_policies: i18n.translate("indexStateManagementPolicies.description", {
+    defaultMessage: "Manage your index state management policies",
+  }),
+  index_templates: i18n.translate("indexTemplates.description", {
+    defaultMessage: "Manage your index templates",
+  }),
+  notification_settings: i18n.translate("notificationSettings.description", {
+    defaultMessage: "Manage your notification settings",
+  }),
+  rollup_jobs: i18n.translate("rollupJobs.description", {
+    defaultMessage: "Manage your rollup jobs",
+  }),
+  transform_jobs: i18n.translate("transformJobs.description", {
+    defaultMessage: "Manage your transform jobs",
+  }),
+  index_snapshots: i18n.translate("indexSnapshots.description", {
+    defaultMessage: "Manage your index snapshots",
+  }),
+  snapshot_policies: i18n.translate("snapshotPolicies.description", {
+    defaultMessage: "Manage your snapshot policies",
+  }),
+  snapshot_repositories: i18n.translate("snapshotRepositories.description", {
+    defaultMessage: "Manage your snapshot repositories",
+  }),
+});
+
 export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup, IndexManagementPluginStart, IndexManagementSetupDeps> {
   constructor(private readonly initializerContext: PluginInitializerContext) {
     // can retrieve config from initializerContext
@@ -97,6 +142,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
       order: 9010,
       category: DEFAULT_APP_CATEGORIES.management,
       workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+      description: ISM_FEATURE_DESCRIPTION.index_management,
       mount: async (params: AppMountParameters) => {
         const { renderApp } = await import("./index_management_app");
         const [coreStart, depsStart] = await core.getStartServices();
@@ -110,6 +156,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
       order: 9020,
       category: DEFAULT_APP_CATEGORIES.management,
       workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+      description: ISM_FEATURE_DESCRIPTION.snapshot_management,
       mount: async (params: AppMountParameters) => {
         const { renderApp } = await import("./index_management_app");
         const [coreStart, depsStart] = await core.getStartServices();
@@ -127,6 +174,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.indexes,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        description: ISM_FEATURE_DESCRIPTION.indexes,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.INDICES);
@@ -140,6 +188,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.indexes,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        description: ISM_FEATURE_DESCRIPTION.policy_managed_indexes,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.MANAGED_INDICES);
@@ -153,6 +202,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.indexes,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        description: ISM_FEATURE_DESCRIPTION.data_streams,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.DATA_STREAMS);
@@ -166,6 +216,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.indexes,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        description: ISM_FEATURE_DESCRIPTION.aliases,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.ALIASES);
@@ -179,6 +230,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.indexes,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        description: ISM_FEATURE_DESCRIPTION.index_state_management_policies,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.INDEX_POLICIES);
@@ -192,6 +244,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.indexes,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        description: ISM_FEATURE_DESCRIPTION.index_templates,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.TEMPLATES);
@@ -205,6 +258,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.indexes,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        description: ISM_FEATURE_DESCRIPTION.notification_settings,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.NOTIFICATIONS);
@@ -218,6 +272,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.indexes,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        description: ISM_FEATURE_DESCRIPTION.rollup_jobs,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.ROLLUPS);
@@ -231,6 +286,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.indexes,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        description: ISM_FEATURE_DESCRIPTION.transform_jobs,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.TRANSFORMS);
@@ -244,6 +300,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.index_backup_and_recovery,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        description: ISM_FEATURE_DESCRIPTION.index_snapshots,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.SNAPSHOTS);
@@ -257,6 +314,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.index_backup_and_recovery,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        description: ISM_FEATURE_DESCRIPTION.snapshot_policies,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.SNAPSHOT_POLICIES);
@@ -270,6 +328,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         order: 8040,
         category: ISM_CATEGORIES.index_backup_and_recovery,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
+        description: ISM_FEATURE_DESCRIPTION.snapshot_repositories,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.REPOSITORIES);


### PR DESCRIPTION
### Description
This change persists dataSourceId across ISM sub applications when new Nav Ux is enabled

### Issues Resolved
Related Issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7027

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
