### PR TITLE
[navigation]feat: reuse applications

### DIFF
--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -223,20 +223,6 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         },
       });
 
-      // index state management policies route
-      core.application.register({
-        id: `opensearch_index_management_dashboards_${encodeURIComponent(ROUTES.INDEX_POLICIES)}`,
-        title: "Index State Management Policies",
-        order: 8040,
-        category: ISM_CATEGORIES.indexes,
-        workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
-        description: ISM_FEATURE_DESCRIPTION.index_state_management_policies,
-        updater$: this.appStateUpdater,
-        mount: async (params: AppMountParameters) => {
-          return mountWrapper(params, ROUTES.INDEX_POLICIES);
-        },
-      });
-
       // index templates route
       core.application.register({
         id: `opensearch_index_management_dashboards_${encodeURIComponent(ROUTES.TEMPLATES)}`,
@@ -307,20 +293,6 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         },
       });
 
-      // snapshot policies route
-      core.application.register({
-        id: `opensearch_index_management_dashboards_${encodeURIComponent(ROUTES.SNAPSHOT_POLICIES)}`,
-        title: "Snapshot Policies",
-        order: 8040,
-        category: ISM_CATEGORIES.index_backup_and_recovery,
-        workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
-        description: ISM_FEATURE_DESCRIPTION.snapshot_policies,
-        updater$: this.appStateUpdater,
-        mount: async (params: AppMountParameters) => {
-          return mountWrapper(params, ROUTES.SNAPSHOT_POLICIES);
-        },
-      });
-
       // snapshot repositories route
       core.application.register({
         id: `opensearch_index_management_dashboards_${encodeURIComponent(ROUTES.REPOSITORIES)}`,
@@ -360,8 +332,10 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         category: ISM_CATEGORIES.indexes,
       },
       {
-        id: `opensearch_index_management_dashboards_${encodeURIComponent(ROUTES.INDEX_POLICIES)}`,
+        id: imApplicationID,
         category: ISM_CATEGORIES.indexes,
+        title: "Index State Management Policies",
+        order: 8040,
       },
       {
         id: `opensearch_index_management_dashboards_${encodeURIComponent(ROUTES.TEMPLATES)}`,
@@ -384,8 +358,10 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         category: ISM_CATEGORIES.index_backup_and_recovery,
       },
       {
-        id: `opensearch_index_management_dashboards_${encodeURIComponent(ROUTES.SNAPSHOT_POLICIES)}`,
+        id: smApplicationID,
         category: ISM_CATEGORIES.index_backup_and_recovery,
+        title: "Snapshot Policies",
+        order: 8040,
       },
       {
         id: `opensearch_index_management_dashboards_${encodeURIComponent(ROUTES.REPOSITORIES)}`,


### PR DESCRIPTION
### Description
[Describe what this change achieves]
This PR try to reuse existing applications into new left navigation so that there won't be duplicated entries for the same page.
#### Before the PR
![image](https://github.com/user-attachments/assets/0841ef50-83e1-4f09-a6db-4ae18e4166f6)

![image](https://github.com/user-attachments/assets/5916800f-4f06-4e84-8ea4-e6b69104d27f)

#### After the PR
![image](https://github.com/user-attachments/assets/b403160e-b1c3-436a-bb67-40b3216127bc)

![image](https://github.com/user-attachments/assets/f6d2de6c-c28a-44dd-9df7-b4e903fe42f3)


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
