### PR TITLE
 Use smaller and compressed varients of buttons and form components

### DIFF
--- a/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
@@ -81,7 +81,7 @@ describe("Aliases", () => {
   describe("can create a alias with wildcard and specific name", () => {
     it("successfully", () => {
       cy.get('[data-test-subj="Create aliasButton"]').click();
-      cy.get('[data-test-subj="form-name-alias"]').type(CREATE_ALIAS);
+      cy.get('[data-test-subj="form-name-alias"] input').type(CREATE_ALIAS);
       cy.get('[data-test-subj="form-name-indexArray"] [data-test-subj="comboBoxSearchInput"]').type(
         `${EDIT_INDEX}{enter}${SAMPLE_INDEX_PREFIX}-*{enter}`
       );

--- a/public/JobHandler/components/ErrorToastContentForJob.tsx
+++ b/public/JobHandler/components/ErrorToastContentForJob.tsx
@@ -2,7 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { EuiButton, EuiSpacer, EuiText } from "@elastic/eui";
+import { EuiSmallButton, EuiSpacer, EuiText } from "@elastic/eui";
 import React from "react";
 import { Modal } from "../../components/Modal";
 
@@ -14,7 +14,7 @@ export const ErrorToastContentForJob = (props: { shortError?: React.ReactChild; 
       {fullError ? (
         <>
           <EuiSpacer />
-          <EuiButton
+          <EuiSmallButton
             onClick={
               /* istanbul ignore next */ () => {
                 Modal.show({
@@ -34,7 +34,7 @@ export const ErrorToastContentForJob = (props: { shortError?: React.ReactChild; 
             color="danger"
           >
             See full error
-          </EuiButton>
+          </EuiSmallButton>
         </>
       ) : null}
     </div>

--- a/public/JobHandler/components/__snapshots__/components.test.tsx.snap
+++ b/public/JobHandler/components/__snapshots__/components.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`<ErrorToastContentForJob /> spec render with action 1`] = `
       class="euiSpacer euiSpacer--l"
     />
     <button
-      class="euiButton euiButton--danger"
+      class="euiButton euiButton--danger euiButton--small"
       style="float: right;"
       type="button"
     >

--- a/public/components/AdvancedSettings/__snapshots__/AdvancedSettings.test.tsx.snap
+++ b/public/components/AdvancedSettings/__snapshots__/AdvancedSettings.test.tsx.snap
@@ -41,7 +41,7 @@ HTMLCollection [
               class="euiSpacer euiSpacer--s"
             />
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div

--- a/public/components/AliasSelect/__snapshots__/AliasSelect.test.tsx.snap
+++ b/public/components/AliasSelect/__snapshots__/AliasSelect.test.tsx.snap
@@ -4,17 +4,17 @@ exports[`<AliasSelect /> spec renders the component and remove duplicate aliases
 <div
   aria-expanded="false"
   aria-haspopup="listbox"
-  class="euiComboBox"
+  class="euiComboBox euiComboBox--compressed"
   role="combobox"
 >
   <div
-    class="euiFormControlLayout"
+    class="euiFormControlLayout euiFormControlLayout--compressed"
   >
     <div
       class="euiFormControlLayout__childrenWrapper"
     >
       <div
-        class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+        class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
         data-test-subj="comboBoxInput"
         tabindex="-1"
       >
@@ -61,17 +61,17 @@ exports[`<AliasSelect /> spec renders with error 1`] = `
   <div
     aria-expanded="false"
     aria-haspopup="listbox"
-    class="euiComboBox"
+    class="euiComboBox euiComboBox--compressed"
     role="combobox"
   >
     <div
-      class="euiFormControlLayout"
+      class="euiFormControlLayout euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <div
-          class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+          class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
           data-test-subj="comboBoxInput"
           tabindex="-1"
         >

--- a/public/components/ChannelNotification/ChannelNotification.tsx
+++ b/public/components/ChannelNotification/ChannelNotification.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiSpacer, EuiFormRow, EuiTextArea, EuiSelect, EuiButton, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiSpacer, EuiFormRow, EuiTextArea, EuiSelect, EuiSmallButton, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import "brace/theme/github";
 import "brace/mode/json";
 import { FeatureChannelList } from "../../../server/models/interfaces";
@@ -48,7 +48,7 @@ const ChannelNotification = ({
             />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               iconType="refresh"
               onClick={getChannels}
               disabled={loadingChannels}
@@ -57,9 +57,9 @@ const ChannelNotification = ({
             />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton iconType="popout" href="notifications-dashboards#/channels" target="_blank">
+            <EuiSmallButton iconType="popout" href="notifications-dashboards#/channels" target="_blank">
               Manage channels
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </CustomFormRow>

--- a/public/components/ChannelNotification/ChannelNotification.tsx
+++ b/public/components/ChannelNotification/ChannelNotification.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiSpacer, EuiFormRow, EuiTextArea, EuiSelect, EuiSmallButton, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiSpacer, EuiCompressedFormRow, EuiTextArea, EuiSelect, EuiSmallButton, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import "brace/theme/github";
 import "brace/mode/json";
 import { FeatureChannelList } from "../../../server/models/interfaces";
@@ -68,7 +68,7 @@ const ChannelNotification = ({
         <>
           <EuiSpacer size="m" />
 
-          <EuiFormRow title="Notification message" helpText="Embed variables in your message using Mustache template.">
+          <EuiCompressedFormRow title="Notification message" helpText="Embed variables in your message using Mustache template.">
             <EuiTextArea
               placeholder="The index {{ctx.index}} failed during policy execution."
               style={{ minHeight: "150px" }}
@@ -77,7 +77,7 @@ const ChannelNotification = ({
               onChange={onChangeMessage}
               data-test-subj={actionNotification ? "create-policy-notification-action-message" : "create-policy-notification-message"}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </>
       )}
     </>

--- a/public/components/ChannelNotification/ChannelNotification.tsx
+++ b/public/components/ChannelNotification/ChannelNotification.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiSpacer, EuiCompressedFormRow, EuiTextArea, EuiSelect, EuiSmallButton, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiSpacer, EuiCompressedFormRow, EuiTextArea, EuiCompressedSelect, EuiSmallButton, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import "brace/theme/github";
 import "brace/mode/json";
 import { FeatureChannelList } from "../../../server/models/interfaces";
@@ -36,7 +36,7 @@ const ChannelNotification = ({
       <CustomFormRow label="Channel ID">
         <EuiFlexGroup gutterSize="s" style={{ maxWidth: 600, width: 600 }}>
           <EuiFlexItem>
-            <EuiSelect
+            <EuiCompressedSelect
               id={actionNotification ? "action-channel-id" : "channel-id"}
               placeholder="Select channel ID"
               hasNoInitialSelection

--- a/public/components/ChannelNotification/__snapshots__/ChannelNotification.test.tsx.snap
+++ b/public/components/ChannelNotification/__snapshots__/ChannelNotification.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<ChannelNotification /> spec renders the component 1`] = `
 <div
-  class="euiFormRow"
+  class="euiFormRow euiFormRow--compressed"
   id="some_html_id-row"
 >
   <div
@@ -26,13 +26,13 @@ exports[`<ChannelNotification /> spec renders the component 1`] = `
         class="euiFlexItem"
       >
         <div
-          class="euiFormControlLayout"
+          class="euiFormControlLayout euiFormControlLayout--compressed"
         >
           <div
             class="euiFormControlLayout__childrenWrapper"
           >
             <select
-              class="euiSelect"
+              class="euiSelect euiSelect--compressed"
               data-test-subj="create-policy-notification-channel-id"
               id="channel-id"
               placeholder="Select channel ID"
@@ -67,7 +67,7 @@ exports[`<ChannelNotification /> spec renders the component 1`] = `
         class="euiFlexItem euiFlexItem--flexGrowZero"
       >
         <button
-          class="euiButton euiButton--primary refresh-button"
+          class="euiButton euiButton--primary euiButton--small refresh-button"
           data-test-subj="channel-notification-refresh"
           type="button"
         >
@@ -85,7 +85,7 @@ exports[`<ChannelNotification /> spec renders the component 1`] = `
         class="euiFlexItem euiFlexItem--flexGrowZero"
       >
         <a
-          class="euiButton euiButton--primary"
+          class="euiButton euiButton--primary euiButton--small"
           href="notifications-dashboards#/channels"
           rel="noopener noreferrer"
           target="_blank"

--- a/public/components/ComboBoxWithoutWarning/index.tsx
+++ b/public/components/ComboBoxWithoutWarning/index.tsx
@@ -2,14 +2,14 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { EuiComboBox, EuiComboBoxProps } from "@elastic/eui";
+import { EuiCompressedComboBox, EuiComboBoxProps } from "@elastic/eui";
 
 /**
  * The EuiComboBox has an issue when calling closeList.
  * It does not check if the component is still mounted.
  * And it will give a warning in browser console and terminal when running unittest.
  */
-export default class ComboBoxWithoutWarning<T> extends EuiComboBox<T> {
+export default class ComboBoxWithoutWarning<T> extends EuiCompressedComboBox<T> {
   memoriedCloseList: (event?: Event) => void;
   constructor(props: EuiComboBoxProps<T>) {
     super(props as any);

--- a/public/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/public/components/ConfirmationModal/ConfirmationModal.tsx
@@ -12,7 +12,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiOverlayMask,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   // @ts-ignore
 } from "@elastic/eui";
 
@@ -47,9 +47,9 @@ const ConfirmationModal: React.SFC<ConfirmationModalProps> = ({
         <EuiModalBody>{bodyMessage}</EuiModalBody>
 
         <EuiModalFooter>
-          <EuiButtonEmpty onClick={onClose} data-test-subj="confirmationModalCloseButton">
+          <EuiSmallButtonEmpty onClick={onClose} data-test-subj="confirmationModalCloseButton">
             Cancel
-          </EuiButtonEmpty>
+          </EuiSmallButtonEmpty>
           <EuiSmallButton
             onClick={() => {
               onAction();

--- a/public/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/public/components/ConfirmationModal/ConfirmationModal.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
@@ -50,7 +50,7 @@ const ConfirmationModal: React.SFC<ConfirmationModalProps> = ({
           <EuiButtonEmpty onClick={onClose} data-test-subj="confirmationModalCloseButton">
             Cancel
           </EuiButtonEmpty>
-          <EuiButton
+          <EuiSmallButton
             onClick={() => {
               onAction();
               onClose();
@@ -60,7 +60,7 @@ const ConfirmationModal: React.SFC<ConfirmationModalProps> = ({
             {...actionProps}
           >
             {actionMessage}
-          </EuiButton>
+          </EuiSmallButton>
         </EuiModalFooter>
       </EuiModal>
     </EuiOverlayMask>

--- a/public/components/ConfirmationModal/__snapshots__/ConfirmationModal.test.tsx.snap
+++ b/public/components/ConfirmationModal/__snapshots__/ConfirmationModal.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`<ConfirmationModal /> spec renders the component 1`] = `
           class="euiModalFooter"
         >
           <button
-            class="euiButtonEmpty euiButtonEmpty--primary"
+            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
             data-test-subj="confirmationModalCloseButton"
             type="button"
           >
@@ -66,7 +66,7 @@ exports[`<ConfirmationModal /> spec renders the component 1`] = `
             </span>
           </button>
           <button
-            class="euiButton euiButton--primary euiButton--fill"
+            class="euiButton euiButton--primary euiButton--small euiButton--fill"
             data-test-subj="confirmationModalActionButton"
             type="button"
           >

--- a/public/components/ContentPanel/ContentPanelActions.tsx
+++ b/public/components/ContentPanel/ContentPanelActions.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { EuiButton, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiSmallButton, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import { ModalConsumer } from "../Modal";
 
 interface ContentPanelActionsProps {
@@ -26,18 +26,18 @@ const ContentPanelActions: React.SFC<ContentPanelActionsProps> = ({ actions, siz
       let button = children ? (
         children
       ) : (
-        <EuiButton {...buttonProps} data-test-subj={`${text}Button`} size={size ? size : "m"}>
+        <EuiSmallButton {...buttonProps} data-test-subj={`${text}Button`}>
           {text}
-        </EuiButton>
+        </EuiSmallButton>
       );
 
       if (modal) {
         button = (
           <ModalConsumer>
             {({ onShow }) => (
-              <EuiButton {...buttonProps} onClick={modal.onClickModal(onShow)} data-test-subj={`${text}Button`}>
+              <EuiSmallButton {...buttonProps} onClick={modal.onClickModal(onShow)} data-test-subj={`${text}Button`}>
                 {text}
-              </EuiButton>
+              </EuiSmallButton>
             )}
           </ModalConsumer>
         );

--- a/public/components/ContentPanel/__snapshots__/ContentPanelActions.test.tsx.snap
+++ b/public/components/ContentPanel/__snapshots__/ContentPanelActions.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`<ContentPanelActions /> spec renders the component 1`] = `
     class="euiFlexItem euiFlexItem--flexGrowZero"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       data-test-subj="ContentPanelActionsButton"
       type="button"
     >

--- a/public/components/CreatePolicyModal/CreatePolicyModal.tsx
+++ b/public/components/CreatePolicyModal/CreatePolicyModal.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState } from "react";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
@@ -90,7 +90,7 @@ const CreatePolicyModal: React.SFC<CreatePolicyModalProps> = ({ isEdit = false, 
               </EuiButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 onClick={() => {
                   onClose();
                   onClickContinue(visual);
@@ -99,7 +99,7 @@ const CreatePolicyModal: React.SFC<CreatePolicyModalProps> = ({ isEdit = false, 
                 data-test-subj="createPolicyModalContinueButton"
               >
                 Continue
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiModalFooter>

--- a/public/components/CreatePolicyModal/CreatePolicyModal.tsx
+++ b/public/components/CreatePolicyModal/CreatePolicyModal.tsx
@@ -17,7 +17,7 @@ import {
   EuiFlexItem,
   EuiText,
   EuiCompressedFormRow,
-  EuiRadio,
+  EuiCompressedRadio,
   EuiPanel,
 } from "@elastic/eui";
 
@@ -54,7 +54,7 @@ const CreatePolicyModal: React.SFC<CreatePolicyModalProps> = ({ isEdit = false, 
                         isEdit ? "" : " using pre-defined options."
                       }`}
                     >
-                      <EuiRadio
+                      <EuiCompressedRadio
                         id="create-policy-visual"
                         label="Visual editor"
                         checked={visual}
@@ -69,7 +69,7 @@ const CreatePolicyModal: React.SFC<CreatePolicyModalProps> = ({ isEdit = false, 
                     <EuiCompressedFormRow
                       helpText={`Use the JSON editor to ${isEdit ? "update" : "create or import"} your policy using JSON.`}
                     >
-                      <EuiRadio
+                      <EuiCompressedRadio
                         id="create-policy-json"
                         label="JSON editor"
                         checked={!visual}

--- a/public/components/CreatePolicyModal/CreatePolicyModal.tsx
+++ b/public/components/CreatePolicyModal/CreatePolicyModal.tsx
@@ -16,7 +16,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiText,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiRadio,
   EuiPanel,
 } from "@elastic/eui";
@@ -49,7 +49,7 @@ const CreatePolicyModal: React.SFC<CreatePolicyModalProps> = ({ isEdit = false, 
               <EuiFlexGroup>
                 <EuiFlexItem>
                   <EuiPanel className={visual ? "selected-radio-panel" : ""}>
-                    <EuiFormRow
+                    <EuiCompressedFormRow
                       helpText={`Use the visual editor to ${isEdit ? "update" : "create"} your policy${
                         isEdit ? "" : " using pre-defined options."
                       }`}
@@ -61,12 +61,14 @@ const CreatePolicyModal: React.SFC<CreatePolicyModalProps> = ({ isEdit = false, 
                         onChange={(e) => setVisual(e.target.checked)}
                         data-test-subj="createPolicyModalVisualRadio"
                       />
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </EuiPanel>
                 </EuiFlexItem>
                 <EuiFlexItem>
                   <EuiPanel className={visual ? "" : "selected-radio-panel"}>
-                    <EuiFormRow helpText={`Use the JSON editor to ${isEdit ? "update" : "create or import"} your policy using JSON.`}>
+                    <EuiCompressedFormRow
+                      helpText={`Use the JSON editor to ${isEdit ? "update" : "create or import"} your policy using JSON.`}
+                    >
                       <EuiRadio
                         id="create-policy-json"
                         label="JSON editor"
@@ -74,7 +76,7 @@ const CreatePolicyModal: React.SFC<CreatePolicyModalProps> = ({ isEdit = false, 
                         onChange={(e) => setVisual(!e.target.checked)}
                         data-test-subj="createPolicyModalJsonRadio"
                       />
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </EuiPanel>
                 </EuiFlexItem>
               </EuiFlexGroup>

--- a/public/components/CreatePolicyModal/CreatePolicyModal.tsx
+++ b/public/components/CreatePolicyModal/CreatePolicyModal.tsx
@@ -12,7 +12,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiOverlayMask,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiText,
@@ -85,9 +85,9 @@ const CreatePolicyModal: React.SFC<CreatePolicyModalProps> = ({ isEdit = false, 
         <EuiModalFooter>
           <EuiFlexGroup justifyContent="flexEnd">
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty onClick={onClose} data-test-subj="createPolicyModalCancelButton">
+              <EuiSmallButtonEmpty onClick={onClose} data-test-subj="createPolicyModalCancelButton">
                 Cancel
-              </EuiButtonEmpty>
+              </EuiSmallButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiSmallButton

--- a/public/components/CreatePolicyModal/__snapshots__/CreatePolicyModal.test.tsx.snap
+++ b/public/components/CreatePolicyModal/__snapshots__/CreatePolicyModal.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`<CreatePolicyModal /> spec renders the component 1`] = `
                       class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow selected-radio-panel"
                     >
                       <div
-                        class="euiFormRow"
+                        class="euiFormRow euiFormRow--compressed"
                         id="some_html_id-row"
                       >
                         <div
@@ -81,7 +81,7 @@ exports[`<CreatePolicyModal /> spec renders the component 1`] = `
                         >
                           <div
                             aria-describedby="some_html_id-help-0"
-                            class="euiRadio"
+                            class="euiRadio euiRadio--compressed"
                             data-test-subj="createPolicyModalVisualRadio"
                           >
                             <input
@@ -118,7 +118,7 @@ exports[`<CreatePolicyModal /> spec renders the component 1`] = `
                       class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                     >
                       <div
-                        class="euiFormRow"
+                        class="euiFormRow euiFormRow--compressed"
                         id="some_html_id-row"
                       >
                         <div
@@ -126,7 +126,7 @@ exports[`<CreatePolicyModal /> spec renders the component 1`] = `
                         >
                           <div
                             aria-describedby="some_html_id-help-0"
-                            class="euiRadio"
+                            class="euiRadio euiRadio--compressed"
                             data-test-subj="createPolicyModalJsonRadio"
                           >
                             <input
@@ -170,7 +170,7 @@ exports[`<CreatePolicyModal /> spec renders the component 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButtonEmpty euiButtonEmpty--primary"
+                class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
                 data-test-subj="createPolicyModalCancelButton"
                 type="button"
               >
@@ -189,7 +189,7 @@ exports[`<CreatePolicyModal /> spec renders the component 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButton euiButton--primary euiButton--fill"
+                class="euiButton euiButton--primary euiButton--small euiButton--fill"
                 data-test-subj="createPolicyModalContinueButton"
                 type="button"
               >
@@ -292,7 +292,7 @@ exports[`<CreatePolicyModal /> spec renders the component w/ edit 1`] = `
                       class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow selected-radio-panel"
                     >
                       <div
-                        class="euiFormRow"
+                        class="euiFormRow euiFormRow--compressed"
                         id="some_html_id-row"
                       >
                         <div
@@ -300,7 +300,7 @@ exports[`<CreatePolicyModal /> spec renders the component w/ edit 1`] = `
                         >
                           <div
                             aria-describedby="some_html_id-help-0"
-                            class="euiRadio"
+                            class="euiRadio euiRadio--compressed"
                             data-test-subj="createPolicyModalVisualRadio"
                           >
                             <input
@@ -337,7 +337,7 @@ exports[`<CreatePolicyModal /> spec renders the component w/ edit 1`] = `
                       class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                     >
                       <div
-                        class="euiFormRow"
+                        class="euiFormRow euiFormRow--compressed"
                         id="some_html_id-row"
                       >
                         <div
@@ -345,7 +345,7 @@ exports[`<CreatePolicyModal /> spec renders the component w/ edit 1`] = `
                         >
                           <div
                             aria-describedby="some_html_id-help-0"
-                            class="euiRadio"
+                            class="euiRadio euiRadio--compressed"
                             data-test-subj="createPolicyModalJsonRadio"
                           >
                             <input
@@ -389,7 +389,7 @@ exports[`<CreatePolicyModal /> spec renders the component w/ edit 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButtonEmpty euiButtonEmpty--primary"
+                class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
                 data-test-subj="createPolicyModalCancelButton"
                 type="button"
               >
@@ -408,7 +408,7 @@ exports[`<CreatePolicyModal /> spec renders the component w/ edit 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButton euiButton--primary euiButton--fill"
+                class="euiButton euiButton--primary euiButton--small euiButton--fill"
                 data-test-subj="createPolicyModalContinueButton"
                 type="button"
               >

--- a/public/components/CustomFormRow/__snapshots__/CustomFormRow.test.tsx.snap
+++ b/public/components/CustomFormRow/__snapshots__/CustomFormRow.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`<FormGenerator /> spec render the component 1`] = `
 HTMLCollection [
   <div>
     <div
-      class="euiFormRow"
+      class="euiFormRow euiFormRow--compressed"
       id="some_html_id-row"
     >
       <div

--- a/public/components/CustomFormRow/index.tsx
+++ b/public/components/CustomFormRow/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React from "react";
-import { EuiDescribedFormGroup, EuiFormRow, EuiFormRowProps } from "@elastic/eui";
+import { EuiDescribedFormGroup, EuiCompressedFormRow, EuiFormRowProps } from "@elastic/eui";
 
 export type CustomFormRowProps = {
   position?: "top" | "bottom";
@@ -30,13 +30,13 @@ export default function CustomFormRow(props: CustomFormRowProps) {
         }
         description={helpText}
       >
-        {children ? <EuiFormRow {...others}>{children}</EuiFormRow> : null}
+        {children ? <EuiCompressedFormRow {...others}>{children}</EuiCompressedFormRow> : null}
       </EuiDescribedFormGroup>
     );
   }
 
   return (
-    <EuiFormRow
+    <EuiCompressedFormRow
       {...others}
       label={
         isOptional ? (
@@ -58,6 +58,6 @@ export default function CustomFormRow(props: CustomFormRowProps) {
         ) : null}
         {children}
       </>
-    </EuiFormRow>
+    </EuiCompressedFormRow>
   );
 }

--- a/public/components/DeleteModal/DeleteModal.tsx
+++ b/public/components/DeleteModal/DeleteModal.tsx
@@ -5,7 +5,7 @@
 
 import React, { useEffect, useState } from "react";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiFieldText,
   EuiModal,
@@ -71,9 +71,9 @@ export default function DeleteTemplateModal(props: DeleteModalProps) {
         <EuiButtonEmpty data-test-subj="deletaCancelButton" onClick={onClose}>
           Cancel
         </EuiButtonEmpty>
-        <EuiButton data-test-subj="deleteConfirmButton" onClick={onConfirm} fill color="danger" disabled={value !== "delete"}>
+        <EuiSmallButton data-test-subj="deleteConfirmButton" onClick={onConfirm} fill color="danger" disabled={value !== "delete"}>
           Delete
-        </EuiButton>
+        </EuiSmallButton>
       </EuiModalFooter>
     </EuiModal>
   );

--- a/public/components/DeleteModal/DeleteModal.tsx
+++ b/public/components/DeleteModal/DeleteModal.tsx
@@ -6,7 +6,7 @@
 import React, { useEffect, useState } from "react";
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFieldText,
   EuiModal,
   EuiModalBody,
@@ -68,9 +68,9 @@ export default function DeleteTemplateModal(props: DeleteModalProps) {
       </EuiModalBody>
 
       <EuiModalFooter>
-        <EuiButtonEmpty data-test-subj="deletaCancelButton" onClick={onClose}>
+        <EuiSmallButtonEmpty data-test-subj="deletaCancelButton" onClick={onClose}>
           Cancel
-        </EuiButtonEmpty>
+        </EuiSmallButtonEmpty>
         <EuiSmallButton data-test-subj="deleteConfirmButton" onClick={onConfirm} fill color="danger" disabled={value !== "delete"}>
           Delete
         </EuiSmallButton>

--- a/public/components/DeleteModal/DeleteModal.tsx
+++ b/public/components/DeleteModal/DeleteModal.tsx
@@ -7,7 +7,7 @@ import React, { useEffect, useState } from "react";
 import {
   EuiSmallButton,
   EuiSmallButtonEmpty,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
@@ -57,7 +57,7 @@ export default function DeleteTemplateModal(props: DeleteModalProps) {
           <EuiText color="subdued" size="s">
             To confirm your action, type <b style={{ color: "#000" }}>delete</b>.
           </EuiText>
-          <EuiFieldText
+          <EuiCompressedFieldText
             data-test-subj="deleteInput"
             placeholder="delete"
             fullWidth

--- a/public/components/DeleteModal/__snapshots__/DeleteModal.test.tsx.snap
+++ b/public/components/DeleteModal/__snapshots__/DeleteModal.test.tsx.snap
@@ -80,13 +80,13 @@ HTMLCollection [
                   </div>
                 </div>
                 <div
-                  class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                  class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <input
-                      class="euiFieldText euiFieldText--fullWidth"
+                      class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
                       data-test-subj="deleteInput"
                       placeholder="delete"
                       type="text"
@@ -101,7 +101,7 @@ HTMLCollection [
             class="euiModalFooter"
           >
             <button
-              class="euiButtonEmpty euiButtonEmpty--primary"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
               data-test-subj="deletaCancelButton"
               type="button"
             >
@@ -116,7 +116,7 @@ HTMLCollection [
               </span>
             </button>
             <button
-              class="euiButton euiButton--danger euiButton--fill euiButton-isDisabled"
+              class="euiButton euiButton--danger euiButton--small euiButton--fill euiButton-isDisabled"
               data-test-subj="deleteConfirmButton"
               disabled=""
               type="button"

--- a/public/components/FilterGroup/__snapshots__/FilterGroup.test.tsx.snap
+++ b/public/components/FilterGroup/__snapshots__/FilterGroup.test.tsx.snap
@@ -13,7 +13,7 @@ HTMLCollection [
           class="euiPopover__anchor"
         >
           <button
-            class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton-hasNotification euiFilterButton--hasIcon"
+            class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton-hasNotification euiFilterButton--hasIcon"
             data-test-subj="test"
             placeholder="test"
             type="button"
@@ -63,7 +63,7 @@ HTMLCollection [
           class="euiPopover__anchor"
         >
           <button
-            class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton-isSelected euiFilterButton-hasNotification euiFilterButton--hasIcon"
+            class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton-isSelected euiFilterButton-hasNotification euiFilterButton--hasIcon"
             data-test-subj="test"
             placeholder="test"
             type="button"
@@ -181,7 +181,7 @@ HTMLCollection [
           class="euiPopover__anchor"
         >
           <button
-            class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton-isSelected euiFilterButton-hasActiveFilters euiFilterButton-hasNotification euiFilterButton--hasIcon"
+            class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton-isSelected euiFilterButton-hasActiveFilters euiFilterButton-hasNotification euiFilterButton--hasIcon"
             data-test-subj="test"
             placeholder="test"
             type="button"
@@ -299,7 +299,7 @@ HTMLCollection [
           class="euiPopover__anchor"
         >
           <button
-            class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton-isSelected euiFilterButton-hasNotification euiFilterButton--hasIcon"
+            class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton-isSelected euiFilterButton-hasNotification euiFilterButton--hasIcon"
             data-test-subj="test"
             placeholder="test"
             type="button"

--- a/public/components/FilterGroup/index.tsx
+++ b/public/components/FilterGroup/index.tsx
@@ -1,4 +1,4 @@
-import { EuiFilterButton, EuiFilterButtonProps, EuiFilterGroup, EuiFilterSelectItem, EuiPopover } from "@elastic/eui";
+import { EuiSmallFilterButton, EuiFilterButtonProps, EuiFilterGroup, EuiFilterSelectItem, EuiPopover } from "@elastic/eui";
 import React, { useState } from "react";
 
 export interface IFilterGroupProps {
@@ -24,7 +24,7 @@ export default function FilterGroup({ options, value, filterButtonProps, onChang
     <EuiFilterGroup>
       <EuiPopover
         button={
-          <EuiFilterButton
+          <EuiSmallFilterButton
             iconType="arrowDown"
             onClick={onButtonClick}
             isSelected={isPopoverOpen}

--- a/public/components/FilterGroup/index.tsx
+++ b/public/components/FilterGroup/index.tsx
@@ -31,7 +31,6 @@ export default function FilterGroup({ options, value, filterButtonProps, onChang
             numFilters={options?.length}
             hasActiveFilters={!!value?.length}
             numActiveFilters={value?.length}
-            size={useNewUX ? "s" : undefined}
             {...filterButtonProps}
           />
         }

--- a/public/components/FormGenerator/__snapshots__/FormGenerator.test.tsx.snap
+++ b/public/components/FormGenerator/__snapshots__/FormGenerator.test.tsx.snap
@@ -7,7 +7,7 @@ HTMLCollection [
       class="euiForm"
     >
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         data-test-subj="form-name-test"
         id="some_html_id-row"
       >
@@ -29,13 +29,13 @@ HTMLCollection [
             class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
-                  class="euiFieldText"
+                  class="euiFieldText euiFieldText--compressed"
                   type="text"
                   value=""
                 />
@@ -45,7 +45,7 @@ HTMLCollection [
         </div>
       </div>
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         data-test-subj="form-name-test_component"
         id="some_html_id-row"
       >
@@ -69,7 +69,7 @@ HTMLCollection [
         </div>
       </div>
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         data-test-subj="form-name-test_component_2"
         id="some_html_id-row"
       >
@@ -91,13 +91,13 @@ HTMLCollection [
             class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
-                  class="euiFieldText"
+                  class="euiFieldText euiFieldText--compressed"
                   type="text"
                   value=""
                 />
@@ -107,7 +107,7 @@ HTMLCollection [
         </div>
       </div>
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         data-test-subj="form-name-test_component_3"
         id="some_html_id-row"
       >

--- a/public/components/FormGenerator/built_in_components/index.tsx
+++ b/public/components/FormGenerator/built_in_components/index.tsx
@@ -13,7 +13,7 @@ import {
   EuiComboBoxOptionOption,
 } from "@elastic/eui";
 import EuiToolTipWrapper, { IEuiToolTipWrapperProps } from "../../EuiToolTipWrapper";
-import EuiComboBox from "../../ComboBoxWithoutWarning";
+import EuiCompressedComboBox from "../../ComboBoxWithoutWarning";
 
 export type ComponentMapEnum = "Input" | "Number" | "Switch" | "Select" | "Text" | "ComboBoxSingle" | "CheckBox" | "ComboBoxMultiple";
 
@@ -80,7 +80,7 @@ const componentMap: Record<ComponentMapEnum, React.ComponentType<IFieldComponent
   ComboBoxSingle: EuiToolTipWrapper(
     forwardRef(({ onChange, value, options, ...others }, ref: React.Ref<any>) => {
       return (
-        <EuiComboBox
+        <EuiCompressedComboBox
           onCreateOption={(searchValue) => {
             const allOptions = (options as { label: string; options?: { label: string }[] }[]).reduce((total, current) => {
               if (current.options) {
@@ -125,7 +125,7 @@ const componentMap: Record<ComponentMapEnum, React.ComponentType<IFieldComponent
         ref: React.Ref<any>
       ) => {
         return (
-          <EuiComboBox
+          <EuiCompressedComboBox
             onCreateOption={(searchValue) => {
               const allOptions = others.options.reduce((total, current) => {
                 if (current.options) {

--- a/public/components/FormGenerator/built_in_components/index.tsx
+++ b/public/components/FormGenerator/built_in_components/index.tsx
@@ -9,7 +9,7 @@ import {
   EuiSwitch,
   EuiCompressedSelect,
   EuiText,
-  EuiCheckbox,
+  EuiCompressedCheckbox,
   EuiComboBoxOptionOption,
 } from "@elastic/eui";
 import EuiToolTipWrapper, { IEuiToolTipWrapperProps } from "../../EuiToolTipWrapper";
@@ -67,7 +67,7 @@ const componentMap: Record<ComponentMapEnum, React.ComponentType<IFieldComponent
     forwardRef(({ onChange, value, ...others }, ref: React.Ref<any>) => {
       const idRef = useRef(globalId++);
       return (
-        <EuiCheckbox
+        <EuiCompressedCheckbox
           ref={ref}
           id={`builtInCheckBoxId-${idRef.current}`}
           checked={value === undefined ? false : value}

--- a/public/components/FormGenerator/built_in_components/index.tsx
+++ b/public/components/FormGenerator/built_in_components/index.tsx
@@ -6,7 +6,7 @@ import React, { forwardRef, useRef } from "react";
 import {
   EuiCompressedFieldNumber,
   EuiCompressedFieldText,
-  EuiSwitch,
+  EuiCompressedSwitch,
   EuiCompressedSelect,
   EuiText,
   EuiCompressedCheckbox,
@@ -49,7 +49,7 @@ const componentMap: Record<ComponentMapEnum, React.ComponentType<IFieldComponent
   Switch: EuiToolTipWrapper(
     forwardRef(({ value, onChange, ...others }, ref: React.Ref<any>) => (
       <div ref={ref}>
-        <EuiSwitch showLabel={false} label="" checked={value || false} onChange={(e) => onChange(e.target.checked)} {...others} />
+        <EuiCompressedSwitch showLabel={false} label="" checked={value || false} onChange={(e) => onChange(e.target.checked)} {...others} />
       </div>
     )) as React.ComponentType<IFieldComponentProps>
   ),

--- a/public/components/FormGenerator/built_in_components/index.tsx
+++ b/public/components/FormGenerator/built_in_components/index.tsx
@@ -3,7 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React, { forwardRef, useRef } from "react";
-import { EuiFieldNumber, EuiFieldText, EuiSwitch, EuiSelect, EuiText, EuiCheckbox, EuiComboBoxOptionOption } from "@elastic/eui";
+import {
+  EuiCompressedFieldNumber,
+  EuiCompressedFieldText,
+  EuiSwitch,
+  EuiSelect,
+  EuiText,
+  EuiCheckbox,
+  EuiComboBoxOptionOption,
+} from "@elastic/eui";
 import EuiToolTipWrapper, { IEuiToolTipWrapperProps } from "../../EuiToolTipWrapper";
 import EuiComboBox from "../../ComboBoxWithoutWarning";
 
@@ -20,7 +28,7 @@ let globalId = 0;
 const componentMap: Record<ComponentMapEnum, React.ComponentType<IFieldComponentProps>> = {
   Input: EuiToolTipWrapper(
     forwardRef(({ onChange, value, removeWhenEmpty, ...others }, ref: React.Ref<HTMLInputElement>) => (
-      <EuiFieldText
+      <EuiCompressedFieldText
         inputRef={ref}
         value={value || ""}
         onChange={(e) => onChange(e.target.value ? e.target.value : removeWhenEmpty ? undefined : e.target.value)}
@@ -30,7 +38,7 @@ const componentMap: Record<ComponentMapEnum, React.ComponentType<IFieldComponent
   ),
   Number: EuiToolTipWrapper(
     forwardRef(({ onChange, value, removeWhenEmpty, ...others }, ref: React.Ref<HTMLInputElement>) => (
-      <EuiFieldNumber
+      <EuiCompressedFieldNumber
         inputRef={ref}
         onChange={(e) => onChange(e.target.value ? e.target.value : removeWhenEmpty ? undefined : e.target.value)}
         value={value === undefined ? "" : value}

--- a/public/components/FormGenerator/built_in_components/index.tsx
+++ b/public/components/FormGenerator/built_in_components/index.tsx
@@ -7,7 +7,7 @@ import {
   EuiCompressedFieldNumber,
   EuiCompressedFieldText,
   EuiSwitch,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiText,
   EuiCheckbox,
   EuiComboBoxOptionOption,
@@ -60,7 +60,7 @@ const componentMap: Record<ComponentMapEnum, React.ComponentType<IFieldComponent
   )) as React.ComponentType<IFieldComponentProps>,
   Select: EuiToolTipWrapper(
     forwardRef(({ onChange, value, ...others }, ref: React.Ref<any>) => (
-      <EuiSelect inputRef={ref} onChange={(e) => onChange(e.target.value)} value={value || ""} {...others} />
+      <EuiCompressedSelect inputRef={ref} onChange={(e) => onChange(e.target.value)} value={value || ""} {...others} />
     )) as React.ComponentType<IFieldComponentProps>
   ),
   CheckBox: EuiToolTipWrapper(

--- a/public/components/IndexDetail/IndexDetail.tsx
+++ b/public/components/IndexDetail/IndexDetail.tsx
@@ -6,7 +6,7 @@
 import React, { Ref, forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import {
   EuiSpacer,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiLink,
   EuiOverlayMask,
   EuiLoadingSpinner,
@@ -561,7 +561,7 @@ const IndexDetail = (
         ? null
         : (() => {
             const content = (
-              <EuiFormRow fullWidth>
+              <EuiCompressedFormRow fullWidth>
                 <IndexMapping
                   isEdit={isEdit}
                   value={finalValue?.mappings}
@@ -571,7 +571,7 @@ const IndexDetail = (
                   readonly={readonly}
                   docVersion={docVersion}
                 />
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             );
 
             if (mode && mode === IndicesUpdateMode.mappings) {
@@ -601,7 +601,7 @@ const IndexDetail = (
                         <OptionalLabel />
                       </div>
                     </EuiTitle>
-                    <EuiFormRow
+                    <EuiCompressedFormRow
                       fullWidth
                       helpText={
                         <>
@@ -616,7 +616,7 @@ const IndexDetail = (
                       }
                     >
                       <></>
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </>
                 }
                 titleSize="s"

--- a/public/components/IndexDetail/IndexDetail.tsx
+++ b/public/components/IndexDetail/IndexDetail.tsx
@@ -11,7 +11,7 @@ import {
   EuiOverlayMask,
   EuiLoadingSpinner,
   EuiContextMenu,
-  EuiButton,
+  EuiSmallButton,
   EuiCallOut,
   EuiTitle,
 } from "@elastic/eui";
@@ -445,9 +445,9 @@ const IndexDetail = (
             data-test-subj="moreAction"
             panelPaddingSize="none"
             button={
-              <EuiButton iconType="arrowDown" iconSide="right" data-test-subj="importSettingMappingBtn">
+              <EuiSmallButton iconType="arrowDown" iconSide="right" data-test-subj="importSettingMappingBtn">
                 Import settings and mappings
-              </EuiButton>
+              </EuiSmallButton>
             }
           >
             <EuiContextMenu

--- a/public/components/IndexDetail/__snapshots__/IndexDetail.test.tsx.snap
+++ b/public/components/IndexDetail/__snapshots__/IndexDetail.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`<IndexDetail /> spec renders the component 1`] = `
       class="euiForm"
     >
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         data-test-subj="form-name-index"
         id="some_html_id-row"
       >
@@ -57,13 +57,13 @@ exports[`<IndexDetail /> spec renders the component 1`] = `
             class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
-                  class="euiFieldText"
+                  class="euiFieldText euiFieldText--compressed"
                   placeholder="Specify a name for the new index."
                   type="text"
                   value=""
@@ -82,7 +82,7 @@ exports[`<IndexDetail /> spec renders the component 1`] = `
         </div>
       </div>
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         data-test-subj="form-name-templateMessage"
         id="some_html_id-row"
       >
@@ -91,7 +91,7 @@ exports[`<IndexDetail /> spec renders the component 1`] = `
         />
       </div>
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         data-test-subj="form-name-aliases"
         id="some_html_id-row"
       >
@@ -124,17 +124,17 @@ exports[`<IndexDetail /> spec renders the component 1`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              class="euiComboBox"
+              class="euiComboBox euiComboBox--compressed"
               role="combobox"
             >
               <div
-                class="euiFormControlLayout"
+                class="euiFormControlLayout euiFormControlLayout--compressed"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <div
-                    class="euiComboBox__inputWrap euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
+                    class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
                     data-test-subj="comboBoxInput"
                     tabindex="-1"
                   >

--- a/public/components/IndexMapping/IndexMapping.tsx
+++ b/public/components/IndexMapping/IndexMapping.tsx
@@ -4,7 +4,17 @@
  */
 
 import React, { forwardRef, useCallback, useState, Ref, useRef, useMemo, useImperativeHandle } from "react";
-import { EuiTreeView, EuiIcon, EuiTreeViewProps, EuiButton, EuiSmallButton, EuiSpacer, EuiButtonGroup, EuiLink, EuiCallOut } from "@elastic/eui";
+import {
+  EuiTreeView,
+  EuiIcon,
+  EuiTreeViewProps,
+  EuiSmallButton,
+  EuiButton,
+  EuiSpacer,
+  EuiButtonGroup,
+  EuiLink,
+  EuiCallOut,
+} from "@elastic/eui";
 import { set, get, isEmpty } from "lodash";
 import MonacoJSONEditor, { IJSONEditorRef } from "../MonacoJSONEditor";
 import { Modal } from "../Modal";

--- a/public/components/IndexMapping/IndexMapping.tsx
+++ b/public/components/IndexMapping/IndexMapping.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { forwardRef, useCallback, useState, Ref, useRef, useMemo, useImperativeHandle } from "react";
-import { EuiTreeView, EuiIcon, EuiTreeViewProps, EuiButton, EuiSpacer, EuiButtonGroup, EuiLink, EuiCallOut } from "@elastic/eui";
+import { EuiTreeView, EuiIcon, EuiTreeViewProps, EuiButton, EuiSmallButton, EuiSpacer, EuiButtonGroup, EuiLink, EuiCallOut } from "@elastic/eui";
 import { set, get, isEmpty } from "lodash";
 import MonacoJSONEditor, { IJSONEditorRef } from "../MonacoJSONEditor";
 import { Modal } from "../Modal";
@@ -194,16 +194,10 @@ const IndexMapping = (
           {readonly ? null : (
             <>
               <EuiSpacer />
-              <EuiButton
-                size={useNewUx ? "s" : undefined}
-                style={{ marginRight: 8 }}
-                data-test-subj="createIndexAddFieldButton"
-                onClick={() => addField("")}
-              >
+              <EuiSmallButton style={{ marginRight: 8 }} data-test-subj="createIndexAddFieldButton" onClick={() => addField("")}>
                 Add new field
-              </EuiButton>
-              <EuiButton
-                size={useNewUx ? "s" : undefined}
+              </EuiSmallButton>
+              <EuiSmallButton
                 data-test-subj="createIndexAddObjectFieldButton"
                 onClick={() =>
                   addField("", {
@@ -212,7 +206,7 @@ const IndexMapping = (
                 }
               >
                 Add new object
-              </EuiButton>
+              </EuiSmallButton>
             </>
           )}
         </>

--- a/public/components/IndexMapping/__snapshots__/IndexMapping.test.tsx.snap
+++ b/public/components/IndexMapping/__snapshots__/IndexMapping.test.tsx.snap
@@ -689,7 +689,7 @@ exports[`<IndexMapping /> spec render mappings with object type 1`] = `
     class="euiSpacer euiSpacer--l"
   />
   <button
-    class="euiButton euiButton--primary"
+    class="euiButton euiButton--primary euiButton--small"
     data-test-subj="createIndexAddFieldButton"
     style="margin-right: 8px;"
     type="button"
@@ -705,7 +705,7 @@ exports[`<IndexMapping /> spec render mappings with object type 1`] = `
     </span>
   </button>
   <button
-    class="euiButton euiButton--primary"
+    class="euiButton euiButton--primary euiButton--small"
     data-test-subj="createIndexAddObjectFieldButton"
     type="button"
   >

--- a/public/components/JSONDiffEditor/JSONDiffEditor.tsx
+++ b/public/components/JSONDiffEditor/JSONDiffEditor.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React, { forwardRef, useState, useEffect, useRef, useImperativeHandle, useCallback } from "react";
-import { EuiFormRow } from "@elastic/eui";
+import { EuiCompressedFormRow } from "@elastic/eui";
 import { MonacoDiffEditor } from "react-monaco-editor";
 import { monaco } from "@osd/monaco";
 import CustomFormRow from "../CustomFormRow";
@@ -135,13 +135,13 @@ const JSONDiffEditor = forwardRef(({ value, onChange, ...others }: JSONDiffEdito
         />
       </div>
       {confirmModalVisible && (
-        <EuiFormRow
+        <EuiCompressedFormRow
           fullWidth
           isInvalid={confirmModalVisible}
           error="Your input does not match the validation of json format, please fix the error line with error aside."
         >
           <></>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       )}
     </>
   );

--- a/public/components/JSONDiffEditor/JSONTextArea.tsx
+++ b/public/components/JSONDiffEditor/JSONTextArea.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { forwardRef, useState, useEffect, useImperativeHandle, useRef } from "react";
-import { EuiFormRow } from "@elastic/eui";
+import { EuiCompressedFormRow } from "@elastic/eui";
 import type { MonacoDiffEditorProps } from "react-monaco-editor";
 import { IJSONEditorRef } from "../JSONEditor";
 import CustomFormRow from "../CustomFormRow";
@@ -74,13 +74,13 @@ const JSONDiffEditor = forwardRef(({ value, onChange, ...others }: JSONDiffEdito
         </div>
       </div>
       {confirmModalVisible && (
-        <EuiFormRow
+        <EuiCompressedFormRow
           fullWidth
           isInvalid={confirmModalVisible}
           error="Your input does not match the validation of json format, please fix the error line with error aside."
         >
           <></>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       )}
     </div>
   );

--- a/public/components/JSONEditor/JSONEditor.tsx
+++ b/public/components/JSONEditor/JSONEditor.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React, { useState, useEffect, forwardRef, useImperativeHandle, useRef } from "react";
-import { EuiCodeEditor, EuiCodeEditorProps, EuiFormRow } from "@elastic/eui";
+import { EuiCodeEditor, EuiCodeEditorProps, EuiCompressedFormRow } from "@elastic/eui";
 
 export interface JSONEditorProps extends Partial<EuiCodeEditorProps> {
   disabled?: boolean;
@@ -75,13 +75,13 @@ const JSONEditor = forwardRef(({ value, onChange, disabled, ...others }: JSONEdi
         }}
       />
       {confirmModalVisible && (
-        <EuiFormRow
+        <EuiCompressedFormRow
           fullWidth
           isInvalid={confirmModalVisible}
           error="Your input does not match the validation of json format, please fix the error line with error aside."
         >
           <></>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       )}
     </>
   );

--- a/public/components/JSONModal/JSONModal.tsx
+++ b/public/components/JSONModal/JSONModal.tsx
@@ -12,7 +12,7 @@ import {
   EuiModalHeaderTitle,
   EuiOverlayMask,
   EuiCodeBlock,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
 } from "@elastic/eui";
 
 interface JSONModalProps {
@@ -36,9 +36,9 @@ const JSONModal: React.SFC<JSONModalProps> = ({ title, json, onClose }) => {
         </EuiModalBody>
 
         <EuiModalFooter>
-          <EuiButtonEmpty onClick={onClose} data-test-subj="jsonModalCloseButton">
+          <EuiSmallButtonEmpty onClick={onClose} data-test-subj="jsonModalCloseButton">
             Close
-          </EuiButtonEmpty>
+          </EuiSmallButtonEmpty>
         </EuiModalFooter>
       </EuiModal>
     </EuiOverlayMask>

--- a/public/components/JSONModal/__snapshots__/JSONModal.test.tsx.snap
+++ b/public/components/JSONModal/__snapshots__/JSONModal.test.tsx.snap
@@ -258,7 +258,7 @@ exports[`<JSONModal /> spec renders the component 1`] = `
           class="euiModalFooter"
         >
           <button
-            class="euiButtonEmpty euiButtonEmpty--primary"
+            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
             data-test-subj="jsonModalCloseButton"
             type="button"
           >

--- a/public/components/LegacyNotification/LegacyNotification.tsx
+++ b/public/components/LegacyNotification/LegacyNotification.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { EuiFormRow, EuiCallOut, EuiSmallButton, EuiSpacer } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiCallOut, EuiSmallButton, EuiSpacer } from "@elastic/eui";
 import "brace/theme/github";
 import "brace/mode/json";
 import { DarkModeConsumer } from "../../components/DarkMode";
@@ -28,7 +28,7 @@ const LegacyNotification = ({ value, onChange, onSwitchToChannels }: LegacyNotif
         <EuiSmallButton onClick={onSwitchToChannels}>Switch to using Channel ID</EuiSmallButton>
       </EuiCallOut>
       <EuiSpacer size="m" />
-      <EuiFormRow fullWidth style={{ maxWidth: "100%" }}>
+      <EuiCompressedFormRow fullWidth style={{ maxWidth: "100%" }}>
         <DarkModeConsumer>
           {(isDarkMode) => (
             <JSONEditor
@@ -42,7 +42,7 @@ const LegacyNotification = ({ value, onChange, onSwitchToChannels }: LegacyNotif
             />
           )}
         </DarkModeConsumer>
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </>
   );
 };

--- a/public/components/LegacyNotification/LegacyNotification.tsx
+++ b/public/components/LegacyNotification/LegacyNotification.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { EuiFormRow, EuiCallOut, EuiButton, EuiSpacer } from "@elastic/eui";
+import { EuiFormRow, EuiCallOut, EuiSmallButton, EuiSpacer } from "@elastic/eui";
 import "brace/theme/github";
 import "brace/mode/json";
 import { DarkModeConsumer } from "../../components/DarkMode";
@@ -25,7 +25,7 @@ const LegacyNotification = ({ value, onChange, onSwitchToChannels }: LegacyNotif
           Using Channel ID will give you more control to manage notifications across OpenSearch dashboards. If you do decide to switch, you
           will lose your current error notification settings.
         </p>
-        <EuiButton onClick={onSwitchToChannels}>Switch to using Channel ID</EuiButton>
+        <EuiSmallButton onClick={onSwitchToChannels}>Switch to using Channel ID</EuiSmallButton>
       </EuiCallOut>
       <EuiSpacer size="m" />
       <EuiFormRow fullWidth style={{ maxWidth: "100%" }}>

--- a/public/components/LegacyNotification/__snapshots__/LegacyNotification.test.tsx.snap
+++ b/public/components/LegacyNotification/__snapshots__/LegacyNotification.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`<LegacyNotification /> spec renders the component 1`] = `
         Using Channel ID will give you more control to manage notifications across OpenSearch dashboards. If you do decide to switch, you will lose your current error notification settings.
       </p>
       <button
-        class="euiButton euiButton--primary"
+        class="euiButton euiButton--primary euiButton--small"
         type="button"
       >
         <span

--- a/public/components/Modal/Modal.tsx
+++ b/public/components/Modal/Modal.tsx
@@ -13,7 +13,7 @@ import {
   EuiModalProps,
   EuiModalBodyProps,
   EuiButtonProps,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
 } from "@elastic/eui";
 import React, { Component, createContext, useEffect, useState } from "react";
 import { render } from "react-dom";
@@ -72,7 +72,7 @@ interface IShowOptions extends Pick<EuiModalProps, "style" | "maxWidth" | "class
   footer?: footerEnum[];
   bodyProps?: EuiModalBodyProps;
   confirmButtonProps?: EuiButtonProps;
-  CancelButtonComponent?: typeof EuiSmallButton | typeof EuiButtonEmpty;
+  CancelButtonComponent?: typeof EuiSmallButton | typeof EuiSmallButtonEmpty;
 }
 
 const blank = () => null;
@@ -89,7 +89,7 @@ const SimpleModal = (props: IShowOptions) => {
     visible,
     footer = ["confirm", "cancel"],
     confirmButtonProps,
-    CancelButtonComponent = EuiButtonEmpty,
+    CancelButtonComponent = EuiSmallButtonEmpty,
     ...others
   } = props;
   const testSubj = props["data-test-subj"] || title || Date.now();

--- a/public/components/Modal/Modal.tsx
+++ b/public/components/Modal/Modal.tsx
@@ -7,7 +7,7 @@ import {
   EuiModal,
   EuiModalHeader,
   EuiModalHeaderTitle,
-  EuiButton,
+  EuiSmallButton,
   EuiModalBody,
   EuiModalFooter,
   EuiModalProps,
@@ -72,7 +72,7 @@ interface IShowOptions extends Pick<EuiModalProps, "style" | "maxWidth" | "class
   footer?: footerEnum[];
   bodyProps?: EuiModalBodyProps;
   confirmButtonProps?: EuiButtonProps;
-  CancelButtonComponent?: typeof EuiButton | typeof EuiButtonEmpty;
+  CancelButtonComponent?: typeof EuiSmallButton | typeof EuiButtonEmpty;
 }
 
 const blank = () => null;
@@ -127,7 +127,7 @@ const SimpleModal = (props: IShowOptions) => {
             {footer.map((item) => {
               if (item === "confirm") {
                 return (
-                  <EuiButton
+                  <EuiSmallButton
                     key={item}
                     fill
                     color="primary"
@@ -143,7 +143,7 @@ const SimpleModal = (props: IShowOptions) => {
                     {...confirmButtonProps}
                   >
                     {finalLocale.confirm}
-                  </EuiButton>
+                  </EuiSmallButton>
                 );
               } else if (item === "cancel") {
                 return (
@@ -163,7 +163,7 @@ const SimpleModal = (props: IShowOptions) => {
           </>
         ) : (
           <>
-            <EuiButton
+            <EuiSmallButton
               fill
               color="primary"
               data-test-subj={`${testSubj}-ok`}
@@ -177,7 +177,7 @@ const SimpleModal = (props: IShowOptions) => {
               }}
             >
               {finalLocale.ok}
-            </EuiButton>
+            </EuiSmallButton>
           </>
         )}
       </EuiModalFooter>

--- a/public/components/MonacoJSONEditor/MonacoJSONEditor.tsx
+++ b/public/components/MonacoJSONEditor/MonacoJSONEditor.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React, { forwardRef, useState, useEffect, useRef, useImperativeHandle, useCallback } from "react";
-import { EuiFormRow } from "@elastic/eui";
+import { EuiCompressedFormRow } from "@elastic/eui";
 import MonacoEditor from "react-monaco-editor";
 import { monaco } from "@osd/monaco";
 import { IJSONEditorRef } from "../JSONEditor";
@@ -131,13 +131,13 @@ const MonacoJSONEditor = forwardRef(
           />
         </div>
         {confirmModalVisible && (
-          <EuiFormRow
+          <EuiCompressedFormRow
             fullWidth
             isInvalid={confirmModalVisible}
             error="Your input does not match the validation of json format, please fix the error line with error aside."
           >
             <></>
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         )}
       </>
     );

--- a/public/components/PolicyModal/PolicyModal.tsx
+++ b/public/components/PolicyModal/PolicyModal.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
@@ -62,14 +62,14 @@ const PolicyModal: React.SFC<PolicyModalProps> = ({ policyId, policy, errorMessa
               </EuiButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton onClick={() => onEdit(false)} fill disabled={!policyId || !policy} data-test-subj="policyModalEditJsonButton">
+              <EuiSmallButton onClick={() => onEdit(false)} fill disabled={!policyId || !policy} data-test-subj="policyModalEditJsonButton">
                 Edit as JSON
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton onClick={() => onEdit(true)} fill disabled={!policyId || !policy} data-test-subj="policyModalEditButton">
+              <EuiSmallButton onClick={() => onEdit(true)} fill disabled={!policyId || !policy} data-test-subj="policyModalEditButton">
                 Edit
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiModalFooter>

--- a/public/components/PolicyModal/PolicyModal.tsx
+++ b/public/components/PolicyModal/PolicyModal.tsx
@@ -13,7 +13,7 @@ import {
   EuiModalHeaderTitle,
   EuiOverlayMask,
   EuiCodeBlock,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   // @ts-ignore
   EuiCopy,
   EuiFlexGroup,
@@ -50,16 +50,16 @@ const PolicyModal: React.SFC<PolicyModalProps> = ({ policyId, policy, errorMessa
             <EuiFlexItem grow={false} style={{ marginRight: "auto" }}>
               <EuiCopy textToCopy={policyString}>
                 {(copy: () => void) => (
-                  <EuiButtonEmpty iconType="copyClipboard" onClick={copy} disabled={!policy} data-test-subj="policyModalCopyButton">
+                  <EuiSmallButtonEmpty iconType="copyClipboard" onClick={copy} disabled={!policy} data-test-subj="policyModalCopyButton">
                     Copy
-                  </EuiButtonEmpty>
+                  </EuiSmallButtonEmpty>
                 )}
               </EuiCopy>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty onClick={onClose} data-test-subj="policyModalCloseButton">
+              <EuiSmallButtonEmpty onClick={onClose} data-test-subj="policyModalCloseButton">
                 Close
-              </EuiButtonEmpty>
+              </EuiSmallButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiSmallButton onClick={() => onEdit(false)} fill disabled={!policyId || !policy} data-test-subj="policyModalEditJsonButton">

--- a/public/components/PolicyModal/__snapshots__/PolicyModal.test.tsx.snap
+++ b/public/components/PolicyModal/__snapshots__/PolicyModal.test.tsx.snap
@@ -153,7 +153,7 @@ exports[`<PolicyModal /> spec renders the component 1`] = `
                 class="euiToolTipAnchor"
               >
                 <button
-                  class="euiButtonEmpty euiButtonEmpty--primary"
+                  class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
                   data-test-subj="policyModalCopyButton"
                   type="button"
                 >
@@ -174,7 +174,7 @@ exports[`<PolicyModal /> spec renders the component 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButtonEmpty euiButtonEmpty--primary"
+                class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
                 data-test-subj="policyModalCloseButton"
                 type="button"
               >
@@ -193,7 +193,7 @@ exports[`<PolicyModal /> spec renders the component 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButton euiButton--primary euiButton--fill"
+                class="euiButton euiButton--primary euiButton--small euiButton--fill"
                 data-test-subj="policyModalEditJsonButton"
                 type="button"
               >
@@ -212,7 +212,7 @@ exports[`<PolicyModal /> spec renders the component 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButton euiButton--primary euiButton--fill"
+                class="euiButton euiButton--primary euiButton--small euiButton--fill"
                 data-test-subj="policyModalEditButton"
                 type="button"
               >

--- a/public/components/RemoteSelect/__snapshots__/RemoteSelect.test.tsx.snap
+++ b/public/components/RemoteSelect/__snapshots__/RemoteSelect.test.tsx.snap
@@ -4,17 +4,17 @@ exports[`<AliasSelect /> spec renders the component 1`] = `
 <div
   aria-expanded="false"
   aria-haspopup="listbox"
-  class="euiComboBox"
+  class="euiComboBox euiComboBox--compressed"
   role="combobox"
 >
   <div
-    class="euiFormControlLayout"
+    class="euiFormControlLayout euiFormControlLayout--compressed"
   >
     <div
       class="euiFormControlLayout__childrenWrapper"
     >
       <div
-        class="euiComboBox__inputWrap euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
+        class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
         data-test-subj="comboBoxInput"
         tabindex="-1"
       >
@@ -58,17 +58,17 @@ exports[`<AliasSelect /> spec renders with error 1`] = `
 <div
   aria-expanded="false"
   aria-haspopup="listbox"
-  class="euiComboBox"
+  class="euiComboBox euiComboBox--compressed"
   role="combobox"
 >
   <div
-    class="euiFormControlLayout"
+    class="euiFormControlLayout euiFormControlLayout--compressed"
   >
     <div
       class="euiFormControlLayout__childrenWrapper"
     >
       <div
-        class="euiComboBox__inputWrap euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
+        class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
         data-test-subj="comboBoxInput"
         tabindex="-1"
       >

--- a/public/components/RemoteSelect/index.tsx
+++ b/public/components/RemoteSelect/index.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useCallback, useRef, useState, forwardRef } from "react";
-import { EuiComboBox, EuiComboBoxProps } from "@elastic/eui";
+import { EuiCompressedComboBox, EuiComboBoxProps } from "@elastic/eui";
 import { useEffect } from "react";
 import { debounce } from "lodash";
 import { ServerResponse } from "../../../server/models/types";
@@ -75,7 +75,7 @@ const RemoteSelect = forwardRef((props: RemoteSelectProps, ref: React.Ref<HTMLIn
     }
   };
   return (
-    <EuiComboBox
+    <EuiCompressedComboBox
       onCreateOption={onCreateOption}
       {...others}
       inputRef={ref as (instance: HTMLInputElement | null) => void}

--- a/public/components/SwitchableEditor/SwitchableEditor.tsx
+++ b/public/components/SwitchableEditor/SwitchableEditor.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiSpacer, EuiSwitch } from "@elastic/eui";
+import { EuiSpacer, EuiCompressedSwitch } from "@elastic/eui";
 import React, { forwardRef, useRef, useState, useImperativeHandle } from "react";
 import JSONEditor, { IJSONEditorRef } from "../JSONEditor";
 import MonacoJSONEditor, { MonacoJSONEditorProps } from "../MonacoJSONEditor";
@@ -30,7 +30,7 @@ const SwitchableEditor = forwardRef(
         {mode === "diff" ? (
           <>
             <EuiSpacer />
-            <EuiSwitch
+            <EuiCompressedSwitch
               label="Compare previously saved settings"
               checked={checked}
               onChange={async (e) => {

--- a/public/components/SwitchableEditor/__snapshots__/SwitchableEditor.test.tsx.snap
+++ b/public/components/SwitchableEditor/__snapshots__/SwitchableEditor.test.tsx.snap
@@ -7,7 +7,7 @@ HTMLCollection [
       class="euiSpacer euiSpacer--l"
     />
     <div
-      class="euiSwitch euiSwitch--primary"
+      class="euiSwitch euiSwitch--primary euiSwitch--compressed"
     >
       <button
         aria-checked="false"
@@ -25,10 +25,7 @@ HTMLCollection [
           />
           <span
             class="euiSwitch__track"
-          >
-            EuiIconMock
-            EuiIconMock
-          </span>
+          />
         </span>
       </button>
       <span
@@ -169,7 +166,7 @@ HTMLCollection [
       class="euiSpacer euiSpacer--l"
     />
     <div
-      class="euiSwitch euiSwitch--primary"
+      class="euiSwitch euiSwitch--primary euiSwitch--compressed"
     >
       <button
         aria-checked="true"
@@ -187,10 +184,7 @@ HTMLCollection [
           />
           <span
             class="euiSwitch__track"
-          >
-            EuiIconMock
-            EuiIconMock
-          </span>
+          />
         </span>
       </button>
       <span
@@ -218,7 +212,7 @@ HTMLCollection [
           style="flex-grow: 1;"
         >
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             id="some_html_id-row"
           >
             <div
@@ -247,7 +241,7 @@ HTMLCollection [
           style="flex-grow: 1;"
         >
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             id="some_html_id-row"
           >
             <div

--- a/public/components/UnsavedChangesBottomBar/UnsavedChangesBottomBar.tsx
+++ b/public/components/UnsavedChangesBottomBar/UnsavedChangesBottomBar.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { EuiSmallButton, EuiFlexGroup, EuiFlexItem, EuiButtonEmpty, EuiButtonProps, EuiButtonEmptyProps } from "@elastic/eui";
+import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiSmallButtonEmpty, EuiButtonProps, EuiButtonEmptyProps } from "@elastic/eui";
 import classNames from "classnames";
 import BottomBar from "../BottomBar";
 import "./index.scss";
@@ -50,7 +50,7 @@ export default function UnsavedChangesBottomBar(props: CustomFormRowProps) {
   const renderCancel = useCallback(
     () => (
       <EuiFlexItem grow={false}>
-        <EuiButtonEmpty onClick={onClickCancel} color="ghost" iconType="cross" children="Cancel" {...props.cancelButtonprops} />
+        <EuiSmallButtonEmpty onClick={onClickCancel} color="ghost" iconType="cross" children="Cancel" {...props.cancelButtonprops} />
       </EuiFlexItem>
     ),
     [onClickCancel]
@@ -59,7 +59,7 @@ export default function UnsavedChangesBottomBar(props: CustomFormRowProps) {
   const renderConfirm = useCallback(
     () => (
       <EuiFlexItem grow={false}>
-        <EuiSmallButton
+        <EuiButton
           data-test-subj={submitButtonDataTestSubj}
           onClick={onClick}
           isLoading={loading}

--- a/public/components/UnsavedChangesBottomBar/UnsavedChangesBottomBar.tsx
+++ b/public/components/UnsavedChangesBottomBar/UnsavedChangesBottomBar.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiButtonEmpty, EuiButtonProps, EuiButtonEmptyProps } from "@elastic/eui";
+import { EuiSmallButton, EuiFlexGroup, EuiFlexItem, EuiButtonEmpty, EuiButtonProps, EuiButtonEmptyProps } from "@elastic/eui";
 import classNames from "classnames";
 import BottomBar from "../BottomBar";
 import "./index.scss";
@@ -59,7 +59,7 @@ export default function UnsavedChangesBottomBar(props: CustomFormRowProps) {
   const renderConfirm = useCallback(
     () => (
       <EuiFlexItem grow={false}>
-        <EuiButton
+        <EuiSmallButton
           data-test-subj={submitButtonDataTestSubj}
           onClick={onClick}
           isLoading={loading}

--- a/public/components/UnsavedChangesBottomBar/__snapshots__/UnsavedChangesBottomBar.test.tsx.snap
+++ b/public/components/UnsavedChangesBottomBar/__snapshots__/UnsavedChangesBottomBar.test.tsx.snap
@@ -20,7 +20,7 @@ HTMLCollection [
           class="euiFlexItem euiFlexItem--flexGrowZero"
         >
           <button
-            class="euiButtonEmpty euiButtonEmpty--ghost"
+            class="euiButtonEmpty euiButtonEmpty--ghost euiButtonEmpty--small"
             type="button"
           >
             <span

--- a/public/containers/ChannelSelect/__snapshots__/ChannelSelect.test.tsx.snap
+++ b/public/containers/ChannelSelect/__snapshots__/ChannelSelect.test.tsx.snap
@@ -16,17 +16,17 @@ exports[`<ChannelNotification /> spec renders the component 1`] = `
         <div
           aria-expanded="false"
           aria-haspopup="listbox"
-          class="euiComboBox channelSelect-combobox"
+          class="euiComboBox channelSelect-combobox euiComboBox--compressed"
           role="combobox"
         >
           <div
-            class="euiFormControlLayout"
+            class="euiFormControlLayout euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <div
-                class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                 data-test-subj="comboBoxInput"
                 tabindex="-1"
               >
@@ -83,17 +83,17 @@ exports[`<ChannelNotification /> spec renders the component 1`] = `
         <div
           aria-expanded="false"
           aria-haspopup="listbox"
-          class="euiComboBox channelSelect-combobox"
+          class="euiComboBox channelSelect-combobox euiComboBox--compressed"
           role="combobox"
         >
           <div
-            class="euiFormControlLayout"
+            class="euiFormControlLayout euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <div
-                class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                 data-test-subj="comboBoxInput"
                 tabindex="-1"
               >

--- a/public/containers/ClearCacheModal/ClearCacheModal.tsx
+++ b/public/containers/ClearCacheModal/ClearCacheModal.tsx
@@ -12,7 +12,7 @@ import { CoreServicesContext } from "../../components/core_services";
 import { INDEX_OP_BLOCKS_TYPE, INDEX_OP_TARGET_TYPE } from "../../utils/constants";
 import { getErrorMessage, filterBlockedItems } from "../../utils/helpers";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiCallOut,
   EuiModal,
@@ -218,14 +218,14 @@ export default function ClearCacheModal(props: ClearCacheModalProps) {
         <EuiButtonEmpty data-test-subj="ClearCacheCancelButton" onClick={onClose}>
           Cancel
         </EuiButtonEmpty>
-        <EuiButton
+        <EuiSmallButton
           data-test-subj="ClearCacheConfirmButton"
           onClick={onConfirm}
           fill
           isDisabled={selectedItems.length > 0 && unBlockedItems.length == 0}
         >
           Clear cache
-        </EuiButton>
+        </EuiSmallButton>
       </EuiModalFooter>
     </EuiModal>
   );

--- a/public/containers/ClearCacheModal/ClearCacheModal.tsx
+++ b/public/containers/ClearCacheModal/ClearCacheModal.tsx
@@ -13,7 +13,7 @@ import { INDEX_OP_BLOCKS_TYPE, INDEX_OP_TARGET_TYPE } from "../../utils/constant
 import { getErrorMessage, filterBlockedItems } from "../../utils/helpers";
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiCallOut,
   EuiModal,
   EuiModalBody,
@@ -215,9 +215,9 @@ export default function ClearCacheModal(props: ClearCacheModalProps) {
       <EuiModalBody>{!!selectedItems && selectedItems.length > 0 ? specificIndexesChildren : noSpecificIndexesChildren}</EuiModalBody>
 
       <EuiModalFooter>
-        <EuiButtonEmpty data-test-subj="ClearCacheCancelButton" onClick={onClose}>
+        <EuiSmallButtonEmpty data-test-subj="ClearCacheCancelButton" onClick={onClose}>
           Cancel
-        </EuiButtonEmpty>
+        </EuiSmallButtonEmpty>
         <EuiSmallButton
           data-test-subj="ClearCacheConfirmButton"
           onClick={onConfirm}

--- a/public/containers/ClearCacheModal/__snapshots__/ClearCacheModal.test.tsx.snap
+++ b/public/containers/ClearCacheModal/__snapshots__/ClearCacheModal.test.tsx.snap
@@ -65,7 +65,7 @@ HTMLCollection [
             class="euiModalFooter"
           >
             <button
-              class="euiButtonEmpty euiButtonEmpty--primary"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
               data-test-subj="ClearCacheCancelButton"
               type="button"
             >
@@ -80,7 +80,7 @@ HTMLCollection [
               </span>
             </button>
             <button
-              class="euiButton euiButton--primary euiButton--fill"
+              class="euiButton euiButton--primary euiButton--small euiButton--fill"
               data-test-subj="ClearCacheConfirmButton"
               type="button"
             >

--- a/public/containers/ErrorNotification/__snapshots__/ErrorNotification.test.tsx.snap
+++ b/public/containers/ErrorNotification/__snapshots__/ErrorNotification.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`<ErrorNotification /> spec renders the component 1`] = `
       style="padding: 10px 0px 0px 10px;"
     >
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -107,13 +107,13 @@ exports[`<ErrorNotification /> spec renders the component 1`] = `
               class="euiFlexItem"
             >
               <div
-                class="euiFormControlLayout"
+                class="euiFormControlLayout euiFormControlLayout--compressed"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <select
-                    class="euiSelect"
+                    class="euiSelect euiSelect--compressed"
                     data-test-subj="create-policy-notification-channel-id"
                     id="channel-id"
                     placeholder="Select channel ID"
@@ -143,7 +143,7 @@ exports[`<ErrorNotification /> spec renders the component 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButton euiButton--primary refresh-button"
+                class="euiButton euiButton--primary euiButton--small refresh-button"
                 data-test-subj="channel-notification-refresh"
                 type="button"
               >
@@ -161,7 +161,7 @@ exports[`<ErrorNotification /> spec renders the component 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <a
-                class="euiButton euiButton--primary"
+                class="euiButton euiButton--primary euiButton--small"
                 href="notifications-dashboards#/channels"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -185,7 +185,7 @@ exports[`<ErrorNotification /> spec renders the component 1`] = `
         class="euiSpacer euiSpacer--m"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
         title="Notification message"
       >

--- a/public/containers/FlushIndexModal/FlushIndexModal.tsx
+++ b/public/containers/FlushIndexModal/FlushIndexModal.tsx
@@ -5,7 +5,7 @@
 
 import React, { useCallback, useContext, useState, useEffect } from "react";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiCallOut,
   EuiModal,
@@ -191,9 +191,9 @@ export default function FlushIndexModal(props: FlushIndexModalProps) {
         <EuiButtonEmpty data-test-subj="flushCancelButton" onClick={onClose}>
           Cancel
         </EuiButtonEmpty>
-        <EuiButton data-test-subj="flushConfirmButton" onClick={onFlushConfirm} fill>
+        <EuiSmallButton data-test-subj="flushConfirmButton" onClick={onFlushConfirm} fill>
           Flush
-        </EuiButton>
+        </EuiSmallButton>
       </EuiModalFooter>
     </EuiModal>
   );

--- a/public/containers/FlushIndexModal/FlushIndexModal.tsx
+++ b/public/containers/FlushIndexModal/FlushIndexModal.tsx
@@ -6,7 +6,7 @@
 import React, { useCallback, useContext, useState, useEffect } from "react";
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiCallOut,
   EuiModal,
   EuiModalBody,
@@ -188,9 +188,9 @@ export default function FlushIndexModal(props: FlushIndexModalProps) {
       </EuiModalBody>
 
       <EuiModalFooter>
-        <EuiButtonEmpty data-test-subj="flushCancelButton" onClick={onClose}>
+        <EuiSmallButtonEmpty data-test-subj="flushCancelButton" onClick={onClose}>
           Cancel
-        </EuiButtonEmpty>
+        </EuiSmallButtonEmpty>
         <EuiSmallButton data-test-subj="flushConfirmButton" onClick={onFlushConfirm} fill>
           Flush
         </EuiSmallButton>

--- a/public/containers/FlushIndexModal/__snapshots__/FlushIndexModal.test.tsx.snap
+++ b/public/containers/FlushIndexModal/__snapshots__/FlushIndexModal.test.tsx.snap
@@ -102,7 +102,7 @@ HTMLCollection [
             class="euiModalFooter"
           >
             <button
-              class="euiButtonEmpty euiButtonEmpty--primary"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
               data-test-subj="flushCancelButton"
               type="button"
             >
@@ -117,7 +117,7 @@ HTMLCollection [
               </span>
             </button>
             <button
-              class="euiButton euiButton--primary euiButton--fill"
+              class="euiButton euiButton--primary euiButton--small euiButton--fill"
               data-test-subj="flushConfirmButton"
               type="button"
             >
@@ -248,7 +248,7 @@ HTMLCollection [
             class="euiModalFooter"
           >
             <button
-              class="euiButtonEmpty euiButtonEmpty--primary"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
               data-test-subj="flushCancelButton"
               type="button"
             >
@@ -263,7 +263,7 @@ HTMLCollection [
               </span>
             </button>
             <button
-              class="euiButton euiButton--primary euiButton--fill"
+              class="euiButton euiButton--primary euiButton--small euiButton--fill"
               data-test-subj="flushConfirmButton"
               type="button"
             >
@@ -397,7 +397,7 @@ HTMLCollection [
             class="euiModalFooter"
           >
             <button
-              class="euiButtonEmpty euiButtonEmpty--primary"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
               data-test-subj="flushCancelButton"
               type="button"
             >
@@ -412,7 +412,7 @@ HTMLCollection [
               </span>
             </button>
             <button
-              class="euiButton euiButton--primary euiButton--fill"
+              class="euiButton euiButton--primary euiButton--small euiButton--fill"
               data-test-subj="flushConfirmButton"
               type="button"
             >
@@ -530,7 +530,7 @@ HTMLCollection [
             class="euiModalFooter"
           >
             <button
-              class="euiButtonEmpty euiButtonEmpty--primary"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
               data-test-subj="flushCancelButton"
               type="button"
             >
@@ -545,7 +545,7 @@ HTMLCollection [
               </span>
             </button>
             <button
-              class="euiButton euiButton--primary euiButton--fill"
+              class="euiButton euiButton--primary euiButton--small euiButton--fill"
               data-test-subj="flushConfirmButton"
               type="button"
             >
@@ -673,7 +673,7 @@ HTMLCollection [
             class="euiModalFooter"
           >
             <button
-              class="euiButtonEmpty euiButtonEmpty--primary"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
               data-test-subj="flushCancelButton"
               type="button"
             >
@@ -688,7 +688,7 @@ HTMLCollection [
               </span>
             </button>
             <button
-              class="euiButton euiButton--primary euiButton--fill"
+              class="euiButton euiButton--primary euiButton--small euiButton--fill"
               data-test-subj="flushConfirmButton"
               type="button"
             >

--- a/public/containers/IndexForm/__snapshots__/IndexForm.test.tsx.snap
+++ b/public/containers/IndexForm/__snapshots__/IndexForm.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`<IndexForm /> spec render page 1`] = `
         class="euiForm"
       >
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           data-test-subj="form-name-index"
           id="some_html_id-row"
         >
@@ -58,13 +58,13 @@ exports[`<IndexForm /> spec render page 1`] = `
               class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
             >
               <div
-                class="euiFormControlLayout"
+                class="euiFormControlLayout euiFormControlLayout--compressed"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <input
-                    class="euiFieldText"
+                    class="euiFieldText euiFieldText--compressed"
                     placeholder="Specify a name for the new index."
                     type="text"
                     value=""
@@ -83,7 +83,7 @@ exports[`<IndexForm /> spec render page 1`] = `
           </div>
         </div>
         <div
-          class="euiFormRow euiFormRow--fullWidth"
+          class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
           data-test-subj="form-name-templateMessage"
           id="some_html_id-row"
         >
@@ -92,7 +92,7 @@ exports[`<IndexForm /> spec render page 1`] = `
           />
         </div>
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           data-test-subj="form-name-aliases"
           id="some_html_id-row"
         >
@@ -125,17 +125,17 @@ exports[`<IndexForm /> spec render page 1`] = `
               <div
                 aria-expanded="false"
                 aria-haspopup="listbox"
-                class="euiComboBox"
+                class="euiComboBox euiComboBox--compressed"
                 role="combobox"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <div
-                      class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                      class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                       data-test-subj="comboBoxInput"
                       tabindex="-1"
                     >
@@ -218,7 +218,7 @@ exports[`<IndexForm /> spec render page 1`] = `
         class="euiForm"
       >
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           data-test-subj="form-name-index.number_of_shards"
           id="some_html_id-row"
         >
@@ -251,13 +251,13 @@ exports[`<IndexForm /> spec render page 1`] = `
               class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
             >
               <div
-                class="euiFormControlLayout"
+                class="euiFormControlLayout euiFormControlLayout--compressed"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <input
-                    class="euiFieldNumber"
+                    class="euiFieldNumber euiFieldNumber--compressed"
                     placeholder="Specify primary shard count."
                     type="number"
                     value=""
@@ -268,7 +268,7 @@ exports[`<IndexForm /> spec render page 1`] = `
           </div>
         </div>
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           data-test-subj="form-name-index.number_of_replicas"
           id="some_html_id-row"
         >
@@ -296,13 +296,13 @@ exports[`<IndexForm /> spec render page 1`] = `
               class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
             >
               <div
-                class="euiFormControlLayout"
+                class="euiFormControlLayout euiFormControlLayout--compressed"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <input
-                    class="euiFieldNumber"
+                    class="euiFieldNumber euiFieldNumber--compressed"
                     placeholder="Specify number of replicas."
                     type="number"
                     value=""
@@ -313,7 +313,7 @@ exports[`<IndexForm /> spec render page 1`] = `
           </div>
         </div>
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           data-test-subj="form-name-index.refresh_interval"
           id="some_html_id-row"
         >
@@ -341,13 +341,13 @@ exports[`<IndexForm /> spec render page 1`] = `
               class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
             >
               <div
-                class="euiFormControlLayout"
+                class="euiFormControlLayout euiFormControlLayout--compressed"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <input
-                    class="euiFieldText"
+                    class="euiFieldText euiFieldText--compressed"
                     placeholder="Can be set to -1 to disable refreshing."
                     type="text"
                     value=""
@@ -403,7 +403,7 @@ exports[`<IndexForm /> spec render page 1`] = `
                   class="euiSpacer euiSpacer--s"
                 />
                 <div
-                  class="euiFormRow euiFormRow--fullWidth"
+                  class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                   data-test-subj="formNameAdvancedSettings"
                   id="some_html_id-row"
                 >
@@ -612,7 +612,7 @@ exports[`<IndexForm /> spec render page 1`] = `
           </i>
         </div>
         <div
-          class="euiFormRow euiFormRow--fullWidth"
+          class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -655,7 +655,7 @@ exports[`<IndexForm /> spec render page 1`] = `
       style="padding: 0px 10px;"
     >
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -735,7 +735,7 @@ exports[`<IndexForm /> spec render page 1`] = `
             class="euiSpacer euiSpacer--l"
           />
           <button
-            class="euiButton euiButton--primary"
+            class="euiButton euiButton--primary euiButton--small"
             data-test-subj="createIndexAddFieldButton"
             style="margin-right: 8px;"
             type="button"
@@ -751,7 +751,7 @@ exports[`<IndexForm /> spec render page 1`] = `
             </span>
           </button>
           <button
-            class="euiButton euiButton--primary"
+            class="euiButton euiButton--primary euiButton--small"
             data-test-subj="createIndexAddObjectFieldButton"
             type="button"
           >

--- a/public/containers/NotificationConfig/NotificationConfig.tsx
+++ b/public/containers/NotificationConfig/NotificationConfig.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useRef, forwardRef, useMemo, useImperativeHandle, useContext, useEffect, useState } from "react";
-import { EuiBadge, EuiButton, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from "@elastic/eui";
+import { EuiBadge, EuiSmallButton, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from "@elastic/eui";
 import ChannelSelect, { useChannels } from "../ChannelSelect";
 import { AllBuiltInComponents } from "../../components/FormGenerator";
 import {
@@ -224,9 +224,9 @@ const NotificationConfig = (
                     />
                   </EuiFlexItem>
                   <EuiFlexItem>
-                    <EuiButton onClick={() => window.open("/app/notifications-dashboards#/channels")} iconType="popout">
+                    <EuiSmallButton onClick={() => window.open("/app/notifications-dashboards#/channels")} iconType="popout">
                       Manage channels
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                 </EuiFlexGroup>
               </CustomFormRow>

--- a/public/containers/NotificationConfig/__snapshots__/NotificationConfig.test.tsx.snap
+++ b/public/containers/NotificationConfig/__snapshots__/NotificationConfig.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`<ChannelNotification /> spec renders with create permission and no defa
       class="euiSpacer euiSpacer--l"
     />
     <div
-      class="euiFormRow"
+      class="euiFormRow euiFormRow--compressed"
       id="some_html_id-row"
     >
       <div
@@ -55,7 +55,7 @@ exports[`<ChannelNotification /> spec renders with create permission and no defa
           class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
         >
           <div
-            class="euiCheckbox"
+            class="euiCheckbox euiCheckbox--compressed"
           >
             <input
               class="euiCheckbox__input"
@@ -81,7 +81,7 @@ exports[`<ChannelNotification /> spec renders with create permission and no defa
           class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
         >
           <div
-            class="euiCheckbox"
+            class="euiCheckbox euiCheckbox--compressed"
           >
             <input
               class="euiCheckbox__input"
@@ -162,7 +162,7 @@ exports[`<ChannelNotification /> spec renders with full permission and default n
         class="euiFlexItem"
       >
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -195,7 +195,7 @@ exports[`<ChannelNotification /> spec renders with full permission and default n
         class="euiFlexItem"
       >
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -243,7 +243,7 @@ exports[`<ChannelNotification /> spec renders with full permission and default n
       class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
     >
       <div
-        class="euiCheckbox"
+        class="euiCheckbox euiCheckbox--compressed"
       >
         <input
           class="euiCheckbox__input"
@@ -316,7 +316,7 @@ exports[`<ChannelNotification /> spec renders with full permission and no defaul
       class="euiSpacer euiSpacer--l"
     />
     <div
-      class="euiFormRow"
+      class="euiFormRow euiFormRow--compressed"
       id="some_html_id-row"
     >
       <div
@@ -336,7 +336,7 @@ exports[`<ChannelNotification /> spec renders with full permission and no defaul
           class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
         >
           <div
-            class="euiCheckbox"
+            class="euiCheckbox euiCheckbox--compressed"
           >
             <input
               class="euiCheckbox__input"
@@ -362,7 +362,7 @@ exports[`<ChannelNotification /> spec renders with full permission and no defaul
           class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
         >
           <div
-            class="euiCheckbox"
+            class="euiCheckbox euiCheckbox--compressed"
           >
             <input
               class="euiCheckbox__input"
@@ -442,7 +442,7 @@ exports[`<ChannelNotification /> spec renders with view permission and default n
         class="euiFlexItem"
       >
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -475,7 +475,7 @@ exports[`<ChannelNotification /> spec renders with view permission and default n
         class="euiFlexItem"
       >
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div

--- a/public/containers/RefreshAction/index.tsx
+++ b/public/containers/RefreshAction/index.tsx
@@ -6,7 +6,7 @@
 import React, { useCallback, useContext, useEffect, useState } from "react";
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiCallOut,
   EuiModal,
   EuiModalBody,
@@ -208,7 +208,7 @@ export default function RefreshActionModal<T>(props: RefreshActionModalProps) {
       </EuiModalBody>
 
       <EuiModalFooter>
-        <EuiButtonEmpty onClick={onClose}>Cancel</EuiButtonEmpty>
+        <EuiSmallButtonEmpty onClick={onClose}>Cancel</EuiSmallButtonEmpty>
         <EuiSmallButton data-test-subj="refreshConfirmButton" onClick={onConfirm} fill>
           Refresh
         </EuiSmallButton>

--- a/public/containers/RefreshAction/index.tsx
+++ b/public/containers/RefreshAction/index.tsx
@@ -5,7 +5,7 @@
 
 import React, { useCallback, useContext, useEffect, useState } from "react";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiCallOut,
   EuiModal,
@@ -209,9 +209,9 @@ export default function RefreshActionModal<T>(props: RefreshActionModalProps) {
 
       <EuiModalFooter>
         <EuiButtonEmpty onClick={onClose}>Cancel</EuiButtonEmpty>
-        <EuiButton data-test-subj="refreshConfirmButton" onClick={onConfirm} fill>
+        <EuiSmallButton data-test-subj="refreshConfirmButton" onClick={onConfirm} fill>
           Refresh
-        </EuiButton>
+        </EuiSmallButton>
       </EuiModalFooter>
     </EuiModal>
   );

--- a/public/pages/Aliases/components/IndexControls/IndexControls.tsx
+++ b/public/pages/Aliases/components/IndexControls/IndexControls.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useEffect, useState } from "react";
-import { EuiComboBox, EuiFieldSearch, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiComboBox, EuiCompressedFieldSearch, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import { ALIAS_STATUS_OPTIONS, IndicesUpdateMode } from "../../../../utils/constants";
 import { getUISettings } from "../../../../services/Services";
 import AliasesActions from "../../containers/AliasActions";
@@ -44,8 +44,7 @@ export default function SearchControls(props: SearchControlsProps) {
   return useUpdatedUX ? (
     <EuiFlexGroup style={{ padding: "0px 5px" }} alignItems="center">
       <EuiFlexItem>
-        <EuiFieldSearch
-          compressed
+        <EuiCompressedFieldSearch
           fullWidth
           placeholder="Search"
           value={state.search}
@@ -75,7 +74,12 @@ export default function SearchControls(props: SearchControlsProps) {
   ) : (
     <EuiFlexGroup style={{ padding: "0px 5px" }} alignItems="center">
       <EuiFlexItem>
-        <EuiFieldSearch fullWidth placeholder="Search..." value={state.search} onChange={(e) => onChange("search", e.target.value)} />
+        <EuiCompressedFieldSearch
+          fullWidth
+          placeholder="Search..."
+          value={state.search}
+          onChange={(e) => onChange("search", e.target.value)}
+        />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiComboBox

--- a/public/pages/Aliases/components/IndexControls/IndexControls.tsx
+++ b/public/pages/Aliases/components/IndexControls/IndexControls.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useEffect, useState } from "react";
-import { EuiComboBox, EuiCompressedFieldSearch, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiCompressedComboBox, EuiCompressedFieldSearch, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import { ALIAS_STATUS_OPTIONS, IndicesUpdateMode } from "../../../../utils/constants";
 import { getUISettings } from "../../../../services/Services";
 import AliasesActions from "../../containers/AliasActions";
@@ -82,7 +82,7 @@ export default function SearchControls(props: SearchControlsProps) {
         />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiComboBox
+        <EuiCompressedComboBox
           style={{
             width: 300,
           }}

--- a/public/pages/Aliases/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
+++ b/public/pages/Aliases/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
@@ -9,13 +9,13 @@ exports[`<IndexControls /> spec renders the component 1`] = `
     class="euiFlexItem"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <input
-          class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
+          class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch-isClearable"
           placeholder="Search..."
           type="search"
           value="testing"
@@ -34,7 +34,7 @@ exports[`<IndexControls /> spec renders the component 1`] = `
         >
           <button
             aria-label="Clear input"
-            class="euiFormControlLayoutClearButton"
+            class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
             type="button"
           >
             EuiIconMock
@@ -49,18 +49,18 @@ exports[`<IndexControls /> spec renders the component 1`] = `
     <div
       aria-expanded="false"
       aria-haspopup="listbox"
-      class="euiComboBox"
+      class="euiComboBox euiComboBox--compressed"
       role="combobox"
       style="width: 300px;"
     >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout euiFormControlLayout--compressed"
       >
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+            class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
             data-test-subj="comboBoxInput"
             tabindex="-1"
           >
@@ -107,7 +107,7 @@ exports[`<IndexControls /> spec renders the component 1`] = `
           >
             <button
               aria-label="Clear input"
-              class="euiFormControlLayoutClearButton"
+              class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
               data-test-subj="comboBoxClearButton"
               type="button"
             >

--- a/public/pages/Aliases/containers/AliasActions/__snapshots__/AliasActions.test.tsx.snap
+++ b/public/pages/Aliases/containers/AliasActions/__snapshots__/AliasActions.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`<AliasesActions /> spec cannot clear cache for aliases if some indexes 
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -36,7 +36,7 @@ exports[`<AliasesActions /> spec clear cache for aliases by calling commonServic
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -63,7 +63,7 @@ exports[`<AliasesActions /> spec delete alias by calling commonService 1`] = `
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -90,7 +90,7 @@ exports[`<AliasesActions /> spec filter aliases failed when clearing caches for 
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -124,7 +124,7 @@ exports[`<AliasesActions /> spec refresh alias by calling commonService 1`] = `
         class="euiPopover__anchor"
       >
         <button
-          class="euiButton euiButton--primary"
+          class="euiButton euiButton--primary euiButton--small"
           type="button"
         >
           <span
@@ -242,7 +242,7 @@ exports[`<AliasesActions /> spec refresh alias by calling commonService 1`] = `
             class="euiModalFooter"
           >
             <button
-              class="euiButtonEmpty euiButtonEmpty--primary"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
               type="button"
             >
               <span
@@ -256,7 +256,7 @@ exports[`<AliasesActions /> spec refresh alias by calling commonService 1`] = `
               </span>
             </button>
             <button
-              class="euiButton euiButton--primary euiButton--fill"
+              class="euiButton euiButton--primary euiButton--small euiButton--fill"
               data-test-subj="refreshConfirmButton"
               type="button"
             >
@@ -301,7 +301,7 @@ exports[`<AliasesActions /> spec refresh multi alias even failed to get index st
         class="euiPopover__anchor"
       >
         <button
-          class="euiButton euiButton--primary"
+          class="euiButton euiButton--primary euiButton--small"
           type="button"
         >
           <span
@@ -392,7 +392,7 @@ exports[`<AliasesActions /> spec refresh multi alias even failed to get index st
             class="euiModalFooter"
           >
             <button
-              class="euiButtonEmpty euiButtonEmpty--primary"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
               type="button"
             >
               <span
@@ -406,7 +406,7 @@ exports[`<AliasesActions /> spec refresh multi alias even failed to get index st
               </span>
             </button>
             <button
-              class="euiButton euiButton--primary euiButton--fill"
+              class="euiButton euiButton--primary euiButton--small euiButton--fill"
               data-test-subj="refreshConfirmButton"
               type="button"
             >
@@ -449,7 +449,7 @@ HTMLCollection [
         class="euiPopover__anchor"
       >
         <button
-          class="euiButton euiButton--primary"
+          class="euiButton euiButton--primary euiButton--small"
           type="button"
         >
           <span
@@ -562,7 +562,7 @@ HTMLCollection [
             class="euiModalFooter"
           >
             <button
-              class="euiButtonEmpty euiButtonEmpty--primary"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
               data-test-subj="flushCancelButton"
               type="button"
             >
@@ -577,7 +577,7 @@ HTMLCollection [
               </span>
             </button>
             <button
-              class="euiButton euiButton--primary euiButton--fill"
+              class="euiButton euiButton--primary euiButton--small euiButton--fill"
               data-test-subj="flushConfirmButton"
               type="button"
             >
@@ -615,7 +615,7 @@ exports[`<AliasesActions /> spec renders the component and all the actions shoul
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span

--- a/public/pages/Aliases/containers/AliasActions/index.tsx
+++ b/public/pages/Aliases/containers/AliasActions/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React, { useMemo, useState } from "react";
-import { EuiButton, EuiContextMenu } from "@elastic/eui";
+import { EuiSmallButton, EuiContextMenu } from "@elastic/eui";
 import { RouteComponentProps } from "react-router-dom";
 import SimplePopover from "../../../../components/SimplePopover";
 import DeleteIndexModal from "../DeleteAliasModal";
@@ -56,9 +56,9 @@ export default function AliasesActions(props: AliasesActionsProps) {
         data-test-subj="moreAction"
         panelPaddingSize="none"
         button={
-          <EuiButton iconType="arrowDown" iconSide="right" size={size}>
+          <EuiSmallButton iconType="arrowDown" iconSide="right">
             Actions
-          </EuiButton>
+          </EuiSmallButton>
         }
       >
         <EuiContextMenu

--- a/public/pages/Aliases/containers/Aliases/Aliases.tsx
+++ b/public/pages/Aliases/containers/Aliases/Aliases.tsx
@@ -21,7 +21,7 @@ import {
   EuiText,
   EuiLink,
   EuiTitle,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiEmptyPrompt,
   EuiSmallButton,
 } from "@elastic/eui";
@@ -531,7 +531,7 @@ class Aliases extends MDSEnabledComponent<AliasesProps, AliasesState> {
             <EuiTitle>
               <span>Aliases</span>
             </EuiTitle>
-            <EuiFormRow
+            <EuiCompressedFormRow
               fullWidth
               helpText={
                 <div style={{ width: "50%" }}>
@@ -544,7 +544,7 @@ class Aliases extends MDSEnabledComponent<AliasesProps, AliasesState> {
               }
             >
               <></>
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </>
         }
       >

--- a/public/pages/Aliases/containers/Aliases/Aliases.tsx
+++ b/public/pages/Aliases/containers/Aliases/Aliases.tsx
@@ -307,7 +307,7 @@ class Aliases extends MDSEnabledComponent<AliasesProps, AliasesState> {
     const description = [
       {
         renderComponent: (
-          <EuiFormRow
+          <EuiCompressedFormRow
             fullWidth
             helpText={
               <div style={{ width: "51%" }}>
@@ -320,7 +320,7 @@ class Aliases extends MDSEnabledComponent<AliasesProps, AliasesState> {
             }
           >
             <></>
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         ),
       },
     ];

--- a/public/pages/Aliases/containers/Aliases/Aliases.tsx
+++ b/public/pages/Aliases/containers/Aliases/Aliases.tsx
@@ -23,7 +23,7 @@ import {
   EuiTitle,
   EuiFormRow,
   EuiEmptyPrompt,
-  EuiButton,
+  EuiSmallButton,
 } from "@elastic/eui";
 import { ContentPanel, ContentPanelActions } from "../../../../components/ContentPanel";
 import { DEFAULT_PAGE_SIZE_OPTIONS, DEFAULT_QUERY_PARAMS } from "../../utils/constants";
@@ -325,8 +325,6 @@ class Aliases extends MDSEnabledComponent<AliasesProps, AliasesState> {
       },
     ];
 
-    const Buttonsize = this.state.useUpdatedUX ? "s" : undefined;
-
     const commonRender = () => {
       return (
         <>
@@ -395,8 +393,7 @@ class Aliases extends MDSEnabledComponent<AliasesProps, AliasesState> {
                     </EuiText>
                   }
                   actions={[
-                    <EuiButton
-                      size={Buttonsize}
+                    <EuiSmallButton
                       fill
                       onClick={() => {
                         this.setState({
@@ -405,7 +402,7 @@ class Aliases extends MDSEnabledComponent<AliasesProps, AliasesState> {
                       }}
                     >
                       Create alias
-                    </EuiButton>,
+                    </EuiSmallButton>,
                   ]}
                 />
               ) : (
@@ -416,8 +413,7 @@ class Aliases extends MDSEnabledComponent<AliasesProps, AliasesState> {
                     </EuiText>
                   }
                   actions={[
-                    <EuiButton
-                      size={Buttonsize}
+                    <EuiSmallButton
                       fill
                       onClick={() => {
                         this.setState(defaultFilter, () => {
@@ -426,7 +422,7 @@ class Aliases extends MDSEnabledComponent<AliasesProps, AliasesState> {
                       }}
                     >
                       Reset filters
-                    </EuiButton>,
+                    </EuiSmallButton>,
                   ]}
                 />
               )

--- a/public/pages/Aliases/containers/Aliases/__snapshots__/Aliases.test.tsx.snap
+++ b/public/pages/Aliases/containers/Aliases/__snapshots__/Aliases.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`<Aliases /> spec renders the component 1`] = `
         Aliases
       </span>
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -75,7 +75,7 @@ exports[`<Aliases /> spec renders the component 1`] = `
                   class="euiPopover__anchor"
                 >
                   <button
-                    class="euiButton euiButton--primary"
+                    class="euiButton euiButton--primary euiButton--small"
                     type="button"
                   >
                     <span
@@ -96,7 +96,7 @@ exports[`<Aliases /> spec renders the component 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButton euiButton--primary euiButton--fill"
+                class="euiButton euiButton--primary euiButton--small euiButton--fill"
                 data-test-subj="Create aliasButton"
                 type="button"
               >
@@ -130,13 +130,13 @@ exports[`<Aliases /> spec renders the component 1`] = `
         class="euiFlexItem"
       >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+          class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
         >
           <div
             class="euiFormControlLayout__childrenWrapper"
           >
             <input
-              class="euiFieldSearch euiFieldSearch--fullWidth"
+              class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
               placeholder="Search..."
               type="search"
               value=""
@@ -159,18 +159,18 @@ exports[`<Aliases /> spec renders the component 1`] = `
         <div
           aria-expanded="false"
           aria-haspopup="listbox"
-          class="euiComboBox"
+          class="euiComboBox euiComboBox--compressed"
           role="combobox"
           style="width: 300px;"
         >
           <div
-            class="euiFormControlLayout"
+            class="euiFormControlLayout euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <div
-                class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                 data-test-subj="comboBoxInput"
                 tabindex="-1"
               >
@@ -421,7 +421,7 @@ exports[`<Aliases /> spec renders the component 1`] = `
                           class="euiFlexItem euiFlexItem--flexGrowZero"
                         >
                           <button
-                            class="euiButton euiButton--primary euiButton--fill"
+                            class="euiButton euiButton--primary euiButton--small euiButton--fill"
                             type="button"
                           >
                             <span

--- a/public/pages/Aliases/containers/CreateAlias/__snapshots__/CreateAlias.test.tsx.snap
+++ b/public/pages/Aliases/containers/CreateAlias/__snapshots__/CreateAlias.test.tsx.snap
@@ -55,7 +55,7 @@ HTMLCollection [
                 class="euiForm"
               >
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   data-test-subj="form-name-alias"
                   id="some_html_id-row"
                 >
@@ -77,13 +77,13 @@ HTMLCollection [
                       class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
                     >
                       <div
-                        class="euiFormControlLayout"
+                        class="euiFormControlLayout euiFormControlLayout--compressed"
                       >
                         <div
                           class="euiFormControlLayout__childrenWrapper"
                         >
                           <input
-                            class="euiFieldText"
+                            class="euiFieldText euiFieldText--compressed"
                             placeholder="Specify alias name"
                             type="text"
                             value=""
@@ -100,7 +100,7 @@ HTMLCollection [
                   </div>
                 </div>
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   data-test-subj="form-name-indexArray"
                   id="some_html_id-row"
                 >
@@ -127,17 +127,17 @@ HTMLCollection [
                     <div
                       aria-expanded="false"
                       aria-haspopup="listbox"
-                      class="euiComboBox"
+                      class="euiComboBox euiComboBox--compressed"
                       role="combobox"
                     >
                       <div
-                        class="euiFormControlLayout"
+                        class="euiFormControlLayout euiFormControlLayout--compressed"
                       >
                         <div
                           class="euiFormControlLayout__childrenWrapper"
                         >
                           <div
-                            class="euiComboBox__inputWrap euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
+                            class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
                             data-test-subj="comboBoxInput"
                             tabindex="-1"
                           >
@@ -193,7 +193,7 @@ HTMLCollection [
           >
             <div>
               <button
-                class="euiButton euiButton--primary"
+                class="euiButton euiButton--primary euiButton--small"
                 data-test-subj="cancelCreateAliasButton"
                 style="margin-right: 20px;"
                 type="button"
@@ -209,7 +209,7 @@ HTMLCollection [
                 </span>
               </button>
               <button
-                class="euiButton euiButton--primary euiButton--fill"
+                class="euiButton euiButton--primary euiButton--small euiButton--fill"
                 data-test-subj="createAliasButton"
                 type="button"
               >

--- a/public/pages/Aliases/containers/CreateAlias/index.tsx
+++ b/public/pages/Aliases/containers/CreateAlias/index.tsx
@@ -4,7 +4,7 @@
  */
 import React, { useContext, useEffect, useRef } from "react";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiCallOut,
   EuiModal,
   EuiModalHeader,
@@ -188,10 +188,10 @@ export default function CreateAlias(props: ICreateAliasProps) {
       </EuiModalBody>
       <EuiModalFooter>
         <div>
-          <EuiButton data-test-subj="cancelCreateAliasButton" style={{ marginRight: 20 }} onClick={props.onClose}>
+          <EuiSmallButton data-test-subj="cancelCreateAliasButton" style={{ marginRight: 20 }} onClick={props.onClose}>
             Cancel
-          </EuiButton>
-          <EuiButton
+          </EuiSmallButton>
+          <EuiSmallButton
             fill
             color="primary"
             data-test-subj="createAliasButton"
@@ -241,7 +241,7 @@ export default function CreateAlias(props: ICreateAliasProps) {
             }}
           >
             {isEdit ? "Save changes" : "Create alias"}
-          </EuiButton>
+          </EuiSmallButton>
         </div>
       </EuiModalFooter>
     </EuiModal>

--- a/public/pages/Aliases/containers/DeleteAliasModal/DeleteAliasModal.tsx
+++ b/public/pages/Aliases/containers/DeleteAliasModal/DeleteAliasModal.tsx
@@ -6,7 +6,7 @@
 import React, { useCallback, useContext, useEffect, useState } from "react";
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiCallOut,
   EuiFieldText,
   EuiModal,
@@ -103,7 +103,7 @@ export default function DeleteAliasModal(props: DeleteAliasModalProps) {
       </EuiModalBody>
 
       <EuiModalFooter>
-        <EuiButtonEmpty onClick={onClose}>Cancel</EuiButtonEmpty>
+        <EuiSmallButtonEmpty onClick={onClose}>Cancel</EuiSmallButtonEmpty>
         <EuiSmallButton data-test-subj="deleteConfirmButton" onClick={onConfirm} fill color="danger" disabled={value !== "delete"}>
           Delete
         </EuiSmallButton>

--- a/public/pages/Aliases/containers/DeleteAliasModal/DeleteAliasModal.tsx
+++ b/public/pages/Aliases/containers/DeleteAliasModal/DeleteAliasModal.tsx
@@ -5,7 +5,7 @@
 
 import React, { useCallback, useContext, useEffect, useState } from "react";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiCallOut,
   EuiFieldText,
@@ -104,9 +104,9 @@ export default function DeleteAliasModal(props: DeleteAliasModalProps) {
 
       <EuiModalFooter>
         <EuiButtonEmpty onClick={onClose}>Cancel</EuiButtonEmpty>
-        <EuiButton data-test-subj="deleteConfirmButton" onClick={onConfirm} fill color="danger" disabled={value !== "delete"}>
+        <EuiSmallButton data-test-subj="deleteConfirmButton" onClick={onConfirm} fill color="danger" disabled={value !== "delete"}>
           Delete
-        </EuiButton>
+        </EuiSmallButton>
       </EuiModalFooter>
     </EuiModal>
   );

--- a/public/pages/Aliases/containers/DeleteAliasModal/DeleteAliasModal.tsx
+++ b/public/pages/Aliases/containers/DeleteAliasModal/DeleteAliasModal.tsx
@@ -8,7 +8,7 @@ import {
   EuiSmallButton,
   EuiSmallButtonEmpty,
   EuiCallOut,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
@@ -92,7 +92,7 @@ export default function DeleteAliasModal(props: DeleteAliasModalProps) {
           <EuiText color="subdued">
             To confirm your action, type <b style={{ color: "#000" }}>delete</b>.
           </EuiText>
-          <EuiFieldText
+          <EuiCompressedFieldText
             data-test-subj="deleteInput"
             placeholder="delete"
             fullWidth

--- a/public/pages/Aliases/containers/DeleteAliasModal/__snapshots__/DeleteAliasModal.test.tsx.snap
+++ b/public/pages/Aliases/containers/DeleteAliasModal/__snapshots__/DeleteAliasModal.test.tsx.snap
@@ -76,13 +76,13 @@ HTMLCollection [
                   </div>
                 </div>
                 <div
-                  class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                  class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <input
-                      class="euiFieldText euiFieldText--fullWidth"
+                      class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
                       data-test-subj="deleteInput"
                       placeholder="delete"
                       type="text"
@@ -97,7 +97,7 @@ HTMLCollection [
             class="euiModalFooter"
           >
             <button
-              class="euiButtonEmpty euiButtonEmpty--primary"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
               type="button"
             >
               <span
@@ -111,7 +111,7 @@ HTMLCollection [
               </span>
             </button>
             <button
-              class="euiButton euiButton--danger euiButton--fill euiButton-isDisabled"
+              class="euiButton euiButton--danger euiButton--small euiButton--fill euiButton-isDisabled"
               data-test-subj="deleteConfirmButton"
               disabled=""
               type="button"

--- a/public/pages/ChangePolicy/components/ChangeManagedIndices/ChangeManagedIndices.tsx
+++ b/public/pages/ChangePolicy/components/ChangeManagedIndices/ChangeManagedIndices.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { Component } from "react";
-import { EuiSpacer, EuiComboBox, EuiFormRow } from "@elastic/eui";
+import { EuiSpacer, EuiComboBox, EuiCompressedFormRow } from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
 import { ManagedIndexService } from "../../../../services";
 import { ManagedIndexItem, State } from "../../../../../models/interfaces";
@@ -93,7 +93,7 @@ export default class ChangeManagedIndices extends Component<ChangeManagedIndices
       <ContentPanel bodyStyles={{ padding: "initial" }} title="Choose managed indices" titleSize="s">
         <div style={{ paddingLeft: "10px" }}>
           <EuiSpacer size="m" />
-          <EuiFormRow
+          <EuiCompressedFormRow
             label="Managed indices"
             helpText="You can use * as wildcards to form index patterns."
             isInvalid={!!managedIndicesError}
@@ -111,9 +111,9 @@ export default class ChangeManagedIndices extends Component<ChangeManagedIndices
               onSearchChange={this.onManagedIndexSearchChange}
               compressed={useUpdatedUX ? true : false}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
 
-          <EuiFormRow label="State filters" helpText="Apply new policy only on managed indices in these states.">
+          <EuiCompressedFormRow label="State filters" helpText="Apply new policy only on managed indices in these states.">
             <EuiComboBox
               isDisabled={!selectedManagedIndices.length}
               placeholder="Choose state filters"
@@ -124,7 +124,7 @@ export default class ChangeManagedIndices extends Component<ChangeManagedIndices
               onSearchChange={this.onStateFilterSearchChange}
               compressed={useUpdatedUX ? true : false}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </div>
       </ContentPanel>
     );

--- a/public/pages/ChangePolicy/components/ChangeManagedIndices/ChangeManagedIndices.tsx
+++ b/public/pages/ChangePolicy/components/ChangeManagedIndices/ChangeManagedIndices.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { Component } from "react";
-import { EuiSpacer, EuiComboBox, EuiCompressedFormRow } from "@elastic/eui";
+import { EuiSpacer, EuiCompressedComboBox, EuiCompressedFormRow } from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
 import { ManagedIndexService } from "../../../../services";
 import { ManagedIndexItem, State } from "../../../../../models/interfaces";
@@ -99,7 +99,7 @@ export default class ChangeManagedIndices extends Component<ChangeManagedIndices
             isInvalid={!!managedIndicesError}
             error={managedIndicesError}
           >
-            <EuiComboBox
+            <EuiCompressedComboBox
               placeholder=""
               async
               options={managedIndices}
@@ -114,7 +114,7 @@ export default class ChangeManagedIndices extends Component<ChangeManagedIndices
           </EuiCompressedFormRow>
 
           <EuiCompressedFormRow label="State filters" helpText="Apply new policy only on managed indices in these states.">
-            <EuiComboBox
+            <EuiCompressedComboBox
               isDisabled={!selectedManagedIndices.length}
               placeholder="Choose state filters"
               options={stateOptions}

--- a/public/pages/ChangePolicy/components/ChangeManagedIndices/__snapshots__/ChangeManagedIndices.test.tsx.snap
+++ b/public/pages/ChangePolicy/components/ChangeManagedIndices/__snapshots__/ChangeManagedIndices.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`<ChangeManagedIndices /> spec renders the component 1`] = `
         class="euiSpacer euiSpacer--m"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -59,17 +59,17 @@ exports[`<ChangeManagedIndices /> spec renders the component 1`] = `
             aria-describedby="some_html_id-help-0"
             aria-expanded="false"
             aria-haspopup="listbox"
-            class="euiComboBox"
+            class="euiComboBox euiComboBox--compressed"
             role="combobox"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <div
-                  class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                  class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                   data-test-subj="comboBoxInput"
                   tabindex="-1"
                 >
@@ -114,7 +114,7 @@ exports[`<ChangeManagedIndices /> spec renders the component 1`] = `
         </div>
       </div>
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -134,17 +134,17 @@ exports[`<ChangeManagedIndices /> spec renders the component 1`] = `
             aria-describedby="some_html_id-help-0"
             aria-expanded="false"
             aria-haspopup="listbox"
-            class="euiComboBox euiComboBox-isDisabled"
+            class="euiComboBox euiComboBox--compressed euiComboBox-isDisabled"
             role="combobox"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <div
-                  class="euiComboBox__inputWrap"
+                  class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed"
                   data-test-subj="comboBoxInput"
                   tabindex="-1"
                 >

--- a/public/pages/ChangePolicy/components/ChangeManagedIndices/__snapshots__/ChangeManagedIndices.test.tsx.snap
+++ b/public/pages/ChangePolicy/components/ChangeManagedIndices/__snapshots__/ChangeManagedIndices.test.tsx.snap
@@ -59,17 +59,17 @@ exports[`<ChangeManagedIndices /> spec renders the component 1`] = `
             aria-describedby="some_html_id-help-0"
             aria-expanded="false"
             aria-haspopup="listbox"
-            class="euiComboBox euiComboBox--compressed"
+            class="euiComboBox"
             role="combobox"
           >
             <div
-              class="euiFormControlLayout euiFormControlLayout--compressed"
+              class="euiFormControlLayout"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <div
-                  class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
+                  class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
                   data-test-subj="comboBoxInput"
                   tabindex="-1"
                 >
@@ -134,17 +134,17 @@ exports[`<ChangeManagedIndices /> spec renders the component 1`] = `
             aria-describedby="some_html_id-help-0"
             aria-expanded="false"
             aria-haspopup="listbox"
-            class="euiComboBox euiComboBox--compressed euiComboBox-isDisabled"
+            class="euiComboBox euiComboBox-isDisabled"
             role="combobox"
           >
             <div
-              class="euiFormControlLayout euiFormControlLayout--compressed"
+              class="euiFormControlLayout"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <div
-                  class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed"
+                  class="euiComboBox__inputWrap"
                   data-test-subj="comboBoxInput"
                   tabindex="-1"
                 >

--- a/public/pages/ChangePolicy/components/NewPolicy/NewPolicy.tsx
+++ b/public/pages/ChangePolicy/components/NewPolicy/NewPolicy.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import _ from "lodash";
-import { EuiSpacer, EuiText, EuiRadioGroup, EuiFormRow, EuiSelect, EuiComboBox, EuiLink, EuiIcon } from "@elastic/eui";
+import { EuiSpacer, EuiText, EuiRadioGroup, EuiCompressedFormRow, EuiSelect, EuiComboBox, EuiLink, EuiIcon } from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
 import { IndexService } from "../../../../services";
 import { Radio } from "../../containers/ChangePolicy/ChangePolicy";
@@ -102,7 +102,7 @@ export default class NewPolicy extends React.Component<NewPolicyProps, NewPolicy
 
           <EuiSpacer size="s" />
 
-          <EuiFormRow label="New policy" isInvalid={!!selectedPoliciesError} error={selectedPoliciesError}>
+          <EuiCompressedFormRow label="New policy" isInvalid={!!selectedPoliciesError} error={selectedPoliciesError}>
             <EuiComboBox
               placeholder=""
               async
@@ -116,7 +116,7 @@ export default class NewPolicy extends React.Component<NewPolicyProps, NewPolicy
               onSearchChange={this.onPolicySearchChange}
               compressed={useUpdatedUX ? true : false}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
 
           <EuiSpacer size="m" />
 
@@ -124,7 +124,7 @@ export default class NewPolicy extends React.Component<NewPolicyProps, NewPolicy
 
           <EuiSpacer size="s" />
 
-          <EuiFormRow>
+          <EuiCompressedFormRow>
             <EuiSelect
               disabled={stateRadioIdSelected !== Radio.State}
               options={stateOptions}
@@ -133,7 +133,7 @@ export default class NewPolicy extends React.Component<NewPolicyProps, NewPolicy
               aria-label="Start state for new policy"
               compressed={useUpdatedUX ? true : false}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </div>
       </ContentPanel>
     );

--- a/public/pages/ChangePolicy/components/NewPolicy/NewPolicy.tsx
+++ b/public/pages/ChangePolicy/components/NewPolicy/NewPolicy.tsx
@@ -5,7 +5,16 @@
 
 import React from "react";
 import _ from "lodash";
-import { EuiSpacer, EuiText, EuiRadioGroup, EuiCompressedFormRow, EuiCompressedSelect, EuiComboBox, EuiLink, EuiIcon } from "@elastic/eui";
+import {
+  EuiSpacer,
+  EuiText,
+  EuiCompressedRadioGroup,
+  EuiCompressedFormRow,
+  EuiCompressedSelect,
+  EuiComboBox,
+  EuiLink,
+  EuiIcon,
+} from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
 import { IndexService } from "../../../../services";
 import { Radio } from "../../containers/ChangePolicy/ChangePolicy";
@@ -120,7 +129,7 @@ export default class NewPolicy extends React.Component<NewPolicyProps, NewPolicy
 
           <EuiSpacer size="m" />
 
-          <EuiRadioGroup options={radioOptions} idSelected={stateRadioIdSelected} onChange={this.props.onChangeStateRadio} />
+          <EuiCompressedRadioGroup options={radioOptions} idSelected={stateRadioIdSelected} onChange={this.props.onChangeStateRadio} />
 
           <EuiSpacer size="s" />
 

--- a/public/pages/ChangePolicy/components/NewPolicy/NewPolicy.tsx
+++ b/public/pages/ChangePolicy/components/NewPolicy/NewPolicy.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import _ from "lodash";
-import { EuiSpacer, EuiText, EuiRadioGroup, EuiCompressedFormRow, EuiSelect, EuiComboBox, EuiLink, EuiIcon } from "@elastic/eui";
+import { EuiSpacer, EuiText, EuiRadioGroup, EuiCompressedFormRow, EuiCompressedSelect, EuiComboBox, EuiLink, EuiIcon } from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
 import { IndexService } from "../../../../services";
 import { Radio } from "../../containers/ChangePolicy/ChangePolicy";
@@ -125,7 +125,7 @@ export default class NewPolicy extends React.Component<NewPolicyProps, NewPolicy
           <EuiSpacer size="s" />
 
           <EuiCompressedFormRow>
-            <EuiSelect
+            <EuiCompressedSelect
               disabled={stateRadioIdSelected !== Radio.State}
               options={stateOptions}
               value={stateSelected}

--- a/public/pages/ChangePolicy/components/NewPolicy/NewPolicy.tsx
+++ b/public/pages/ChangePolicy/components/NewPolicy/NewPolicy.tsx
@@ -11,7 +11,7 @@ import {
   EuiCompressedRadioGroup,
   EuiCompressedFormRow,
   EuiCompressedSelect,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiLink,
   EuiIcon,
 } from "@elastic/eui";
@@ -112,7 +112,7 @@ export default class NewPolicy extends React.Component<NewPolicyProps, NewPolicy
           <EuiSpacer size="s" />
 
           <EuiCompressedFormRow label="New policy" isInvalid={!!selectedPoliciesError} error={selectedPoliciesError}>
-            <EuiComboBox
+            <EuiCompressedComboBox
               placeholder=""
               async
               options={policies}

--- a/public/pages/ChangePolicy/components/NewPolicy/__snapshots__/NewPolicy.test.tsx.snap
+++ b/public/pages/ChangePolicy/components/NewPolicy/__snapshots__/NewPolicy.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`<NewPolicy /> spec renders the component 1`] = `
         class="euiSpacer euiSpacer--s"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -80,17 +80,17 @@ exports[`<NewPolicy /> spec renders the component 1`] = `
           <div
             aria-expanded="false"
             aria-haspopup="listbox"
-            class="euiComboBox"
+            class="euiComboBox euiComboBox--compressed"
             role="combobox"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <div
-                  class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                  class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                   data-test-subj="comboBoxInput"
                   tabindex="-1"
                 >
@@ -133,7 +133,7 @@ exports[`<NewPolicy /> spec renders the component 1`] = `
       />
       <div>
         <div
-          class="euiRadio euiRadioGroup__item"
+          class="euiRadio euiRadio--compressed euiRadioGroup__item"
         >
           <input
             checked=""
@@ -153,7 +153,7 @@ exports[`<NewPolicy /> spec renders the component 1`] = `
           </label>
         </div>
         <div
-          class="euiRadio euiRadioGroup__item"
+          class="euiRadio euiRadio--compressed euiRadioGroup__item"
         >
           <input
             class="euiRadio__input"
@@ -177,21 +177,21 @@ exports[`<NewPolicy /> spec renders the component 1`] = `
         class="euiSpacer euiSpacer--s"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
           class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormControlLayout"
+            class="euiFormControlLayout euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <select
                 aria-label="Start state for new policy"
-                class="euiSelect"
+                class="euiSelect euiSelect--compressed"
                 disabled=""
                 id="some_html_id"
               />

--- a/public/pages/ChangePolicy/components/NewPolicy/__snapshots__/NewPolicy.test.tsx.snap
+++ b/public/pages/ChangePolicy/components/NewPolicy/__snapshots__/NewPolicy.test.tsx.snap
@@ -80,17 +80,17 @@ exports[`<NewPolicy /> spec renders the component 1`] = `
           <div
             aria-expanded="false"
             aria-haspopup="listbox"
-            class="euiComboBox euiComboBox--compressed"
+            class="euiComboBox"
             role="combobox"
           >
             <div
-              class="euiFormControlLayout euiFormControlLayout--compressed"
+              class="euiFormControlLayout"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <div
-                  class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                  class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                   data-test-subj="comboBoxInput"
                   tabindex="-1"
                 >

--- a/public/pages/ChangePolicy/containers/ChangePolicy/ChangePolicy.tsx
+++ b/public/pages/ChangePolicy/containers/ChangePolicy/ChangePolicy.tsx
@@ -5,7 +5,7 @@
 
 import React, { Component, useContext } from "react";
 import { RouteComponentProps } from "react-router-dom";
-import { EuiSpacer, EuiTitle, EuiButton, EuiFlexGroup, EuiFlexItem, EuiButtonEmpty } from "@elastic/eui";
+import { EuiSpacer, EuiTitle, EuiSmallButton, EuiFlexGroup, EuiFlexItem, EuiButtonEmpty } from "@elastic/eui";
 import { IndexService, ManagedIndexService } from "../../../../services";
 import ChangeManagedIndices from "../../components/ChangeManagedIndices";
 import NewPolicy from "../../components/NewPolicy";
@@ -194,14 +194,14 @@ export class ChangePolicy extends Component<ChangePolicyProps, ChangePolicyState
 
           <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty size={useUpdatedUX ? "s" : undefined} onClick={this.onCancel} data-test-subj="changePolicyCancelButton">
+              <EuiButtonEmpty onClick={this.onCancel} data-test-subj="changePolicyCancelButton">
                 Cancel
               </EuiButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton size={useUpdatedUX ? "s" : undefined} fill onClick={this.onSubmit} data-test-subj="changePolicyChangeButton">
+              <EuiSmallButton fill onClick={this.onSubmit} data-test-subj="changePolicyChangeButton">
                 Change
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
         </>

--- a/public/pages/ChangePolicy/containers/ChangePolicy/ChangePolicy.tsx
+++ b/public/pages/ChangePolicy/containers/ChangePolicy/ChangePolicy.tsx
@@ -5,7 +5,7 @@
 
 import React, { Component, useContext } from "react";
 import { RouteComponentProps } from "react-router-dom";
-import { EuiSpacer, EuiTitle, EuiSmallButton, EuiFlexGroup, EuiFlexItem, EuiButtonEmpty } from "@elastic/eui";
+import { EuiSpacer, EuiTitle, EuiSmallButton, EuiFlexGroup, EuiFlexItem, EuiSmallButtonEmpty } from "@elastic/eui";
 import { IndexService, ManagedIndexService } from "../../../../services";
 import ChangeManagedIndices from "../../components/ChangeManagedIndices";
 import NewPolicy from "../../components/NewPolicy";
@@ -194,9 +194,9 @@ export class ChangePolicy extends Component<ChangePolicyProps, ChangePolicyState
 
           <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty onClick={this.onCancel} data-test-subj="changePolicyCancelButton">
+              <EuiSmallButtonEmpty onClick={this.onCancel} data-test-subj="changePolicyCancelButton">
                 Cancel
-              </EuiButtonEmpty>
+              </EuiSmallButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiSmallButton fill onClick={this.onSubmit} data-test-subj="changePolicyChangeButton">

--- a/public/pages/ChangePolicy/containers/ChangePolicy/__snapshots__/ChangePolicy.test.tsx.snap
+++ b/public/pages/ChangePolicy/containers/ChangePolicy/__snapshots__/ChangePolicy.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
           class="euiSpacer euiSpacer--m"
         />
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -70,17 +70,17 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
               aria-describedby="some_html_id-help-0"
               aria-expanded="false"
               aria-haspopup="listbox"
-              class="euiComboBox"
+              class="euiComboBox euiComboBox--compressed"
               role="combobox"
             >
               <div
-                class="euiFormControlLayout"
+                class="euiFormControlLayout euiFormControlLayout--compressed"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <div
-                    class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                    class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                     data-test-subj="comboBoxInput"
                     tabindex="-1"
                   >
@@ -125,7 +125,7 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
           </div>
         </div>
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -145,17 +145,17 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
               aria-describedby="some_html_id-help-0"
               aria-expanded="false"
               aria-haspopup="listbox"
-              class="euiComboBox euiComboBox-isDisabled"
+              class="euiComboBox euiComboBox--compressed euiComboBox-isDisabled"
               role="combobox"
             >
               <div
-                class="euiFormControlLayout"
+                class="euiFormControlLayout euiFormControlLayout--compressed"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <div
-                    class="euiComboBox__inputWrap"
+                    class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed"
                     data-test-subj="comboBoxInput"
                     tabindex="-1"
                   >
@@ -271,7 +271,7 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
           class="euiSpacer euiSpacer--s"
         />
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -291,17 +291,17 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              class="euiComboBox"
+              class="euiComboBox euiComboBox--compressed"
               role="combobox"
             >
               <div
-                class="euiFormControlLayout"
+                class="euiFormControlLayout euiFormControlLayout--compressed"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <div
-                    class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                    class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                     data-test-subj="comboBoxInput"
                     tabindex="-1"
                   >
@@ -344,7 +344,7 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
         />
         <div>
           <div
-            class="euiRadio euiRadioGroup__item"
+            class="euiRadio euiRadio--compressed euiRadioGroup__item"
           >
             <input
               checked=""
@@ -364,7 +364,7 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
             </label>
           </div>
           <div
-            class="euiRadio euiRadioGroup__item"
+            class="euiRadio euiRadio--compressed euiRadioGroup__item"
           >
             <input
               class="euiRadio__input"
@@ -388,21 +388,21 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
           class="euiSpacer euiSpacer--s"
         />
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
             class="euiFormRow__fieldWrapper"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <select
                   aria-label="Start state for new policy"
-                  class="euiSelect"
+                  class="euiSelect euiSelect--compressed"
                   disabled=""
                   id="some_html_id"
                 />
@@ -432,7 +432,7 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButtonEmpty euiButtonEmpty--primary"
+        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
         data-test-subj="changePolicyCancelButton"
         type="button"
       >
@@ -451,7 +451,7 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButton euiButton--primary euiButton--fill"
+        class="euiButton euiButton--primary euiButton--small euiButton--fill"
         data-test-subj="changePolicyChangeButton"
         type="button"
       >

--- a/public/pages/ChangePolicy/containers/ChangePolicy/__snapshots__/ChangePolicy.test.tsx.snap
+++ b/public/pages/ChangePolicy/containers/ChangePolicy/__snapshots__/ChangePolicy.test.tsx.snap
@@ -70,17 +70,17 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
               aria-describedby="some_html_id-help-0"
               aria-expanded="false"
               aria-haspopup="listbox"
-              class="euiComboBox euiComboBox--compressed"
+              class="euiComboBox"
               role="combobox"
             >
               <div
-                class="euiFormControlLayout euiFormControlLayout--compressed"
+                class="euiFormControlLayout"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <div
-                    class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
+                    class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
                     data-test-subj="comboBoxInput"
                     tabindex="-1"
                   >
@@ -145,17 +145,17 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
               aria-describedby="some_html_id-help-0"
               aria-expanded="false"
               aria-haspopup="listbox"
-              class="euiComboBox euiComboBox--compressed euiComboBox-isDisabled"
+              class="euiComboBox euiComboBox-isDisabled"
               role="combobox"
             >
               <div
-                class="euiFormControlLayout euiFormControlLayout--compressed"
+                class="euiFormControlLayout"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <div
-                    class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed"
+                    class="euiComboBox__inputWrap"
                     data-test-subj="comboBoxInput"
                     tabindex="-1"
                   >
@@ -291,17 +291,17 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              class="euiComboBox euiComboBox--compressed"
+              class="euiComboBox"
               role="combobox"
             >
               <div
-                class="euiFormControlLayout euiFormControlLayout--compressed"
+                class="euiFormControlLayout"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <div
-                    class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                    class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                     data-test-subj="comboBoxInput"
                     tabindex="-1"
                   >

--- a/public/pages/ComposableTemplates/components/IndexControls/IndexControls.tsx
+++ b/public/pages/ComposableTemplates/components/IndexControls/IndexControls.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useEffect, useState } from "react";
-import { EuiButton, EuiFieldSearch, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiCompressedFieldSearch, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import FilterGroup from "../../../../components/FilterGroup";
 import { IndicesUpdateMode } from "../../../../utils/constants";
 
@@ -33,8 +33,7 @@ export default function SearchControls(props: SearchControlsProps) {
   return (
     <EuiFlexGroup style={{ padding: "0px 5px" }} alignItems="center">
       <EuiFlexItem>
-        <EuiFieldSearch
-          compressed={props.useNewUX}
+        <EuiCompressedFieldSearch
           fullWidth
           placeholder="Search..."
           value={state.search}

--- a/public/pages/ComposableTemplates/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
+++ b/public/pages/ComposableTemplates/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
@@ -9,13 +9,13 @@ exports[`<IndexControls /> spec renders the component 1`] = `
     class="euiFlexItem"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <input
-          class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
+          class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch-isClearable"
           placeholder="Search..."
           type="search"
           value="testing"
@@ -34,7 +34,7 @@ exports[`<IndexControls /> spec renders the component 1`] = `
         >
           <button
             aria-label="Clear input"
-            class="euiFormControlLayoutClearButton"
+            class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
             type="button"
           >
             EuiIconMock
@@ -57,7 +57,7 @@ exports[`<IndexControls /> spec renders the component 1`] = `
           class="euiPopover__anchor"
         >
           <button
-            class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton-hasNotification euiFilterButton--hasIcon"
+            class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton-hasNotification euiFilterButton--hasIcon"
             type="button"
           >
             <span

--- a/public/pages/ComposableTemplates/containers/AssociatedTemplatesModal/AssociatedTemplatesModal.tsx
+++ b/public/pages/ComposableTemplates/containers/AssociatedTemplatesModal/AssociatedTemplatesModal.tsx
@@ -9,7 +9,7 @@ import { ServicesContext } from "../../../../services";
 import { CoreServicesContext } from "../../../../components/core_services";
 import {
   EuiButtonEmpty,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutHeader,
@@ -71,7 +71,7 @@ export default function AssociatedTemplatesModal(props: AssociatedTemplatesModal
                   render: (value: string, record) => {
                     return (
                       <EuiToolTip content="Unlink">
-                        <EuiButtonIcon
+                        <EuiSmallButtonIcon
                           aria-label={`Unlink from ${record.name}?`}
                           iconType="unlink"
                           onClick={() => {

--- a/public/pages/ComposableTemplates/containers/AssociatedTemplatesModal/AssociatedTemplatesModal.tsx
+++ b/public/pages/ComposableTemplates/containers/AssociatedTemplatesModal/AssociatedTemplatesModal.tsx
@@ -8,7 +8,7 @@ import { CoreStart } from "opensearch-dashboards/public";
 import { ServicesContext } from "../../../../services";
 import { CoreServicesContext } from "../../../../components/core_services";
 import {
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiSmallButtonIcon,
   EuiFlyout,
   EuiFlyoutBody,
@@ -91,7 +91,7 @@ export default function AssociatedTemplatesModal(props: AssociatedTemplatesModal
                               confirmButtonProps: {
                                 color: "danger",
                               },
-                              CancelButtonComponent: EuiButtonEmpty,
+                              CancelButtonComponent: EuiSmallButtonEmpty,
                               async onOk() {
                                 const updateResult = await submitTemplateChange({
                                   templateName: record.name,

--- a/public/pages/ComposableTemplates/containers/AssociatedTemplatesModal/__snapshots__/AssociatedTemplatesModal.test.tsx.snap
+++ b/public/pages/ComposableTemplates/containers/AssociatedTemplatesModal/__snapshots__/AssociatedTemplatesModal.test.tsx.snap
@@ -169,7 +169,7 @@ HTMLCollection [
                             >
                               <button
                                 aria-label="Unlink from test_template?"
-                                class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
+                                class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
                                 type="button"
                               >
                                 EuiIconMock

--- a/public/pages/ComposableTemplates/containers/ComposableTemplates/ComposableTemplates.tsx
+++ b/public/pages/ComposableTemplates/containers/ComposableTemplates/ComposableTemplates.tsx
@@ -17,7 +17,7 @@ import {
   EuiSmallButton,
   EuiLink,
   EuiTitle,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiEmptyPrompt,
   EuiText,
   EuiTableSortingType,
@@ -289,7 +289,7 @@ class ComposableTemplates extends MDSEnabledComponent<ComposableTemplatesProps, 
         <EuiTitle>
           <span>Component templates</span>
         </EuiTitle>
-        <EuiFormRow
+        <EuiCompressedFormRow
           fullWidth
           helpText={
             <div>
@@ -302,7 +302,7 @@ class ComposableTemplates extends MDSEnabledComponent<ComposableTemplatesProps, 
           }
         >
           <></>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </>
     );
 

--- a/public/pages/ComposableTemplates/containers/ComposableTemplates/ComposableTemplates.tsx
+++ b/public/pages/ComposableTemplates/containers/ComposableTemplates/ComposableTemplates.tsx
@@ -21,7 +21,7 @@ import {
   EuiEmptyPrompt,
   EuiText,
   EuiTableSortingType,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiToolTip,
   EuiBasicTableColumn,
 } from "@elastic/eui";
@@ -355,7 +355,7 @@ class ComposableTemplates extends MDSEnabledComponent<ComposableTemplatesProps, 
                   onUnlink={/* istanbul ignore next */ () => this.getComposableTemplates()}
                   renderProps={({ setVisible }) => (
                     <EuiToolTip content="View associated index templates">
-                      <EuiButtonIcon
+                      <EuiSmallButtonIcon
                         aria-label="View associated index templates"
                         iconType="kqlSelector"
                         data-test-subj={`ViewAssociatedIndexTemplates-${record.name}`}
@@ -378,7 +378,7 @@ class ComposableTemplates extends MDSEnabledComponent<ComposableTemplatesProps, 
                   }}
                   renderDeleteButton={({ triggerDelete }) => (
                     <EuiToolTip content="Delete component template">
-                      <EuiButtonIcon
+                      <EuiSmallButtonIcon
                         aria-label="Delete component template"
                         color="danger"
                         iconType="trash"

--- a/public/pages/ComposableTemplates/containers/ComposableTemplates/ComposableTemplates.tsx
+++ b/public/pages/ComposableTemplates/containers/ComposableTemplates/ComposableTemplates.tsx
@@ -14,7 +14,7 @@ import {
   Direction,
   Pagination,
   EuiTableSelectionType,
-  EuiButton,
+  EuiSmallButton,
   EuiLink,
   EuiTitle,
   EuiFormRow,
@@ -467,16 +467,15 @@ class ComposableTemplates extends MDSEnabledComponent<ComposableTemplatesProps, 
                     </EuiText>
                   }
                   actions={[
-                    <EuiButton
+                    <EuiSmallButton
                       fill
                       onClick={() => {
                         this.props.history.push(ROUTES.CREATE_COMPOSABLE_TEMPLATE);
                       }}
                       data-test-subj="CreateComponentTemplateWhenNoTemplateFound"
-                      size={useNewUX ? "s" : undefined}
                     >
                       Create component template
-                    </EuiButton>,
+                    </EuiSmallButton>,
                   ]}
                 />
               ) : (
@@ -487,7 +486,7 @@ class ComposableTemplates extends MDSEnabledComponent<ComposableTemplatesProps, 
                     </EuiText>
                   }
                   actions={[
-                    <EuiButton
+                    <EuiSmallButton
                       fill
                       onClick={() => {
                         this.setState(defaultFilter, () => {
@@ -496,7 +495,7 @@ class ComposableTemplates extends MDSEnabledComponent<ComposableTemplatesProps, 
                       }}
                     >
                       Reset filters
-                    </EuiButton>,
+                    </EuiSmallButton>,
                   ]}
                 />
               )
@@ -547,7 +546,7 @@ class ComposableTemplates extends MDSEnabledComponent<ComposableTemplatesProps, 
                     </EuiText>
                   }
                   actions={[
-                    <EuiButton
+                    <EuiSmallButton
                       fill
                       onClick={() => {
                         this.props.history.push(ROUTES.CREATE_COMPOSABLE_TEMPLATE);
@@ -555,7 +554,7 @@ class ComposableTemplates extends MDSEnabledComponent<ComposableTemplatesProps, 
                       data-test-subj="CreateComponentTemplateWhenNoTemplateFound"
                     >
                       Create component template
-                    </EuiButton>,
+                    </EuiSmallButton>,
                   ]}
                 />
               ) : (
@@ -566,7 +565,7 @@ class ComposableTemplates extends MDSEnabledComponent<ComposableTemplatesProps, 
                     </EuiText>
                   }
                   actions={[
-                    <EuiButton
+                    <EuiSmallButton
                       fill
                       onClick={() => {
                         this.setState(defaultFilter, () => {
@@ -575,7 +574,7 @@ class ComposableTemplates extends MDSEnabledComponent<ComposableTemplatesProps, 
                       }}
                     >
                       Reset filters
-                    </EuiButton>,
+                    </EuiSmallButton>,
                   ]}
                 />
               )

--- a/public/pages/ComposableTemplates/containers/ComposableTemplates/__snapshots__/ComposableTemplates.test.tsx.snap
+++ b/public/pages/ComposableTemplates/containers/ComposableTemplates/__snapshots__/ComposableTemplates.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`<ComposableTemplates /> spec renders the component 1`] = `
         Component templates
       </span>
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -58,7 +58,7 @@ exports[`<ComposableTemplates /> spec renders the component 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButton euiButton--danger euiButton-isDisabled"
+                class="euiButton euiButton--danger euiButton--small euiButton-isDisabled"
                 data-test-subj="deleteAction"
                 disabled=""
                 type="button"
@@ -78,7 +78,7 @@ exports[`<ComposableTemplates /> spec renders the component 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButton euiButton--primary euiButton--fill"
+                class="euiButton euiButton--primary euiButton--small euiButton--fill"
                 data-test-subj="Create component templateButton"
                 type="button"
               >
@@ -112,13 +112,13 @@ exports[`<ComposableTemplates /> spec renders the component 1`] = `
         class="euiFlexItem"
       >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+          class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
         >
           <div
             class="euiFormControlLayout__childrenWrapper"
           >
             <input
-              class="euiFieldSearch euiFieldSearch--fullWidth"
+              class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
               placeholder="Search..."
               type="search"
               value=""
@@ -149,7 +149,7 @@ exports[`<ComposableTemplates /> spec renders the component 1`] = `
               class="euiPopover__anchor"
             >
               <button
-                class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton-hasNotification euiFilterButton--hasIcon"
+                class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton-hasNotification euiFilterButton--hasIcon"
                 type="button"
               >
                 <span

--- a/public/pages/ComposableTemplates/containers/ComposableTemplatesActions/__snapshots__/ComposableTemplatesActions.test.tsx.snap
+++ b/public/pages/ComposableTemplates/containers/ComposableTemplatesActions/__snapshots__/ComposableTemplatesActions.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<ComposableTemplatesActions /> spec delete templates by calling commonService 1`] = `
 <button
-  class="euiButton euiButton--danger"
+  class="euiButton euiButton--danger euiButton--small"
   data-test-subj="deleteAction"
   type="button"
 >
@@ -31,7 +31,7 @@ exports[`<ComposableTemplatesActions /> spec renders delete action by using rend
 
 exports[`<ComposableTemplatesActions /> spec renders the component and all the actions should be disabled when no items selected 1`] = `
 <button
-  class="euiButton euiButton--danger euiButton-isDisabled"
+  class="euiButton euiButton--danger euiButton--small euiButton-isDisabled"
   data-test-subj="deleteAction"
   disabled=""
   type="button"

--- a/public/pages/ComposableTemplates/containers/ComposableTemplatesActions/index.tsx
+++ b/public/pages/ComposableTemplates/containers/ComposableTemplatesActions/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React, { useState } from "react";
-import { EuiButton } from "@elastic/eui";
+import { EuiSmallButton } from "@elastic/eui";
 import DeleteIndexModal from "../DeleteComposableTemplatesModal";
 import AssociatedTemplatesModal from "../AssociatedTemplatesModal";
 
@@ -36,9 +36,14 @@ export function ComposableTemplatesDeleteAction(props: ComposableTemplatesAction
     }
 
     return (
-      <EuiButton data-test-subj="deleteAction" color="danger" disabled={renderProps.selectedItems.length !== 1} onClick={triggerDelete}>
+      <EuiSmallButton
+        data-test-subj="deleteAction"
+        color="danger"
+        disabled={renderProps.selectedItems.length !== 1}
+        onClick={triggerDelete}
+      >
         Delete
-      </EuiButton>
+      </EuiSmallButton>
     );
   };
 

--- a/public/pages/ComposableTemplates/containers/DeleteComposableTemplatesModal/DeleteComposableTemplatesModal.tsx
+++ b/public/pages/ComposableTemplates/containers/DeleteComposableTemplatesModal/DeleteComposableTemplatesModal.tsx
@@ -9,7 +9,7 @@ import { ServicesContext } from "../../../../services";
 import { CoreServicesContext } from "../../../../components/core_services";
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiLoadingSpinner,
   EuiModal,
   EuiModalBody,
@@ -146,9 +146,9 @@ export default function DeleteTemplateModal(props: DeleteTemplateModalProps) {
       </EuiModalBody>
 
       <EuiModalFooter>
-        <EuiButtonEmpty disabled={loading} isLoading={loading} data-test-subj="deletaCancelButton" onClick={onClose}>
+        <EuiSmallButtonEmpty disabled={loading} isLoading={loading} data-test-subj="deletaCancelButton" onClick={onClose}>
           Cancel
-        </EuiButtonEmpty>
+        </EuiSmallButtonEmpty>
         {!linkedIndexItemCount ? (
           <EuiSmallButton
             disabled={loading}

--- a/public/pages/ComposableTemplates/containers/DeleteComposableTemplatesModal/DeleteComposableTemplatesModal.tsx
+++ b/public/pages/ComposableTemplates/containers/DeleteComposableTemplatesModal/DeleteComposableTemplatesModal.tsx
@@ -8,7 +8,7 @@ import { CoreStart } from "opensearch-dashboards/public";
 import { ServicesContext } from "../../../../services";
 import { CoreServicesContext } from "../../../../components/core_services";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiLoadingSpinner,
   EuiModal,
@@ -150,12 +150,19 @@ export default function DeleteTemplateModal(props: DeleteTemplateModalProps) {
           Cancel
         </EuiButtonEmpty>
         {!linkedIndexItemCount ? (
-          <EuiButton disabled={loading} isLoading={loading} data-test-subj="deleteConfirmButton" onClick={onConfirm} fill color="danger">
+          <EuiSmallButton
+            disabled={loading}
+            isLoading={loading}
+            data-test-subj="deleteConfirmButton"
+            onClick={onConfirm}
+            fill
+            color="danger"
+          >
             Delete
-          </EuiButton>
+          </EuiSmallButton>
         ) : null}
         {linkedIndexItemCount ? (
-          <EuiButton
+          <EuiSmallButton
             data-test-subj="deleteConfirmUnlinkButton"
             onClick={onConfirm}
             disabled={!checked || loading}
@@ -164,7 +171,7 @@ export default function DeleteTemplateModal(props: DeleteTemplateModalProps) {
             color="danger"
           >
             Apply changes
-          </EuiButton>
+          </EuiSmallButton>
         ) : null}
       </EuiModalFooter>
     </EuiModal>

--- a/public/pages/ComposableTemplates/containers/DeleteComposableTemplatesModal/__snapshots__/DeleteComposableTemplatesModal.test.tsx.snap
+++ b/public/pages/ComposableTemplates/containers/DeleteComposableTemplatesModal/__snapshots__/DeleteComposableTemplatesModal.test.tsx.snap
@@ -64,7 +64,7 @@ HTMLCollection [
             class="euiModalFooter"
           >
             <button
-              class="euiButtonEmpty euiButtonEmpty--primary"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
               data-test-subj="deletaCancelButton"
               type="button"
             >
@@ -79,7 +79,7 @@ HTMLCollection [
               </span>
             </button>
             <button
-              class="euiButton euiButton--danger euiButton--fill"
+              class="euiButton euiButton--danger euiButton--small euiButton--fill"
               data-test-subj="deleteConfirmButton"
               type="button"
             >

--- a/public/pages/CreateComposableTemplate/components/TemplateType/TemplateType.tsx
+++ b/public/pages/CreateComposableTemplate/components/TemplateType/TemplateType.tsx
@@ -1,4 +1,4 @@
-import { EuiRadio } from "@elastic/eui";
+import { EuiCompressedRadio } from "@elastic/eui";
 import { TEMPLATE_TYPE } from "../../../../utils/constants";
 import React from "react";
 
@@ -11,13 +11,13 @@ export default function TemplateType(props: ITemplateTypeProps) {
   const { value, onChange } = props;
   return (
     <>
-      <EuiRadio
+      <EuiCompressedRadio
         id={TEMPLATE_TYPE.INDEX_TEMPLATE}
         onChange={(e) => e.target.checked && onChange(undefined)}
         label={TEMPLATE_TYPE.INDEX_TEMPLATE}
         checked={value === undefined}
       />
-      <EuiRadio
+      <EuiCompressedRadio
         id={TEMPLATE_TYPE.DATA_STREAM}
         onChange={(e) => e.target.checked && onChange({})}
         label={TEMPLATE_TYPE.DATA_STREAM}

--- a/public/pages/CreateComposableTemplate/containers/CreateComposableTemplate/__snapshots__/CreateComposableTemplate.test.tsx.snap
+++ b/public/pages/CreateComposableTemplate/containers/CreateComposableTemplate/__snapshots__/CreateComposableTemplate.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`<CreateComposableTemplate /> spec it goes to templates page when click 
         style="flex-direction: row;"
       >
         <button
-          class="euiButton euiButton--primary"
+          class="euiButton euiButton--primary euiButton--small"
           style="margin-right: 20px;"
           type="button"
         >
@@ -38,7 +38,7 @@ exports[`<CreateComposableTemplate /> spec it goes to templates page when click 
           </span>
         </button>
         <button
-          class="euiButton euiButton--danger"
+          class="euiButton euiButton--danger euiButton--small"
           data-test-subj="deleteAction"
           type="button"
         >
@@ -125,7 +125,7 @@ exports[`<CreateComposableTemplate /> spec it goes to templates page when click 
               class="euiFlexItem euiDescribedFormGroup__fields euiDescribedFormGroup__fieldPadding--xsmall"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 data-test-subj="form-row-_meta.description"
                 id="some_html_id-row"
               >
@@ -136,13 +136,13 @@ exports[`<CreateComposableTemplate /> spec it goes to templates page when click 
                     class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
                   >
                     <div
-                      class="euiFormControlLayout"
+                      class="euiFormControlLayout euiFormControlLayout--compressed"
                     >
                       <div
                         class="euiFormControlLayout__childrenWrapper"
                       >
                         <input
-                          class="euiFieldText"
+                          class="euiFieldText euiFieldText--compressed"
                           id="some_html_id"
                           type="text"
                           value=""
@@ -172,7 +172,7 @@ exports[`<CreateComposableTemplate /> spec it goes to templates page when click 
           class="euiFlexItem"
         >
           <div
-            class="euiFormRow euiFormRow--fullWidth"
+            class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
             id="some_html_id-row"
           >
             <div
@@ -216,7 +216,7 @@ exports[`<CreateComposableTemplate /> spec it goes to templates page when click 
                 >
                   <div>
                     <div
-                      class="euiSwitch euiSwitch--primary"
+                      class="euiSwitch euiSwitch--primary euiSwitch--compressed"
                     >
                       <button
                         aria-checked="false"
@@ -234,10 +234,7 @@ exports[`<CreateComposableTemplate /> spec it goes to templates page when click 
                           />
                           <span
                             class="euiSwitch__track"
-                          >
-                            EuiIconMock
-                            EuiIconMock
-                          </span>
+                          />
                         </span>
                       </button>
                       <span
@@ -299,7 +296,7 @@ exports[`<CreateComposableTemplate /> spec it goes to templates page when click 
                 >
                   <div>
                     <div
-                      class="euiSwitch euiSwitch--primary"
+                      class="euiSwitch euiSwitch--primary euiSwitch--compressed"
                     >
                       <button
                         aria-checked="false"
@@ -317,10 +314,7 @@ exports[`<CreateComposableTemplate /> spec it goes to templates page when click 
                           />
                           <span
                             class="euiSwitch__track"
-                          >
-                            EuiIconMock
-                            EuiIconMock
-                          </span>
+                          />
                         </span>
                       </button>
                       <span
@@ -361,7 +355,7 @@ exports[`<CreateComposableTemplate /> spec it goes to templates page when click 
             Index mapping
           </div>
           <div
-            class="euiFormRow euiFormRow--fullWidth"
+            class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
             id="some_html_id-row"
           >
             <div
@@ -407,7 +401,7 @@ exports[`<CreateComposableTemplate /> spec it goes to templates page when click 
               >
                 <div>
                   <div
-                    class="euiSwitch euiSwitch--primary"
+                    class="euiSwitch euiSwitch--primary euiSwitch--compressed"
                   >
                     <button
                       aria-checked="false"
@@ -425,10 +419,7 @@ exports[`<CreateComposableTemplate /> spec it goes to templates page when click 
                         />
                         <span
                           class="euiSwitch__track"
-                        >
-                          EuiIconMock
-                          EuiIconMock
-                        </span>
+                        />
                       </span>
                     </button>
                     <span

--- a/public/pages/CreateComposableTemplate/containers/TemplateDetail/TemplateDetail.tsx
+++ b/public/pages/CreateComposableTemplate/containers/TemplateDetail/TemplateDetail.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { forwardRef, useContext, useEffect, useImperativeHandle, useRef, Ref, useState } from "react";
-import { EuiSmallButton, EuiButtonEmpty, EuiCodeBlock, EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer, EuiText, EuiTitle } from "@elastic/eui";
+import { EuiSmallButton, EuiSmallButtonEmpty, EuiCodeBlock, EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer, EuiText, EuiTitle } from "@elastic/eui";
 import { RouteComponentProps } from "react-router-dom";
 import { IComposableTemplate, IComposableTemplateRemote } from "../../../../../models/interfaces";
 import useField from "../../../../lib/field";
@@ -304,9 +304,9 @@ const TemplateDetail = (props: TemplateDetailProps, ref: Ref<IComponentTemplateD
           <EuiSpacer />
           <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty onClick={onCancel} data-test-subj="CreateComposableTemplateCancelButton" size={useNewUX ? "s" : undefined}>
+              <EuiSmallButtonEmpty onClick={onCancel} data-test-subj="CreateComposableTemplateCancelButton">
                 Cancel
-              </EuiButtonEmpty>
+              </EuiSmallButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiSmallButton fill onClick={onClickSubmit} isLoading={isSubmitting} data-test-subj="CreateComposableTemplateCreateButton">

--- a/public/pages/CreateComposableTemplate/containers/TemplateDetail/TemplateDetail.tsx
+++ b/public/pages/CreateComposableTemplate/containers/TemplateDetail/TemplateDetail.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { forwardRef, useContext, useEffect, useImperativeHandle, useRef, Ref, useState } from "react";
-import { EuiButton, EuiButtonEmpty, EuiCodeBlock, EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer, EuiText, EuiTitle } from "@elastic/eui";
+import { EuiSmallButton, EuiButtonEmpty, EuiCodeBlock, EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer, EuiText, EuiTitle } from "@elastic/eui";
 import { RouteComponentProps } from "react-router-dom";
 import { IComposableTemplate, IComposableTemplateRemote } from "../../../../../models/interfaces";
 import useField from "../../../../lib/field";
@@ -278,9 +278,9 @@ const TemplateDetail = (props: TemplateDetailProps, ref: Ref<IComponentTemplateD
                   </>
                 ) : (
                   <EuiFlexItem grow={false} style={{ flexDirection: "row" }}>
-                    <EuiButton style={{ marginRight: 20 }} onClick={onClickViewJson}>
+                    <EuiSmallButton style={{ marginRight: 20 }} onClick={onClickViewJson}>
                       View JSON
-                    </EuiButton>
+                    </EuiSmallButton>
                     <ComposableTemplatesActions selectedItems={[templateName || ""]} history={props.history} onDelete={onDelete} />
                   </EuiFlexItem>
                 )}
@@ -309,15 +309,9 @@ const TemplateDetail = (props: TemplateDetailProps, ref: Ref<IComponentTemplateD
               </EuiButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
-                fill
-                onClick={onClickSubmit}
-                isLoading={isSubmitting}
-                data-test-subj="CreateComposableTemplateCreateButton"
-                size={useNewUX ? "s" : undefined}
-              >
+              <EuiSmallButton fill onClick={onClickSubmit} isLoading={isSubmitting} data-test-subj="CreateComposableTemplateCreateButton">
                 Create component template
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
         </>

--- a/public/pages/CreateComposableTemplate/containers/TemplateDetail/__snapshots__/TemplateDetail.test.tsx.snap
+++ b/public/pages/CreateComposableTemplate/containers/TemplateDetail/__snapshots__/TemplateDetail.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`<TemplateDetail /> spec render component 1`] = `
         Create component template
       </h1>
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -76,7 +76,7 @@ exports[`<TemplateDetail /> spec render component 1`] = `
         class="euiSpacer euiSpacer--s"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         data-test-subj="form-row-name"
         id="some_html_id-row"
       >
@@ -106,13 +106,13 @@ exports[`<TemplateDetail /> spec render component 1`] = `
             class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
-                  class="euiFieldText"
+                  class="euiFieldText euiFieldText--compressed"
                   type="text"
                   value=""
                 />
@@ -122,7 +122,7 @@ exports[`<TemplateDetail /> spec render component 1`] = `
         </div>
       </div>
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -142,7 +142,7 @@ exports[`<TemplateDetail /> spec render component 1`] = `
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         data-test-subj="form-row-_meta.description"
         id="some_html_id-row"
       >
@@ -175,13 +175,13 @@ exports[`<TemplateDetail /> spec render component 1`] = `
             class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
-                  class="euiFieldText"
+                  class="euiFieldText euiFieldText--compressed"
                   type="text"
                   value=""
                 />
@@ -207,7 +207,7 @@ exports[`<TemplateDetail /> spec render component 1`] = `
         class="euiFlexItem"
       >
         <div
-          class="euiFormRow euiFormRow--fullWidth"
+          class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -251,7 +251,7 @@ exports[`<TemplateDetail /> spec render component 1`] = `
               >
                 <div>
                   <div
-                    class="euiSwitch euiSwitch--primary"
+                    class="euiSwitch euiSwitch--primary euiSwitch--compressed"
                   >
                     <button
                       aria-checked="false"
@@ -269,10 +269,7 @@ exports[`<TemplateDetail /> spec render component 1`] = `
                         />
                         <span
                           class="euiSwitch__track"
-                        >
-                          EuiIconMock
-                          EuiIconMock
-                        </span>
+                        />
                       </span>
                     </button>
                     <span
@@ -334,7 +331,7 @@ exports[`<TemplateDetail /> spec render component 1`] = `
               >
                 <div>
                   <div
-                    class="euiSwitch euiSwitch--primary"
+                    class="euiSwitch euiSwitch--primary euiSwitch--compressed"
                   >
                     <button
                       aria-checked="false"
@@ -352,10 +349,7 @@ exports[`<TemplateDetail /> spec render component 1`] = `
                         />
                         <span
                           class="euiSwitch__track"
-                        >
-                          EuiIconMock
-                          EuiIconMock
-                        </span>
+                        />
                       </span>
                     </button>
                     <span
@@ -396,7 +390,7 @@ exports[`<TemplateDetail /> spec render component 1`] = `
           Index mapping
         </div>
         <div
-          class="euiFormRow euiFormRow--fullWidth"
+          class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -442,7 +436,7 @@ exports[`<TemplateDetail /> spec render component 1`] = `
             >
               <div>
                 <div
-                  class="euiSwitch euiSwitch--primary"
+                  class="euiSwitch euiSwitch--primary euiSwitch--compressed"
                 >
                   <button
                     aria-checked="false"
@@ -460,10 +454,7 @@ exports[`<TemplateDetail /> spec render component 1`] = `
                       />
                       <span
                         class="euiSwitch__track"
-                      >
-                        EuiIconMock
-                        EuiIconMock
-                      </span>
+                      />
                     </span>
                   </button>
                   <span
@@ -496,7 +487,7 @@ exports[`<TemplateDetail /> spec render component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButtonEmpty euiButtonEmpty--primary"
+        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
         data-test-subj="CreateComposableTemplateCancelButton"
         type="button"
       >
@@ -515,7 +506,7 @@ exports[`<TemplateDetail /> spec render component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButton euiButton--primary euiButton--fill"
+        class="euiButton euiButton--primary euiButton--small euiButton--fill"
         data-test-subj="CreateComposableTemplateCreateButton"
         type="button"
       >

--- a/public/pages/CreateComposableTemplate/containers/TemplateMappings/TemplateMappings.tsx
+++ b/public/pages/CreateComposableTemplate/containers/TemplateMappings/TemplateMappings.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useRef } from "react";
-import { EuiFormRow, EuiLink, EuiSpacer, EuiTitle } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiLink, EuiSpacer, EuiTitle } from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
 import { SubDetailProps } from "../../interface";
 import IndexMapping, { IIndexMappingsRef } from "../../../../components/IndexMapping";
@@ -22,7 +22,7 @@ export default function TemplateMappings(props: SubDetailProps) {
           <EuiTitle size="s">
             <div>Index mapping</div>
           </EuiTitle>
-          <EuiFormRow
+          <EuiCompressedFormRow
             fullWidth
             helpText={
               <div>
@@ -38,7 +38,7 @@ export default function TemplateMappings(props: SubDetailProps) {
             }
           >
             <></>
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </>
       }
       actions={
@@ -55,7 +55,7 @@ export default function TemplateMappings(props: SubDetailProps) {
       {values.includes?.[IndicesUpdateMode.mappings] ? (
         <>
           <EuiSpacer />
-          <EuiFormRow fullWidth>
+          <EuiCompressedFormRow fullWidth>
             <IndexMapping
               {...field.registerField({
                 name: ["template", "mappings"],
@@ -82,7 +82,7 @@ export default function TemplateMappings(props: SubDetailProps) {
               oldMappingsEditable
               docVersion={coreServices.docLinks.DOC_LINK_VERSION}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
           <EuiSpacer />
         </>
       ) : null}

--- a/public/pages/CreateDataStream/containers/CreateDataStream/__snapshots__/CreateDataStream.test.tsx.snap
+++ b/public/pages/CreateDataStream/containers/CreateDataStream/__snapshots__/CreateDataStream.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`<CreateDataStream /> spec it goes to data streams page when click cance
           Create data stream
         </h1>
         <div
-          class="euiFormRow euiFormRow--fullWidth"
+          class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -69,7 +69,7 @@ exports[`<CreateDataStream /> spec it goes to data streams page when click cance
           />
           <div>
             <button
-              class="euiButton euiButton--primary"
+              class="euiButton euiButton--primary euiButton--small"
               type="button"
             >
               <span
@@ -123,7 +123,7 @@ exports[`<CreateDataStream /> spec it goes to data streams page when click cance
           class="euiSpacer euiSpacer--s"
         />
         <div
-          class="euiFormRow euiFormRow--fullWidth"
+          class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
           data-test-subj="form-row-name"
           id="some_html_id-row"
         >
@@ -168,17 +168,17 @@ exports[`<CreateDataStream /> spec it goes to data streams page when click cance
               <div
                 aria-expanded="false"
                 aria-haspopup="listbox"
-                class="euiComboBox"
+                class="euiComboBox euiComboBox--compressed"
                 role="combobox"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <div
-                      class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                      class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                       data-test-subj="comboBoxInput"
                       tabindex="-1"
                     >
@@ -225,7 +225,7 @@ exports[`<CreateDataStream /> spec it goes to data streams page when click cance
           class="euiSpacer euiSpacer--l"
         />
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -259,7 +259,7 @@ exports[`<CreateDataStream /> spec it goes to data streams page when click cance
         class="euiFlexItem euiFlexItem--flexGrowZero"
       >
         <button
-          class="euiButtonEmpty euiButtonEmpty--primary"
+          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
           data-test-subj="CreateDataStreamCancelButton"
           type="button"
         >
@@ -278,7 +278,7 @@ exports[`<CreateDataStream /> spec it goes to data streams page when click cance
         class="euiFlexItem euiFlexItem--flexGrowZero"
       >
         <button
-          class="euiButton euiButton--primary euiButton--fill"
+          class="euiButton euiButton--primary euiButton--small euiButton--fill"
           data-test-subj="CreateDataStreamCreateButton"
           type="button"
         >

--- a/public/pages/CreateDataStream/containers/DataStreamDetail/DataStreamDetail.tsx
+++ b/public/pages/CreateDataStream/containers/DataStreamDetail/DataStreamDetail.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { forwardRef, useContext, useEffect, useImperativeHandle, useRef, Ref, useState } from "react";
-import { EuiButton, EuiButtonEmpty, EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer, EuiTitle, EuiText } from "@elastic/eui";
+import { EuiSmallButton, EuiButtonEmpty, EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer, EuiTitle, EuiText } from "@elastic/eui";
 import { TemplateItemRemote } from "../../../../../models/interfaces";
 import useField, { FieldInstance } from "../../../../lib/field";
 import CustomFormRow from "../../../../components/CustomFormRow";
@@ -184,7 +184,7 @@ const DataStreamDetail = (props: DataStreamDetailProps, ref: Ref<FieldInstance>)
 
             {isEdit ? (
               <EuiFlexItem grow={false} style={{ flexDirection: "row" }}>
-                <EuiButton
+                <EuiSmallButton
                   style={{ marginRight: 20 }}
                   onClick={() => {
                     Modal.show({
@@ -195,7 +195,7 @@ const DataStreamDetail = (props: DataStreamDetailProps, ref: Ref<FieldInstance>)
                   }}
                 >
                   View JSON
-                </EuiButton>
+                </EuiSmallButton>
                 <DataStreamsActions
                   selectedItems={values ? ([values] as DataStreamInEdit[]) : []}
                   history={props.history}
@@ -213,9 +213,9 @@ const DataStreamDetail = (props: DataStreamDetailProps, ref: Ref<FieldInstance>)
             To create a data stream, you must first define its mappings and settings by creating a data stream template.
             <EuiSpacer size="s" />
             <div>
-              <EuiButton onClick={() => props.history.push(`${ROUTES.CREATE_TEMPLATE}?values=${JSON.stringify({ data_stream: {} })}`)}>
+              <EuiSmallButton onClick={() => props.history.push(`${ROUTES.CREATE_TEMPLATE}?values=${JSON.stringify({ data_stream: {} })}`)}>
                 Create template
-              </EuiButton>
+              </EuiSmallButton>
             </div>
           </EuiCallOut>
           <EuiSpacer />
@@ -252,9 +252,9 @@ const DataStreamDetail = (props: DataStreamDetailProps, ref: Ref<FieldInstance>)
               </EuiButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton fill onClick={onSubmit} isLoading={isLoading} data-test-subj="CreateDataStreamCreateButton">
+              <EuiSmallButton fill onClick={onSubmit} isLoading={isLoading} data-test-subj="CreateDataStreamCreateButton">
                 {isEdit ? "Save changes" : "Create data stream"}
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
         </>

--- a/public/pages/CreateDataStream/containers/DataStreamDetail/DataStreamDetail.tsx
+++ b/public/pages/CreateDataStream/containers/DataStreamDetail/DataStreamDetail.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { forwardRef, useContext, useEffect, useImperativeHandle, useRef, Ref, useState } from "react";
-import { EuiSmallButton, EuiButtonEmpty, EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer, EuiTitle, EuiText } from "@elastic/eui";
+import { EuiSmallButton, EuiSmallButtonEmpty, EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer, EuiTitle, EuiText } from "@elastic/eui";
 import { TemplateItemRemote } from "../../../../../models/interfaces";
 import useField, { FieldInstance } from "../../../../lib/field";
 import CustomFormRow from "../../../../components/CustomFormRow";
@@ -247,9 +247,9 @@ const DataStreamDetail = (props: DataStreamDetailProps, ref: Ref<FieldInstance>)
           <EuiSpacer />
           <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty onClick={onCancel} data-test-subj="CreateDataStreamCancelButton">
+              <EuiSmallButtonEmpty onClick={onCancel} data-test-subj="CreateDataStreamCancelButton">
                 Cancel
-              </EuiButtonEmpty>
+              </EuiSmallButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiSmallButton fill onClick={onSubmit} isLoading={isLoading} data-test-subj="CreateDataStreamCreateButton">

--- a/public/pages/CreateDataStream/containers/DataStreamDetail/__snapshots__/DataStreamDetail.test.tsx.snap
+++ b/public/pages/CreateDataStream/containers/DataStreamDetail/__snapshots__/DataStreamDetail.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`<DataStreamDetail /> spec render component 1`] = `
         Create data stream
       </h1>
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -66,7 +66,7 @@ exports[`<DataStreamDetail /> spec render component 1`] = `
         />
         <div>
           <button
-            class="euiButton euiButton--primary"
+            class="euiButton euiButton--primary euiButton--small"
             type="button"
           >
             <span
@@ -120,7 +120,7 @@ exports[`<DataStreamDetail /> spec render component 1`] = `
         class="euiSpacer euiSpacer--s"
       />
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         data-test-subj="form-row-name"
         id="some_html_id-row"
       >
@@ -165,17 +165,17 @@ exports[`<DataStreamDetail /> spec render component 1`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              class="euiComboBox"
+              class="euiComboBox euiComboBox--compressed"
               role="combobox"
             >
               <div
-                class="euiFormControlLayout"
+                class="euiFormControlLayout euiFormControlLayout--compressed"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <div
-                    class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                    class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                     data-test-subj="comboBoxInput"
                     tabindex="-1"
                   >
@@ -222,7 +222,7 @@ exports[`<DataStreamDetail /> spec render component 1`] = `
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -256,7 +256,7 @@ exports[`<DataStreamDetail /> spec render component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButtonEmpty euiButtonEmpty--primary"
+        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
         data-test-subj="CreateDataStreamCancelButton"
         type="button"
       >
@@ -275,7 +275,7 @@ exports[`<DataStreamDetail /> spec render component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButton euiButton--primary euiButton--fill"
+        class="euiButton euiButton--primary euiButton--small euiButton--fill"
         data-test-subj="CreateDataStreamCreateButton"
         type="button"
       >

--- a/public/pages/CreateDataStream/containers/TemplateMappings/TemplateMappings.tsx
+++ b/public/pages/CreateDataStream/containers/TemplateMappings/TemplateMappings.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React, { useContext, useRef } from "react";
-import { EuiFormRow, EuiLink, EuiSpacer, EuiTitle } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiLink, EuiSpacer, EuiTitle } from "@elastic/eui";
 import { CoreStart } from "opensearch-dashboards/public";
 import { SubDetailProps } from "../../interface";
 import IndexMapping, { IIndexMappingsRef } from "../../../../components/IndexMapping";
@@ -16,7 +16,7 @@ export default function TemplateMappings(props: SubDetailProps) {
   return (
     <>
       <EuiTitle size="s">
-        <EuiFormRow
+        <EuiCompressedFormRow
           fullWidth
           label={
             <EuiTitle size="s">
@@ -37,10 +37,10 @@ export default function TemplateMappings(props: SubDetailProps) {
           }
         >
           <></>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </EuiTitle>
       <EuiSpacer size="s" />
-      <EuiFormRow fullWidth>
+      <EuiCompressedFormRow fullWidth>
         <IndexMapping
           {...field.registerField({
             name: ["template", "mappings"],
@@ -50,7 +50,7 @@ export default function TemplateMappings(props: SubDetailProps) {
           ref={mappingsRef}
           docVersion={coreServices.docLinks.DOC_LINK_VERSION}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </>
   );
 }

--- a/public/pages/CreateIndex/containers/IndexForm/index.tsx
+++ b/public/pages/CreateIndex/containers/IndexForm/index.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { Component, forwardRef, useContext } from "react";
-import { EuiSpacer, EuiFlexGroup, EuiFlexItem, EuiButton, EuiButtonEmpty, EuiLoadingSpinner } from "@elastic/eui";
+import { EuiSpacer, EuiFlexGroup, EuiFlexItem, EuiSmallButton, EuiButtonEmpty, EuiLoadingSpinner } from "@elastic/eui";
 import { get, set, differenceWith, isEqual, merge } from "lodash";
 import { diffArrays } from "diff";
 import flattern from "flat";
@@ -472,15 +472,9 @@ export class IndexForm extends Component<IndexFormProps & { services: BrowserSer
                 </EuiButtonEmpty>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiButton
-                  fill
-                  size={useUpdatedUX ? "s" : undefined}
-                  onClick={this.onSubmit}
-                  isLoading={isSubmitting}
-                  data-test-subj="createIndexCreateButton"
-                >
+                <EuiSmallButton fill onClick={this.onSubmit} isLoading={isSubmitting} data-test-subj="createIndexCreateButton">
                   {isEdit ? "Update" : "Create"}
-                </EuiButton>
+                </EuiSmallButton>
               </EuiFlexItem>
             </EuiFlexGroup>
           </>

--- a/public/pages/CreateIndex/containers/IndexForm/index.tsx
+++ b/public/pages/CreateIndex/containers/IndexForm/index.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { Component, forwardRef, useContext } from "react";
-import { EuiSpacer, EuiFlexGroup, EuiFlexItem, EuiSmallButton, EuiButtonEmpty, EuiLoadingSpinner } from "@elastic/eui";
+import { EuiSpacer, EuiFlexGroup, EuiFlexItem, EuiSmallButton, EuiSmallButtonEmpty, EuiLoadingSpinner } from "@elastic/eui";
 import { get, set, differenceWith, isEqual, merge } from "lodash";
 import { diffArrays } from "diff";
 import flattern from "flat";
@@ -467,9 +467,9 @@ export class IndexForm extends Component<IndexFormProps & { services: BrowserSer
             <EuiSpacer />
             <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
               <EuiFlexItem grow={false}>
-                <EuiButtonEmpty size={useUpdatedUX ? "s" : undefined} onClick={this.onCancel} data-test-subj="createIndexCancelButton">
+                <EuiSmallButtonEmpty onClick={this.onCancel} data-test-subj="createIndexCancelButton">
                   Cancel
-                </EuiButtonEmpty>
+                </EuiSmallButtonEmpty>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiSmallButton fill onClick={this.onSubmit} isLoading={isSubmitting} data-test-subj="createIndexCreateButton">

--- a/public/pages/CreateIndexTemplate/components/DefineTemplate/__snapshots__/DefineTemplate.test.tsx.snap
+++ b/public/pages/CreateIndexTemplate/components/DefineTemplate/__snapshots__/DefineTemplate.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`<ComposableTemplatesActions /> spec renders the component in edit mode 
             class="euiFlexItem euiDescribedFormGroup__fields euiDescribedFormGroup__fieldPadding--xsmall"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               data-test-subj="form-row-data_stream"
               id="some_html_id-row"
             >
@@ -64,7 +64,7 @@ exports[`<ComposableTemplatesActions /> spec renders the component in edit mode 
                 class="euiFormRow__fieldWrapper"
               >
                 <div
-                  class="euiRadio"
+                  class="euiRadio euiRadio--compressed"
                 >
                   <input
                     checked=""
@@ -84,7 +84,7 @@ exports[`<ComposableTemplatesActions /> spec renders the component in edit mode 
                   </label>
                 </div>
                 <div
-                  class="euiRadio"
+                  class="euiRadio euiRadio--compressed"
                 >
                   <input
                     class="euiRadio__input"
@@ -140,7 +140,7 @@ exports[`<ComposableTemplatesActions /> spec renders the component in edit mode 
             class="euiFlexItem euiDescribedFormGroup__fields euiDescribedFormGroup__fieldPadding--xsmall"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               data-test-subj="form-row-index_patterns"
               id="some_html_id-row"
             >
@@ -150,17 +150,17 @@ exports[`<ComposableTemplatesActions /> spec renders the component in edit mode 
                 <div
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  class="euiComboBox"
+                  class="euiComboBox euiComboBox--compressed"
                   role="combobox"
                 >
                   <div
-                    class="euiFormControlLayout"
+                    class="euiFormControlLayout euiFormControlLayout--compressed"
                   >
                     <div
                       class="euiFormControlLayout__childrenWrapper"
                     >
                       <div
-                        class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                        class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                         data-test-subj="comboBoxInput"
                         tabindex="-1"
                       >
@@ -227,7 +227,7 @@ exports[`<ComposableTemplatesActions /> spec renders the component in edit mode 
             class="euiFlexItem euiDescribedFormGroup__fields euiDescribedFormGroup__fieldPadding--xsmall"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               data-test-subj="form-row-priority"
               id="some_html_id-row"
             >
@@ -238,13 +238,13 @@ exports[`<ComposableTemplatesActions /> spec renders the component in edit mode 
                   class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
                 >
                   <div
-                    class="euiFormControlLayout"
+                    class="euiFormControlLayout euiFormControlLayout--compressed"
                   >
                     <div
                       class="euiFormControlLayout__childrenWrapper"
                     >
                       <input
-                        class="euiFieldNumber"
+                        class="euiFieldNumber euiFieldNumber--compressed"
                         id="some_html_id"
                         type="number"
                         value=""
@@ -261,7 +261,7 @@ exports[`<ComposableTemplatesActions /> spec renders the component in edit mode 
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         data-test-subj="form-row-_meta.flow"
         id="some_html_id-row"
       >
@@ -431,7 +431,7 @@ exports[`<ComposableTemplatesActions /> spec renders the component in non-edit m
         class="euiSpacer euiSpacer--s"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         data-test-subj="form-row-name"
         id="some_html_id-row"
       >
@@ -461,13 +461,13 @@ exports[`<ComposableTemplatesActions /> spec renders the component in non-edit m
             class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
-                  class="euiFieldText"
+                  class="euiFieldText euiFieldText--compressed"
                   type="text"
                   value=""
                 />
@@ -477,7 +477,7 @@ exports[`<ComposableTemplatesActions /> spec renders the component in non-edit m
         </div>
       </div>
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -497,7 +497,7 @@ exports[`<ComposableTemplatesActions /> spec renders the component in non-edit m
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         data-test-subj="form-row-data_stream"
         id="some_html_id-row"
       >
@@ -516,7 +516,7 @@ exports[`<ComposableTemplatesActions /> spec renders the component in non-edit m
           class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiRadio"
+            class="euiRadio euiRadio--compressed"
           >
             <input
               checked=""
@@ -536,7 +536,7 @@ exports[`<ComposableTemplatesActions /> spec renders the component in non-edit m
             </label>
           </div>
           <div
-            class="euiRadio"
+            class="euiRadio euiRadio--compressed"
           >
             <input
               class="euiRadio__input"
@@ -560,7 +560,7 @@ exports[`<ComposableTemplatesActions /> spec renders the component in non-edit m
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         data-test-subj="form-row-index_patterns"
         id="some_html_id-row"
       >
@@ -587,17 +587,17 @@ exports[`<ComposableTemplatesActions /> spec renders the component in non-edit m
           <div
             aria-expanded="false"
             aria-haspopup="listbox"
-            class="euiComboBox"
+            class="euiComboBox euiComboBox--compressed"
             role="combobox"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <div
-                  class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                  class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                   data-test-subj="comboBoxInput"
                   tabindex="-1"
                 >
@@ -631,7 +631,7 @@ exports[`<ComposableTemplatesActions /> spec renders the component in non-edit m
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         data-test-subj="form-row-priority"
         id="some_html_id-row"
       >
@@ -659,13 +659,13 @@ exports[`<ComposableTemplatesActions /> spec renders the component in non-edit m
             class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
-                  class="euiFieldNumber"
+                  class="euiFieldNumber euiFieldNumber--compressed"
                   type="number"
                   value=""
                 />
@@ -678,7 +678,7 @@ exports[`<ComposableTemplatesActions /> spec renders the component in non-edit m
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         data-test-subj="form-row-_meta.flow"
         id="some_html_id-row"
       >

--- a/public/pages/CreateIndexTemplate/components/TemplateType/TemplateType.tsx
+++ b/public/pages/CreateIndexTemplate/components/TemplateType/TemplateType.tsx
@@ -2,7 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { EuiRadio, EuiSpacer } from "@elastic/eui";
+import { EuiCompressedRadio, EuiSpacer } from "@elastic/eui";
 import { TEMPLATE_TYPE } from "../../../../utils/constants";
 import React from "react";
 import { AllBuiltInComponents } from "../../../../components/FormGenerator";
@@ -21,13 +21,13 @@ export default function TemplateType(props: ITemplateTypeProps) {
   const { value, onChange } = props;
   return (
     <>
-      <EuiRadio
+      <EuiCompressedRadio
         id={TEMPLATE_TYPE.INDEX_TEMPLATE}
         onChange={(e) => e.target.checked && onChange(undefined)}
         label={TEMPLATE_TYPE.INDEX_TEMPLATE}
         checked={value === undefined}
       />
-      <EuiRadio
+      <EuiCompressedRadio
         id={TEMPLATE_TYPE.DATA_STREAM}
         onChange={(e) =>
           e.target.checked &&

--- a/public/pages/CreateIndexTemplate/containers/ComposableTemplate/ComposableTemplate.tsx
+++ b/public/pages/CreateIndexTemplate/containers/ComposableTemplate/ComposableTemplate.tsx
@@ -4,7 +4,7 @@
  */
 import React, { useContext, useRef, useState, useEffect, useMemo } from "react";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonIcon,
   EuiDragDropContext,
   EuiDraggable,
@@ -188,10 +188,10 @@ export default function ComposableTemplate(props: SubDetailProps) {
       <EuiSpacer />
       {readonly ? null : (
         <div>
-          <EuiButton onClick={() => setDialogVisible(true)}>Associate component templates</EuiButton>
-          <EuiButton style={{ marginLeft: 20 }} onClick={() => setCreateComponentVisible(true)}>
+          <EuiSmallButton onClick={() => setDialogVisible(true)}>Associate component templates</EuiSmallButton>
+          <EuiSmallButton style={{ marginLeft: 20 }} onClick={() => setCreateComponentVisible(true)}>
             Create component template
-          </EuiButton>
+          </EuiSmallButton>
         </div>
       )}
       <Modal.SimpleModal

--- a/public/pages/CreateIndexTemplate/containers/ComposableTemplate/ComposableTemplate.tsx
+++ b/public/pages/CreateIndexTemplate/containers/ComposableTemplate/ComposableTemplate.tsx
@@ -5,7 +5,7 @@
 import React, { useContext, useRef, useState, useEffect, useMemo } from "react";
 import {
   EuiSmallButton,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiDragDropContext,
   EuiDraggable,
   EuiDroppable,
@@ -153,7 +153,7 @@ export default function ComposableTemplate(props: SubDetailProps) {
                             </div>
                             <div>
                               {readonly ? null : (
-                                <EuiButtonIcon
+                                <EuiSmallButtonIcon
                                   onClick={() => {
                                     const newValue = [...(values.composed_of || [])];
                                     newValue.splice(index, 1);
@@ -164,7 +164,7 @@ export default function ComposableTemplate(props: SubDetailProps) {
                                   aria-label="delete"
                                 />
                               )}
-                              <EuiButtonIcon
+                              <EuiSmallButtonIcon
                                 onClick={() => window.open(`#${ROUTES.CREATE_COMPOSABLE_TEMPLATE}/${item}`)}
                                 style={{ marginLeft: 12 }}
                                 iconType="inspect"

--- a/public/pages/CreateIndexTemplate/containers/CreateIndexTemplate/__snapshots__/CreateIndexTemplate.test.tsx.snap
+++ b/public/pages/CreateIndexTemplate/containers/CreateIndexTemplate/__snapshots__/CreateIndexTemplate.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`<CreateIndexTemplate /> spec render template pages 1`] = `
         style="flex-direction: row;"
       >
         <button
-          class="euiButton euiButton--primary"
+          class="euiButton euiButton--primary euiButton--small"
           style="margin-right: 20px;"
           type="button"
         >
@@ -38,7 +38,7 @@ exports[`<CreateIndexTemplate /> spec render template pages 1`] = `
           </span>
         </button>
         <button
-          class="euiButton euiButton--danger"
+          class="euiButton euiButton--danger euiButton--small"
           type="button"
         >
           <span
@@ -238,7 +238,7 @@ exports[`<CreateIndexTemplate /> spec render template pages 1`] = `
           class="euiSpacer euiSpacer--s"
         />
         <div
-          class="euiFormRow euiFormRow--fullWidth"
+          class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -406,7 +406,7 @@ exports[`<CreateIndexTemplate /> spec render template pages 1`] = `
                   class="euiSpacer euiSpacer--s"
                 />
                 <div
-                  class="euiFormRow euiFormRow--fullWidth"
+                  class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
@@ -599,7 +599,7 @@ exports[`<CreateIndexTemplate /> spec render template pages 1`] = `
           Index mapping
         </div>
         <div
-          class="euiFormRow euiFormRow--fullWidth"
+          class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -634,7 +634,7 @@ exports[`<CreateIndexTemplate /> spec render template pages 1`] = `
           class="euiSpacer euiSpacer--s"
         />
         <div
-          class="euiFormRow euiFormRow--fullWidth"
+          class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div

--- a/public/pages/CreateIndexTemplate/containers/TemplateDetail/TemplateDetail.tsx
+++ b/public/pages/CreateIndexTemplate/containers/TemplateDetail/TemplateDetail.tsx
@@ -232,9 +232,8 @@ const TemplateDetail = (props: TemplateDetailProps, ref: Ref<FieldInstance>) => 
     },
     {
       renderComponent: (
-        <EuiButton
+        <EuiSmallButton
           fill
-          size="s"
           style={{ marginRight: 20 }}
           onClick={() => {
             const showValue: TemplateItemRemote = {
@@ -259,7 +258,7 @@ const TemplateDetail = (props: TemplateDetailProps, ref: Ref<FieldInstance>) => 
           }}
         >
           View JSON
-        </EuiButton>
+        </EuiSmallButton>
       ),
     },
   ];

--- a/public/pages/CreateIndexTemplate/containers/TemplateDetail/TemplateDetail.tsx
+++ b/public/pages/CreateIndexTemplate/containers/TemplateDetail/TemplateDetail.tsx
@@ -5,7 +5,7 @@
 
 import React, { forwardRef, useContext, useEffect, useImperativeHandle, useRef, Ref, useState } from "react";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiButtonIcon,
   EuiCodeBlock,
@@ -175,7 +175,7 @@ const TemplateDetail = (props: TemplateDetailProps, ref: Ref<FieldInstance>) => 
 
   const PreviewTemplateButton = () => (
     <EuiFlexItem grow={false}>
-      <EuiButton
+      <EuiSmallButton
         onClick={async () => {
           const result = await simulateTemplate({
             template: field.getValues(),
@@ -192,7 +192,7 @@ const TemplateDetail = (props: TemplateDetailProps, ref: Ref<FieldInstance>) => 
         color="ghost"
       >
         Preview template
-      </EuiButton>
+      </EuiSmallButton>
     </EuiFlexItem>
   );
   const { HeaderControl } = getNavigationUI();
@@ -292,7 +292,7 @@ const TemplateDetail = (props: TemplateDetailProps, ref: Ref<FieldInstance>) => 
           {isEdit ? (
             <>
               <EuiFlexItem grow={false} style={{ flexDirection: "row" }}>
-                <EuiButton
+                <EuiSmallButton
                   style={{ marginRight: 20 }}
                   onClick={() => {
                     const showValue: TemplateItemRemote = {
@@ -317,10 +317,10 @@ const TemplateDetail = (props: TemplateDetailProps, ref: Ref<FieldInstance>) => 
                   }}
                 >
                   View JSON
-                </EuiButton>
-                <EuiButton color="danger" onClick={() => setVisible(true)}>
+                </EuiSmallButton>
+                <EuiSmallButton color="danger" onClick={() => setVisible(true)}>
                   Delete
-                </EuiButton>
+                </EuiSmallButton>
                 <DeleteTemplateModal
                   visible={visible}
                   selectedItems={[templateName]}
@@ -440,7 +440,7 @@ const TemplateDetail = (props: TemplateDetailProps, ref: Ref<FieldInstance>) => 
               </EuiFlexItem>
               <PreviewTemplateButton />
               <EuiFlexItem grow={false}>
-                <EuiButton
+                <EuiSmallButton
                   fill
                   onClick={async () => {
                     const result = await onSubmit();
@@ -457,7 +457,7 @@ const TemplateDetail = (props: TemplateDetailProps, ref: Ref<FieldInstance>) => 
                   data-test-subj="CreateIndexTemplateCreateButton"
                 >
                   Create template
-                </EuiButton>
+                </EuiSmallButton>
               </EuiFlexItem>
             </EuiFlexGroup>
           </BottomBar>

--- a/public/pages/CreateIndexTemplate/containers/TemplateDetail/__snapshots__/TemplateDetail.test.tsx.snap
+++ b/public/pages/CreateIndexTemplate/containers/TemplateDetail/__snapshots__/TemplateDetail.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
          template
       </h1>
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -85,7 +85,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
         class="euiSpacer euiSpacer--s"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         data-test-subj="form-row-name"
         id="some_html_id-row"
       >
@@ -115,13 +115,13 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
             class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
-                  class="euiFieldText"
+                  class="euiFieldText euiFieldText--compressed"
                   type="text"
                   value=""
                 />
@@ -131,7 +131,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
         </div>
       </div>
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -151,7 +151,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         data-test-subj="form-row-data_stream"
         id="some_html_id-row"
       >
@@ -170,7 +170,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
           class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiRadio"
+            class="euiRadio euiRadio--compressed"
           >
             <input
               checked=""
@@ -190,7 +190,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
             </label>
           </div>
           <div
-            class="euiRadio"
+            class="euiRadio euiRadio--compressed"
           >
             <input
               class="euiRadio__input"
@@ -214,7 +214,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         data-test-subj="form-row-index_patterns"
         id="some_html_id-row"
       >
@@ -241,17 +241,17 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
           <div
             aria-expanded="false"
             aria-haspopup="listbox"
-            class="euiComboBox"
+            class="euiComboBox euiComboBox--compressed"
             role="combobox"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <div
-                  class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                  class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                   data-test-subj="comboBoxInput"
                   tabindex="-1"
                 >
@@ -285,7 +285,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         data-test-subj="form-row-priority"
         id="some_html_id-row"
       >
@@ -313,13 +313,13 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
             class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
-                  class="euiFieldNumber"
+                  class="euiFieldNumber euiFieldNumber--compressed"
                   type="number"
                   value="0"
                 />
@@ -332,7 +332,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         data-test-subj="form-row-_meta.flow"
         id="some_html_id-row"
       >
@@ -496,7 +496,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
         class="euiSpacer euiSpacer--s"
       />
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -528,7 +528,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
         class="euiSpacer euiSpacer--s"
       />
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         data-test-subj="form-row-template.aliases"
         id="some_html_id-row"
       >
@@ -555,17 +555,17 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
           <div
             aria-expanded="false"
             aria-haspopup="listbox"
-            class="euiComboBox"
+            class="euiComboBox euiComboBox--compressed"
             role="combobox"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <div
-                  class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                  class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                   data-test-subj="comboBoxInput"
                   tabindex="-1"
                 >
@@ -619,7 +619,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
         class="euiSpacer euiSpacer--s"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         data-test-subj="form-row-template.settings.index.number_of_shards"
         id="some_html_id-row"
       >
@@ -647,13 +647,13 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
             class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
-                  class="euiFieldNumber"
+                  class="euiFieldNumber euiFieldNumber--compressed"
                   type="number"
                   value=""
                 />
@@ -666,7 +666,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         data-test-subj="form-row-template.settings.index.number_of_replicas"
         id="some_html_id-row"
       >
@@ -694,13 +694,13 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
             class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
-                  class="euiFieldNumber"
+                  class="euiFieldNumber euiFieldNumber--compressed"
                   type="number"
                   value=""
                 />
@@ -713,7 +713,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         data-test-subj="form-row-template.settings.index.refresh_interval"
         id="some_html_id-row"
       >
@@ -741,13 +741,13 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
             class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
-                  class="euiFieldText"
+                  class="euiFieldText euiFieldText--compressed"
                   type="text"
                   value=""
                 />
@@ -802,7 +802,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
                 class="euiSpacer euiSpacer--s"
               />
               <div
-                class="euiFormRow euiFormRow--fullWidth"
+                class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -992,7 +992,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
         Index mapping
       </div>
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -1027,7 +1027,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
         class="euiSpacer euiSpacer--s"
       />
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -1107,7 +1107,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
             class="euiSpacer euiSpacer--l"
           />
           <button
-            class="euiButton euiButton--primary"
+            class="euiButton euiButton--primary euiButton--small"
             data-test-subj="createIndexAddFieldButton"
             style="margin-right: 8px;"
             type="button"
@@ -1123,7 +1123,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
             </span>
           </button>
           <button
-            class="euiButton euiButton--primary"
+            class="euiButton euiButton--primary euiButton--small"
             data-test-subj="createIndexAddObjectFieldButton"
             type="button"
           >

--- a/public/pages/CreateIndexTemplate/containers/TemplateMappings/TemplateMappings.tsx
+++ b/public/pages/CreateIndexTemplate/containers/TemplateMappings/TemplateMappings.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React, { useContext, useRef } from "react";
-import { EuiFormRow, EuiLink, EuiSpacer, EuiTitle } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiLink, EuiSpacer, EuiTitle } from "@elastic/eui";
 import { CoreStart } from "opensearch-dashboards/public";
 import { ContentPanel } from "../../../../components/ContentPanel";
 import { SubDetailProps } from "../../interface";
@@ -19,7 +19,7 @@ export default function TemplateMappings(props: SubDetailProps) {
       <EuiTitle size="s">
         <div>Index mapping</div>
       </EuiTitle>
-      <EuiFormRow
+      <EuiCompressedFormRow
         fullWidth
         helpText={
           <div>
@@ -35,9 +35,9 @@ export default function TemplateMappings(props: SubDetailProps) {
         }
       >
         <></>
-      </EuiFormRow>
+      </EuiCompressedFormRow>
       <EuiSpacer size="s" />
-      <EuiFormRow fullWidth>
+      <EuiCompressedFormRow fullWidth>
         <IndexMapping
           {...field.registerField({
             name: ["template", "mappings"],
@@ -61,7 +61,7 @@ export default function TemplateMappings(props: SubDetailProps) {
           oldMappingsEditable
           docVersion={coreServices.docLinks.DOC_LINK_VERSION}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </>
   );
 }

--- a/public/pages/CreatePolicy/components/ConfigurePolicy/ConfigurePolicy.tsx
+++ b/public/pages/CreatePolicy/components/ConfigurePolicy/ConfigurePolicy.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiSpacer, EuiCompressedFormRow, EuiFieldText, EuiText } from "@elastic/eui";
+import { EuiSpacer, EuiCompressedFormRow, EuiCompressedFieldText, EuiText } from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
 
 interface ConfigurePolicyProps {
@@ -32,7 +32,13 @@ const ConfigurePolicy = ({ isEdit, policyId, policyIdError, onChange, useNewUx }
         isInvalid={!!policyIdError}
         error={policyIdError}
       >
-        <EuiFieldText isInvalid={!!policyIdError} placeholder="example_policy" readOnly={isEdit} value={policyId} onChange={onChange} />
+        <EuiCompressedFieldText
+          isInvalid={!!policyIdError}
+          placeholder="example_policy"
+          readOnly={isEdit}
+          value={policyId}
+          onChange={onChange}
+        />
       </EuiCompressedFormRow>
     </div>
   </ContentPanel>

--- a/public/pages/CreatePolicy/components/ConfigurePolicy/ConfigurePolicy.tsx
+++ b/public/pages/CreatePolicy/components/ConfigurePolicy/ConfigurePolicy.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiSpacer, EuiFormRow, EuiFieldText, EuiText } from "@elastic/eui";
+import { EuiSpacer, EuiCompressedFormRow, EuiFieldText, EuiText } from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
 
 interface ConfigurePolicyProps {
@@ -26,14 +26,14 @@ const ConfigurePolicy = ({ isEdit, policyId, policyIdError, onChange, useNewUx }
         <></>
       )}
       <EuiSpacer size="s" />
-      <EuiFormRow
+      <EuiCompressedFormRow
         label="Policy ID"
         helpText="Specify a unique ID that is easy to recognize and remember."
         isInvalid={!!policyIdError}
         error={policyIdError}
       >
         <EuiFieldText isInvalid={!!policyIdError} placeholder="example_policy" readOnly={isEdit} value={policyId} onChange={onChange} />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </div>
   </ContentPanel>
 );

--- a/public/pages/CreatePolicy/components/ConfigurePolicy/__snapshots__/ConfigurePolicy.test.tsx.snap
+++ b/public/pages/CreatePolicy/components/ConfigurePolicy/__snapshots__/ConfigurePolicy.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`<ConfigurePolicy /> spec renders the component 1`] = `
         class="euiSpacer euiSpacer--s"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -63,14 +63,14 @@ exports[`<ConfigurePolicy /> spec renders the component 1`] = `
           class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormControlLayout"
+            class="euiFormControlLayout euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <input
                 aria-describedby="some_html_id-help-0"
-                class="euiFieldText"
+                class="euiFieldText euiFieldText--compressed"
                 id="some_html_id"
                 placeholder="example_policy"
                 type="text"

--- a/public/pages/CreatePolicy/components/DefinePolicy/DefinePolicy.tsx
+++ b/public/pages/CreatePolicy/components/DefinePolicy/DefinePolicy.tsx
@@ -6,7 +6,7 @@
 import React from "react";
 import {
   EuiSpacer,
-  EuiButton,
+  EuiSmallButton,
   // @ts-ignore
   EuiCodeEditor,
   EuiText,
@@ -38,14 +38,14 @@ const DefinePolicy = ({ jsonString, onChange, onAutoIndent, hasJSONError, useNew
     actions={[
       <EuiCopy textToCopy={jsonString}>
         {(copy: () => void) => (
-          <EuiButton iconType="copyClipboard" onClick={copy} size={useNewUx ? "s" : undefined}>
+          <EuiSmallButton iconType="copyClipboard" onClick={copy}>
             Copy
-          </EuiButton>
+          </EuiSmallButton>
         )}
       </EuiCopy>,
-      <EuiButton iconType="editorAlignLeft" onClick={onAutoIndent} disabled={hasJSONError} size={useNewUx ? "s" : undefined}>
+      <EuiSmallButton iconType="editorAlignLeft" onClick={onAutoIndent} disabled={hasJSONError}>
         Auto indent
-      </EuiButton>,
+      </EuiSmallButton>,
     ]}
   >
     <div style={{ paddingLeft: "10px" }}>

--- a/public/pages/CreatePolicy/components/DefinePolicy/__mocks__/DefinePolicyMock.tsx
+++ b/public/pages/CreatePolicy/components/DefinePolicy/__mocks__/DefinePolicyMock.tsx
@@ -6,7 +6,7 @@
 import React, { ChangeEvent } from "react";
 import {
   EuiSpacer,
-  EuiButton,
+  EuiSmallButton,
   EuiTextArea,
   EuiText,
   // @ts-ignore
@@ -34,14 +34,14 @@ const DefinePolicy = ({ jsonString, onChange, onAutoIndent, hasJSONError }: Defi
     actions={[
       <EuiCopy textToCopy={jsonString}>
         {(copy: () => void) => (
-          <EuiButton iconType="copyClipboard" onClick={copy}>
+          <EuiSmallButton iconType="copyClipboard" onClick={copy}>
             Copy
-          </EuiButton>
+          </EuiSmallButton>
         )}
       </EuiCopy>,
-      <EuiButton iconType="editorAlignLeft" onClick={onAutoIndent} disabled={hasJSONError}>
+      <EuiSmallButton iconType="editorAlignLeft" onClick={onAutoIndent} disabled={hasJSONError}>
         Auto Indent
-      </EuiButton>,
+      </EuiSmallButton>,
     ]}
   >
     <div style={{ paddingLeft: "10px" }}>

--- a/public/pages/CreatePolicy/components/DefinePolicy/__mocks__/DefinePolicyMock.tsx
+++ b/public/pages/CreatePolicy/components/DefinePolicy/__mocks__/DefinePolicyMock.tsx
@@ -7,7 +7,7 @@ import React, { ChangeEvent } from "react";
 import {
   EuiSpacer,
   EuiSmallButton,
-  EuiTextArea,
+  EuiCompressedTextArea,
   EuiText,
   // @ts-ignore
   EuiCopy,
@@ -23,7 +23,7 @@ interface DefinePolicyProps {
 
 /*
  * Attempting to test EuiCodeEditor which uses react-ace was a lot more effort than seemed worthwhile
- * at the moment, so in the meantime we will mock DefinePolicy as a EuiTextArea so that we can still test
+ * at the moment, so in the meantime we will mock DefinePolicy as a EuiCompressedTextArea so that we can still test
  * the functionality of CreatePolicy (minus the JSON code editor).
  * */
 const DefinePolicy = ({ jsonString, onChange, onAutoIndent, hasJSONError }: DefinePolicyProps) => (
@@ -50,7 +50,11 @@ const DefinePolicy = ({ jsonString, onChange, onAutoIndent, hasJSONError }: Defi
       </EuiText>
     </div>
     <EuiSpacer size="s" />
-    <EuiTextArea value={jsonString} onChange={(e: ChangeEvent<HTMLTextAreaElement>) => onChange(e.target.value)} aria-label="Code Editor" />
+    <EuiCompressedTextArea
+      value={jsonString}
+      onChange={(e: ChangeEvent<HTMLTextAreaElement>) => onChange(e.target.value)}
+      aria-label="Code Editor"
+    />
   </ContentPanel>
 );
 

--- a/public/pages/CreatePolicy/components/DefinePolicy/__snapshots__/DefinePolicy.test.tsx.snap
+++ b/public/pages/CreatePolicy/components/DefinePolicy/__snapshots__/DefinePolicy.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`<DefinePolicy /> spec renders the component 1`] = `
             class="euiToolTipAnchor"
           >
             <button
-              class="euiButton euiButton--primary"
+              class="euiButton euiButton--primary euiButton--small"
               type="button"
             >
               <span
@@ -57,7 +57,7 @@ exports[`<DefinePolicy /> spec renders the component 1`] = `
           class="euiFlexItem"
         >
           <button
-            class="euiButton euiButton--primary"
+            class="euiButton euiButton--primary euiButton--small"
             type="button"
           >
             <span

--- a/public/pages/CreatePolicy/containers/CreatePolicy/CreatePolicy.tsx
+++ b/public/pages/CreatePolicy/containers/CreatePolicy/CreatePolicy.tsx
@@ -10,7 +10,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiCallOut,
   EuiLink,
   EuiIcon,
@@ -302,9 +302,9 @@ export class CreatePolicy extends Component<CreatePolicyProps, CreatePolicyState
         <EuiSpacer />
         <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty onClick={this.onCancel} data-test-subj="createPolicyCancelButton" size={useNewUX ? "s" : undefined}>
+            <EuiSmallButtonEmpty onClick={this.onCancel} data-test-subj="createPolicyCancelButton">
               Cancel
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiSmallButton fill onClick={this.onSubmit} isLoading={isSubmitting} data-test-subj="createPolicyCreateButton">

--- a/public/pages/CreatePolicy/containers/CreatePolicy/CreatePolicy.tsx
+++ b/public/pages/CreatePolicy/containers/CreatePolicy/CreatePolicy.tsx
@@ -13,7 +13,6 @@ import {
   EuiSmallButtonEmpty,
   EuiCallOut,
   EuiLink,
-  EuiIcon,
   EuiText,
 } from "@elastic/eui";
 import queryString from "query-string";

--- a/public/pages/CreatePolicy/containers/CreatePolicy/CreatePolicy.tsx
+++ b/public/pages/CreatePolicy/containers/CreatePolicy/CreatePolicy.tsx
@@ -9,7 +9,7 @@ import {
   EuiTitle,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiCallOut,
   EuiLink,
@@ -307,15 +307,9 @@ export class CreatePolicy extends Component<CreatePolicyProps, CreatePolicyState
             </EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
-              fill
-              onClick={this.onSubmit}
-              isLoading={isSubmitting}
-              data-test-subj="createPolicyCreateButton"
-              size={useNewUX ? "s" : undefined}
-            >
+            <EuiSmallButton fill onClick={this.onSubmit} isLoading={isSubmitting} data-test-subj="createPolicyCreateButton">
               {isEdit ? "Update" : "Create"}
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </div>

--- a/public/pages/CreatePolicy/containers/CreatePolicy/__snapshots__/CreatePolicy.test.tsx.snap
+++ b/public/pages/CreatePolicy/containers/CreatePolicy/__snapshots__/CreatePolicy.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`<CreatePolicy /> spec renders the create component 1`] = `
           class="euiSpacer euiSpacer--s"
         />
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -75,14 +75,14 @@ exports[`<CreatePolicy /> spec renders the create component 1`] = `
             class="euiFormRow__fieldWrapper"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
                   aria-describedby="some_html_id-help-0"
-                  class="euiFieldText"
+                  class="euiFieldText euiFieldText--compressed"
                   id="some_html_id"
                   placeholder="example_policy"
                   type="text"
@@ -140,7 +140,7 @@ exports[`<CreatePolicy /> spec renders the create component 1`] = `
               class="euiToolTipAnchor"
             >
               <button
-                class="euiButton euiButton--primary"
+                class="euiButton euiButton--primary euiButton--small"
                 type="button"
               >
                 <span
@@ -160,7 +160,7 @@ exports[`<CreatePolicy /> spec renders the create component 1`] = `
             class="euiFlexItem"
           >
             <button
-              class="euiButton euiButton--primary"
+              class="euiButton euiButton--primary euiButton--small"
               type="button"
             >
               <span
@@ -200,8 +200,8 @@ exports[`<CreatePolicy /> spec renders the create component 1`] = `
       />
       <textarea
         aria-label="Code Editor"
-        class="euiTextArea euiTextArea--resizeVertical"
-        rows="6"
+        class="euiTextArea euiTextArea--resizeVertical euiTextArea--compressed"
+        rows="3"
       >
         {
     "policy": {
@@ -262,7 +262,7 @@ exports[`<CreatePolicy /> spec renders the create component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButtonEmpty euiButtonEmpty--primary"
+        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
         data-test-subj="createPolicyCancelButton"
         type="button"
       >
@@ -281,7 +281,7 @@ exports[`<CreatePolicy /> spec renders the create component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButton euiButton--primary euiButton--fill"
+        class="euiButton euiButton--primary euiButton--small euiButton--fill"
         data-test-subj="createPolicyCreateButton"
         type="button"
       >
@@ -400,7 +400,7 @@ exports[`<CreatePolicy /> spec renders the edit component 1`] = `
           class="euiSpacer euiSpacer--s"
         />
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -418,14 +418,14 @@ exports[`<CreatePolicy /> spec renders the edit component 1`] = `
             class="euiFormRow__fieldWrapper"
           >
             <div
-              class="euiFormControlLayout euiFormControlLayout--readOnly"
+              class="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--readOnly"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
                   aria-describedby="some_html_id-help-0"
-                  class="euiFieldText"
+                  class="euiFieldText euiFieldText--compressed"
                   id="some_html_id"
                   placeholder="example_policy"
                   readonly=""
@@ -484,7 +484,7 @@ exports[`<CreatePolicy /> spec renders the edit component 1`] = `
               class="euiToolTipAnchor"
             >
               <button
-                class="euiButton euiButton--primary"
+                class="euiButton euiButton--primary euiButton--small"
                 type="button"
               >
                 <span
@@ -504,7 +504,7 @@ exports[`<CreatePolicy /> spec renders the edit component 1`] = `
             class="euiFlexItem"
           >
             <button
-              class="euiButton euiButton--primary"
+              class="euiButton euiButton--primary euiButton--small"
               type="button"
             >
               <span
@@ -544,8 +544,8 @@ exports[`<CreatePolicy /> spec renders the edit component 1`] = `
       />
       <textarea
         aria-label="Code Editor"
-        class="euiTextArea euiTextArea--resizeVertical"
-        rows="6"
+        class="euiTextArea euiTextArea--resizeVertical euiTextArea--compressed"
+        rows="3"
       >
         {
     "policy": {
@@ -608,7 +608,7 @@ exports[`<CreatePolicy /> spec renders the edit component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButtonEmpty euiButtonEmpty--primary"
+        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
         data-test-subj="createPolicyCancelButton"
         type="button"
       >
@@ -627,7 +627,7 @@ exports[`<CreatePolicy /> spec renders the edit component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButton euiButton--primary euiButton--fill"
+        class="euiButton euiButton--primary euiButton--small euiButton--fill"
         data-test-subj="createPolicyCreateButton"
         type="button"
       >

--- a/public/pages/CreateRollup/components/AdvancedAggregation/AdvancedAggregation.tsx
+++ b/public/pages/CreateRollup/components/AdvancedAggregation/AdvancedAggregation.tsx
@@ -34,7 +34,7 @@ import {
   EuiFormHelpText,
   EuiHorizontalRule,
   EuiCallOut,
-  EuiFieldNumber,
+  EuiCompressedFieldNumber,
   EuiTableSortingType,
 } from "@elastic/eui";
 import { AddFieldsColumns } from "../../utils/constants";
@@ -299,7 +299,7 @@ export default class AdvancedAggregation extends Component<AdvancedAggregationPr
           ) : (
             <EuiForm>
               <EuiCompressedFormRow>
-                <EuiFieldNumber
+                <EuiCompressedFieldNumber
                   min={1}
                   value={interval}
                   onChange={(e) => this.onChangeInterval(e, item)}

--- a/public/pages/CreateRollup/components/AdvancedAggregation/AdvancedAggregation.tsx
+++ b/public/pages/CreateRollup/components/AdvancedAggregation/AdvancedAggregation.tsx
@@ -24,7 +24,7 @@ import {
   Criteria,
   EuiTableSelectionType,
   EuiTableFieldDataColumnType,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSelect,
   EuiText,
   EuiLink,
@@ -272,7 +272,7 @@ export default class AdvancedAggregation extends Component<AdvancedAggregationPr
         align: "left",
         render: (aggregationMethod, item) => (
           <EuiForm>
-            <EuiFormRow>
+            <EuiCompressedFormRow>
               <EuiSelect
                 compressed={true}
                 value={aggregationMethod}
@@ -284,7 +284,7 @@ export default class AdvancedAggregation extends Component<AdvancedAggregationPr
                 onChange={(e) => this.onChangeAggregationMethod(e, item)}
                 data-test-subj={`aggregationMethodSelect-${item.field.label}`}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiForm>
         ),
       },
@@ -298,14 +298,14 @@ export default class AdvancedAggregation extends Component<AdvancedAggregationPr
             "-"
           ) : (
             <EuiForm>
-              <EuiFormRow>
+              <EuiCompressedFormRow>
                 <EuiFieldNumber
                   min={1}
                   value={interval}
                   onChange={(e) => this.onChangeInterval(e, item)}
                   data-test-subj={`interval-${item.field.label}`}
                 />
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </EuiForm>
           ),
       },

--- a/public/pages/CreateRollup/components/AdvancedAggregation/AdvancedAggregation.tsx
+++ b/public/pages/CreateRollup/components/AdvancedAggregation/AdvancedAggregation.tsx
@@ -14,7 +14,7 @@ import {
   EuiModalHeaderTitle,
   EuiModalBody,
   EuiModalFooter,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiForm,
@@ -459,9 +459,9 @@ export default class AdvancedAggregation extends Component<AdvancedAggregationPr
                 </EuiModalBody>
 
                 <EuiModalFooter>
-                  <EuiButtonEmpty onClick={this.closeModal} data-test-subj="addFieldsAggregationCancel">
+                  <EuiSmallButtonEmpty onClick={this.closeModal} data-test-subj="addFieldsAggregationCancel">
                     Cancel
-                  </EuiButtonEmpty>
+                  </EuiSmallButtonEmpty>
                   <EuiSmallButton
                     fill
                     onClick={() => {

--- a/public/pages/CreateRollup/components/AdvancedAggregation/AdvancedAggregation.tsx
+++ b/public/pages/CreateRollup/components/AdvancedAggregation/AdvancedAggregation.tsx
@@ -7,7 +7,7 @@ import React, { ChangeEvent, Component, Fragment } from "react";
 import {
   EuiSpacer,
   EuiBasicTable,
-  EuiButton,
+  EuiSmallButton,
   EuiOverlayMask,
   EuiModal,
   EuiModalHeader,
@@ -393,9 +393,9 @@ export default class AdvancedAggregation extends Component<AdvancedAggregationPr
           <EuiFlexItem grow={false}>
             <EuiFlexGroup direction="column" justifyContent="spaceBetween" style={{ padding: "0px 10px" }}>
               <EuiFlexItem grow={false}>
-                <EuiButton onClick={this.showModal} data-test-subj="addFieldsAggregation">
+                <EuiSmallButton onClick={this.showModal} data-test-subj="addFieldsAggregation">
                   Add fields
-                </EuiButton>
+                </EuiSmallButton>
               </EuiFlexItem>
               <EuiFlexItem> </EuiFlexItem>
             </EuiFlexGroup>
@@ -424,9 +424,9 @@ export default class AdvancedAggregation extends Component<AdvancedAggregationPr
                     <EuiSpacer />
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
-                    <EuiButton onClick={this.showModal} data-test-subj="addFieldsAggregationEmpty">
+                    <EuiSmallButton onClick={this.showModal} data-test-subj="addFieldsAggregationEmpty">
                       Add fields
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                   <EuiFlexItem>
                     <EuiSpacer size="m" />
@@ -462,7 +462,7 @@ export default class AdvancedAggregation extends Component<AdvancedAggregationPr
                   <EuiButtonEmpty onClick={this.closeModal} data-test-subj="addFieldsAggregationCancel">
                     Cancel
                   </EuiButtonEmpty>
-                  <EuiButton
+                  <EuiSmallButton
                     fill
                     onClick={() => {
                       this.closeModal();
@@ -471,7 +471,7 @@ export default class AdvancedAggregation extends Component<AdvancedAggregationPr
                     data-test-subj="addFieldsAggregationAdd"
                   >
                     Add
-                  </EuiButton>
+                  </EuiSmallButton>
                 </EuiModalFooter>
               </EuiModal>
             </EuiOverlayMask>

--- a/public/pages/CreateRollup/components/ConfigureRollup/ConfigureRollup.tsx
+++ b/public/pages/CreateRollup/components/ConfigureRollup/ConfigureRollup.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiSpacer, EuiCompressedFormRow, EuiFieldText, EuiTextArea, EuiText, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiSpacer, EuiCompressedFormRow, EuiCompressedFieldText, EuiTextArea, EuiText, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
 
 interface ConfigureRollupProps {
@@ -21,7 +21,13 @@ const ConfigureRollup = ({ isEdit, rollupId, rollupIdError, onChangeName, onChan
     <div style={{ paddingLeft: "10px" }}>
       <EuiSpacer size="s" />
       <EuiCompressedFormRow label="Name" helpText="Specify a unique, descriptive name." isInvalid={!!rollupIdError} error={rollupIdError}>
-        <EuiFieldText isInvalid={!!rollupIdError} placeholder="my-rollupjob1" value={rollupId} onChange={onChangeName} disabled={isEdit} />
+        <EuiCompressedFieldText
+          isInvalid={!!rollupIdError}
+          placeholder="my-rollupjob1"
+          value={rollupId}
+          onChange={onChangeName}
+          disabled={isEdit}
+        />
       </EuiCompressedFormRow>
       <EuiSpacer />
       <EuiFlexGroup gutterSize="xs">

--- a/public/pages/CreateRollup/components/ConfigureRollup/ConfigureRollup.tsx
+++ b/public/pages/CreateRollup/components/ConfigureRollup/ConfigureRollup.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiSpacer, EuiFormRow, EuiFieldText, EuiTextArea, EuiText, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiSpacer, EuiCompressedFormRow, EuiFieldText, EuiTextArea, EuiText, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
 
 interface ConfigureRollupProps {
@@ -20,9 +20,9 @@ const ConfigureRollup = ({ isEdit, rollupId, rollupIdError, onChangeName, onChan
   <ContentPanel bodyStyles={{ padding: "initial" }} title="Job name and description" titleSize="s">
     <div style={{ paddingLeft: "10px" }}>
       <EuiSpacer size="s" />
-      <EuiFormRow label="Name" helpText="Specify a unique, descriptive name." isInvalid={!!rollupIdError} error={rollupIdError}>
+      <EuiCompressedFormRow label="Name" helpText="Specify a unique, descriptive name." isInvalid={!!rollupIdError} error={rollupIdError}>
         <EuiFieldText isInvalid={!!rollupIdError} placeholder="my-rollupjob1" value={rollupId} onChange={onChangeName} disabled={isEdit} />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
       <EuiSpacer />
       <EuiFlexGroup gutterSize="xs">
         <EuiFlexItem grow={false}>
@@ -37,9 +37,9 @@ const ConfigureRollup = ({ isEdit, rollupId, rollupIdError, onChangeName, onChan
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="xs" />
-      <EuiFormRow>
+      <EuiCompressedFormRow>
         <EuiTextArea compressed={true} value={description} onChange={onChangeDescription} data-test-subj="description" />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </div>
   </ContentPanel>
 );

--- a/public/pages/CreateRollup/components/MetricsCalculation/MetricsCalculation.tsx
+++ b/public/pages/CreateRollup/components/MetricsCalculation/MetricsCalculation.tsx
@@ -22,7 +22,7 @@ import {
   EuiTableSelectionType,
   EuiCheckbox,
   EuiText,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiPanel,
   EuiTitle,
   EuiFormHelpText,
@@ -260,7 +260,7 @@ export default class MetricsCalculation extends Component<MetricsCalculationProp
         truncateText: true,
         render: (all: boolean, item: MetricItem) => (
           <EuiForm>
-            <EuiFormRow>
+            <EuiCompressedFormRow>
               <EuiCheckbox
                 compressed
                 id={`all-${item.source_field.label}`}
@@ -268,7 +268,7 @@ export default class MetricsCalculation extends Component<MetricsCalculationProp
                 onChange={(e) => this.setChecked(e, "all", item)}
                 data-test-subj={`all-${item.source_field.label}`}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiForm>
         ),
       },
@@ -278,7 +278,7 @@ export default class MetricsCalculation extends Component<MetricsCalculationProp
         align: "center",
         render: (min: boolean, item: MetricItem) => (
           <EuiForm>
-            <EuiFormRow>
+            <EuiCompressedFormRow>
               <EuiCheckbox
                 compressed
                 id={`min-${item.source_field.label}`}
@@ -286,7 +286,7 @@ export default class MetricsCalculation extends Component<MetricsCalculationProp
                 onChange={(e) => this.setChecked(e, "min", item)}
                 data-test-subj={`min-${item.source_field.label}`}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiForm>
         ),
       },
@@ -296,7 +296,7 @@ export default class MetricsCalculation extends Component<MetricsCalculationProp
         align: "center",
         render: (max: boolean, item: MetricItem) => (
           <EuiForm>
-            <EuiFormRow>
+            <EuiCompressedFormRow>
               <EuiCheckbox
                 compressed
                 id={`max-${item.source_field.label}`}
@@ -304,7 +304,7 @@ export default class MetricsCalculation extends Component<MetricsCalculationProp
                 onChange={(e) => this.setChecked(e, "max", item)}
                 data-test-subj={`max-${item.source_field.label}`}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiForm>
         ),
       },
@@ -314,7 +314,7 @@ export default class MetricsCalculation extends Component<MetricsCalculationProp
         align: "center",
         render: (sum: boolean, item: MetricItem) => (
           <EuiForm>
-            <EuiFormRow>
+            <EuiCompressedFormRow>
               <EuiCheckbox
                 compressed
                 id={`sum-${item.source_field.label}`}
@@ -322,7 +322,7 @@ export default class MetricsCalculation extends Component<MetricsCalculationProp
                 onChange={(e) => this.setChecked(e, "sum", item)}
                 data-test-subj={`sum-${item.source_field.label}`}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiForm>
         ),
       },
@@ -332,7 +332,7 @@ export default class MetricsCalculation extends Component<MetricsCalculationProp
         align: "center",
         render: (avg: boolean, item: MetricItem) => (
           <EuiForm>
-            <EuiFormRow>
+            <EuiCompressedFormRow>
               <EuiCheckbox
                 compressed
                 id={`avg-${item.source_field.label}`}
@@ -340,7 +340,7 @@ export default class MetricsCalculation extends Component<MetricsCalculationProp
                 onChange={(e) => this.setChecked(e, "avg", item)}
                 data-test-subj={`avg-${item.source_field.label}`}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiForm>
         ),
       },
@@ -350,7 +350,7 @@ export default class MetricsCalculation extends Component<MetricsCalculationProp
         align: "center",
         render: (value_count: boolean, item: MetricItem) => (
           <EuiForm>
-            <EuiFormRow>
+            <EuiCompressedFormRow>
               <EuiCheckbox
                 compressed
                 id={`value_count-${item.source_field.label}`}
@@ -358,7 +358,7 @@ export default class MetricsCalculation extends Component<MetricsCalculationProp
                 onChange={(e) => this.setChecked(e, "value_count", item)}
                 data-test-subj={`valueCount-${item.source_field.label}`}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiForm>
         ),
       },

--- a/public/pages/CreateRollup/components/MetricsCalculation/MetricsCalculation.tsx
+++ b/public/pages/CreateRollup/components/MetricsCalculation/MetricsCalculation.tsx
@@ -7,7 +7,7 @@ import React, { ChangeEvent, Component, Fragment } from "react";
 import {
   EuiBasicTable,
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
@@ -639,9 +639,9 @@ export default class MetricsCalculation extends Component<MetricsCalculationProp
                 </EuiModalBody>
 
                 <EuiModalFooter>
-                  <EuiButtonEmpty onClick={this.closeModal} data-test-subj="addFieldsMetricCancel">
+                  <EuiSmallButtonEmpty onClick={this.closeModal} data-test-subj="addFieldsMetricCancel">
                     Cancel
-                  </EuiButtonEmpty>
+                  </EuiSmallButtonEmpty>
                   <EuiSmallButton
                     fill
                     onClick={() => {

--- a/public/pages/CreateRollup/components/MetricsCalculation/MetricsCalculation.tsx
+++ b/public/pages/CreateRollup/components/MetricsCalculation/MetricsCalculation.tsx
@@ -6,7 +6,7 @@
 import React, { ChangeEvent, Component, Fragment } from "react";
 import {
   EuiBasicTable,
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
@@ -529,9 +529,9 @@ export default class MetricsCalculation extends Component<MetricsCalculationProp
               <EuiFlexItem grow={false}>
                 <EuiPopover
                   button={
-                    <EuiButton iconType="arrowDown" iconSide="right" onClick={this.showDisable} disabled={selectedMetrics.length == 0}>
+                    <EuiSmallButton iconType="arrowDown" iconSide="right" onClick={this.showDisable} disabled={selectedMetrics.length == 0}>
                       Disable all
-                    </EuiButton>
+                    </EuiSmallButton>
                   }
                   isOpen={isDisableOpen}
                   closePopover={this.closeDisable}
@@ -544,9 +544,9 @@ export default class MetricsCalculation extends Component<MetricsCalculationProp
               <EuiFlexItem grow={false}>
                 <EuiPopover
                   button={
-                    <EuiButton iconType="arrowDown" iconSide="right" onClick={this.showEnable} disabled={selectedMetrics.length == 0}>
+                    <EuiSmallButton iconType="arrowDown" iconSide="right" onClick={this.showEnable} disabled={selectedMetrics.length == 0}>
                       Enable all
-                    </EuiButton>
+                    </EuiSmallButton>
                   }
                   isOpen={isEnableOpen}
                   closePopover={this.closeEnable}
@@ -557,9 +557,9 @@ export default class MetricsCalculation extends Component<MetricsCalculationProp
                 </EuiPopover>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiButton onClick={this.showModal} data-test-subj="addFieldsMetric">
+                <EuiSmallButton onClick={this.showModal} data-test-subj="addFieldsMetric">
                   Add fields
-                </EuiButton>
+                </EuiSmallButton>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>
@@ -601,9 +601,9 @@ export default class MetricsCalculation extends Component<MetricsCalculationProp
                     <EuiSpacer />
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
-                    <EuiButton onClick={this.showModal} data-test-subj="addFieldsMetricEmpty">
+                    <EuiSmallButton onClick={this.showModal} data-test-subj="addFieldsMetricEmpty">
                       Add fields
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                   <EuiFlexItem>
                     <EuiSpacer />
@@ -642,7 +642,7 @@ export default class MetricsCalculation extends Component<MetricsCalculationProp
                   <EuiButtonEmpty onClick={this.closeModal} data-test-subj="addFieldsMetricCancel">
                     Cancel
                   </EuiButtonEmpty>
-                  <EuiButton
+                  <EuiSmallButton
                     fill
                     onClick={() => {
                       this.closeModal();
@@ -651,7 +651,7 @@ export default class MetricsCalculation extends Component<MetricsCalculationProp
                     data-test-subj="addFieldsMetricAdd"
                   >
                     Add
-                  </EuiButton>
+                  </EuiSmallButton>
                 </EuiModalFooter>
               </EuiModal>
             </EuiOverlayMask>

--- a/public/pages/CreateRollup/components/RollupIndices/RollupIndices.tsx
+++ b/public/pages/CreateRollup/components/RollupIndices/RollupIndices.tsx
@@ -7,7 +7,7 @@ import React, { Component, Fragment } from "react";
 import { EuiSpacer, EuiCompressedFormRow, EuiCallOut, EuiText, EuiLink } from "@elastic/eui";
 import { EuiComboBoxOptionOption } from "@elastic/eui/src/components/combo_box/types";
 import _ from "lodash";
-import EuiComboBox from "../../../../components/ComboBoxWithoutWarning";
+import EuiCompressedComboBox from "../../../../components/ComboBoxWithoutWarning";
 import { ContentPanel } from "../../../../components/ContentPanel";
 import { IndexItem } from "../../../../../models/interfaces";
 import IndexService from "../../../../services/IndexService";
@@ -142,7 +142,7 @@ export default class RollupIndices extends Component<RollupIndicesProps, RollupI
             isInvalid={sourceIndexError != ""}
             helpText="The index pattern on which to performed the rollup job. You can use * as a wildcard."
           >
-            <EuiComboBox
+            <EuiCompressedComboBox
               placeholder="Select source index"
               options={indexOptions}
               selectedOptions={sourceIndex}
@@ -172,7 +172,7 @@ export default class RollupIndices extends Component<RollupIndicesProps, RollupI
               </EuiText>
             }
           >
-            <EuiComboBox
+            <EuiCompressedComboBox
               placeholder="Select or create target index"
               options={targetIndexOptions}
               selectedOptions={targetIndex}

--- a/public/pages/CreateRollup/components/RollupIndices/RollupIndices.tsx
+++ b/public/pages/CreateRollup/components/RollupIndices/RollupIndices.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { Component, Fragment } from "react";
-import { EuiSpacer, EuiFormRow, EuiCallOut, EuiText, EuiLink } from "@elastic/eui";
+import { EuiSpacer, EuiCompressedFormRow, EuiCallOut, EuiText, EuiLink } from "@elastic/eui";
 import { EuiComboBoxOptionOption } from "@elastic/eui/src/components/combo_box/types";
 import _ from "lodash";
 import EuiComboBox from "../../../../components/ComboBoxWithoutWarning";
@@ -136,7 +136,7 @@ export default class RollupIndices extends Component<RollupIndicesProps, RollupI
             </Fragment>
           )}
           <EuiSpacer size="m" />
-          <EuiFormRow
+          <EuiCompressedFormRow
             label="Source index"
             error={sourceIndexError}
             isInvalid={sourceIndexError != ""}
@@ -153,9 +153,9 @@ export default class RollupIndices extends Component<RollupIndicesProps, RollupI
               isInvalid={sourceIndexError != ""}
               data-test-subj="sourceIndexCombobox"
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
 
-          <EuiFormRow
+          <EuiCompressedFormRow
             label="Target index"
             error={targetIndexError}
             isInvalid={targetIndexError != ""}
@@ -184,7 +184,7 @@ export default class RollupIndices extends Component<RollupIndicesProps, RollupI
               isInvalid={targetIndexError != ""}
               data-test-subj="targetIndexCombobox"
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </div>
       </ContentPanel>
     );

--- a/public/pages/CreateRollup/components/Schedule/Schedule.tsx
+++ b/public/pages/CreateRollup/components/Schedule/Schedule.tsx
@@ -9,7 +9,7 @@ import {
   EuiSpacer,
   EuiCheckbox,
   EuiRadioGroup,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSelect,
   EuiFieldNumber,
   EuiFlexGroup,
@@ -69,12 +69,12 @@ const selectInterval = (
   <React.Fragment>
     <EuiFlexGroup style={{ maxWidth: 400 }}>
       <EuiFlexItem grow={false} style={{ width: 200 }}>
-        <EuiFormRow label="Rollup interval" error={intervalError} isInvalid={intervalError != ""}>
+        <EuiCompressedFormRow label="Rollup interval" error={intervalError} isInvalid={intervalError != ""}>
           <EuiFieldNumber value={interval} onChange={onChangeInterval} isInvalid={intervalError != ""} />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </EuiFlexItem>
       <EuiFlexItem>
-        <EuiFormRow hasEmptyLabelSpace={true}>
+        <EuiCompressedFormRow hasEmptyLabelSpace={true}>
           <EuiSelect
             id="selectIntervalTimeunit"
             options={ScheduleIntervalTimeunitOptions}
@@ -82,7 +82,7 @@ const selectInterval = (
             onChange={onChangeTimeunit}
             isInvalid={interval == undefined || interval <= 0}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </EuiFlexItem>
     </EuiFlexGroup>
   </React.Fragment>
@@ -90,9 +90,9 @@ const selectInterval = (
 
 const isContinuous = (continuousJob: string, onChangeContinuousJob: (optionId: string) => void) => (
   <React.Fragment>
-    <EuiFormRow label="Continuous">
+    <EuiCompressedFormRow label="Continuous">
       <EuiRadioGroup options={radios} idSelected={continuousJob} onChange={(id) => onChangeContinuousJob(id)} name="continuousJob" />
-    </EuiFormRow>
+    </EuiCompressedFormRow>
     <EuiSpacer size="m" />
   </React.Fragment>
 );
@@ -144,7 +144,7 @@ export default class Schedule extends Component<ScheduleProps> {
           <EuiSpacer size="m" />
           {!isEdit && isContinuous(continuousJob, onChangeContinuousJob)}
 
-          <EuiFormRow label="Rollup execution frequency">
+          <EuiCompressedFormRow label="Rollup execution frequency">
             <EuiSelect
               id="continuousDefinition"
               options={[
@@ -154,30 +154,30 @@ export default class Schedule extends Component<ScheduleProps> {
               value={continuousDefinition}
               onChange={onChangeContinuousDefinition}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
           <EuiSpacer size="m" />
 
           {continuousDefinition == "fixed" ? (
             selectInterval(interval, intervalTimeunit, intervalError, onChangeIntervalTime, onChangeIntervalTimeunit)
           ) : (
             <React.Fragment>
-              <EuiFormRow label="Define by cron expression">
+              <EuiCompressedFormRow label="Define by cron expression">
                 <EuiTextArea value={cronExpression} onChange={onChangeCron} compressed={true} />
-              </EuiFormRow>
-              <EuiFormRow label="Timezone" helpText="A day starts from 00:00:00 in the specified timezone.">
+              </EuiCompressedFormRow>
+              <EuiCompressedFormRow label="Timezone" helpText="A day starts from 00:00:00 in the specified timezone.">
                 <EuiSelect id="timezone" options={timezones} value={cronTimezone} onChange={onChangeCronTimezone} />
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </React.Fragment>
           )}
 
           <EuiSpacer size="m" />
 
-          <EuiFormRow
+          <EuiCompressedFormRow
             label="Page per execution"
             helpText="The number of pages every execution processes. A larger number means faster execution and higher costs on memory."
           >
             <EuiFieldNumber min={1} placeholder="1000" value={pageSize} onChange={onChangePage} />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
           <EuiSpacer size="m" />
           <EuiFlexGroup style={{ maxWidth: 400 }}>
             <EuiFlexItem grow={false} style={{ width: 200 }}>
@@ -193,14 +193,14 @@ export default class Schedule extends Component<ScheduleProps> {
                   </EuiText>
                 </EuiFlexItem>
               </EuiFlexGroup>
-              <EuiFormRow>
+              <EuiCompressedFormRow>
                 <EuiFieldNumber value={delayTime} onChange={onChangeDelayTime} />
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </EuiFlexItem>
             <EuiFlexItem>
-              <EuiFormRow hasEmptyLabelSpace={true}>
+              <EuiCompressedFormRow hasEmptyLabelSpace={true}>
                 <EuiSelect id="selectTimeunit" options={DelayTimeunitOptions} value={delayTimeunit} onChange={onChangeDelayTimeunit} />
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </EuiFlexItem>
           </EuiFlexGroup>
           <EuiFormHelpText style={{ maxWidth: 400 }}>

--- a/public/pages/CreateRollup/components/Schedule/Schedule.tsx
+++ b/public/pages/CreateRollup/components/Schedule/Schedule.tsx
@@ -10,7 +10,7 @@ import {
   EuiCheckbox,
   EuiRadioGroup,
   EuiCompressedFormRow,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiCompressedFieldNumber,
   EuiFlexGroup,
   EuiFlexItem,
@@ -75,7 +75,7 @@ const selectInterval = (
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiCompressedFormRow hasEmptyLabelSpace={true}>
-          <EuiSelect
+          <EuiCompressedSelect
             id="selectIntervalTimeunit"
             options={ScheduleIntervalTimeunitOptions}
             value={intervalTimeunit}
@@ -145,7 +145,7 @@ export default class Schedule extends Component<ScheduleProps> {
           {!isEdit && isContinuous(continuousJob, onChangeContinuousJob)}
 
           <EuiCompressedFormRow label="Rollup execution frequency">
-            <EuiSelect
+            <EuiCompressedSelect
               id="continuousDefinition"
               options={[
                 { value: "fixed", text: "Define by fixed interval" },
@@ -165,7 +165,7 @@ export default class Schedule extends Component<ScheduleProps> {
                 <EuiTextArea value={cronExpression} onChange={onChangeCron} compressed={true} />
               </EuiCompressedFormRow>
               <EuiCompressedFormRow label="Timezone" helpText="A day starts from 00:00:00 in the specified timezone.">
-                <EuiSelect id="timezone" options={timezones} value={cronTimezone} onChange={onChangeCronTimezone} />
+                <EuiCompressedSelect id="timezone" options={timezones} value={cronTimezone} onChange={onChangeCronTimezone} />
               </EuiCompressedFormRow>
             </React.Fragment>
           )}
@@ -199,7 +199,7 @@ export default class Schedule extends Component<ScheduleProps> {
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiCompressedFormRow hasEmptyLabelSpace={true}>
-                <EuiSelect id="selectTimeunit" options={DelayTimeunitOptions} value={delayTimeunit} onChange={onChangeDelayTimeunit} />
+                <EuiCompressedSelect id="selectTimeunit" options={DelayTimeunitOptions} value={delayTimeunit} onChange={onChangeDelayTimeunit} />
               </EuiCompressedFormRow>
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/public/pages/CreateRollup/components/Schedule/Schedule.tsx
+++ b/public/pages/CreateRollup/components/Schedule/Schedule.tsx
@@ -7,7 +7,7 @@ import React, { ChangeEvent, Component } from "react";
 import moment from "moment-timezone";
 import {
   EuiSpacer,
-  EuiCheckbox,
+  EuiCompressedCheckbox,
   EuiRadioGroup,
   EuiCompressedFormRow,
   EuiCompressedSelect,
@@ -133,7 +133,7 @@ export default class Schedule extends Component<ScheduleProps> {
       <ContentPanel bodyStyles={{ padding: "initial" }} title="Schedule" titleSize="s">
         <div style={{ paddingLeft: "10px" }}>
           {!isEdit && (
-            <EuiCheckbox
+            <EuiCompressedCheckbox
               id="jobEnabledByDefault"
               label="Enable job by default"
               checked={jobEnabledByDefault}
@@ -199,7 +199,12 @@ export default class Schedule extends Component<ScheduleProps> {
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiCompressedFormRow hasEmptyLabelSpace={true}>
-                <EuiCompressedSelect id="selectTimeunit" options={DelayTimeunitOptions} value={delayTimeunit} onChange={onChangeDelayTimeunit} />
+                <EuiCompressedSelect
+                  id="selectTimeunit"
+                  options={DelayTimeunitOptions}
+                  value={delayTimeunit}
+                  onChange={onChangeDelayTimeunit}
+                />
               </EuiCompressedFormRow>
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/public/pages/CreateRollup/components/Schedule/Schedule.tsx
+++ b/public/pages/CreateRollup/components/Schedule/Schedule.tsx
@@ -11,7 +11,7 @@ import {
   EuiRadioGroup,
   EuiCompressedFormRow,
   EuiSelect,
-  EuiFieldNumber,
+  EuiCompressedFieldNumber,
   EuiFlexGroup,
   EuiFlexItem,
   EuiTextArea,
@@ -70,7 +70,7 @@ const selectInterval = (
     <EuiFlexGroup style={{ maxWidth: 400 }}>
       <EuiFlexItem grow={false} style={{ width: 200 }}>
         <EuiCompressedFormRow label="Rollup interval" error={intervalError} isInvalid={intervalError != ""}>
-          <EuiFieldNumber value={interval} onChange={onChangeInterval} isInvalid={intervalError != ""} />
+          <EuiCompressedFieldNumber value={interval} onChange={onChangeInterval} isInvalid={intervalError != ""} />
         </EuiCompressedFormRow>
       </EuiFlexItem>
       <EuiFlexItem>
@@ -176,7 +176,7 @@ export default class Schedule extends Component<ScheduleProps> {
             label="Page per execution"
             helpText="The number of pages every execution processes. A larger number means faster execution and higher costs on memory."
           >
-            <EuiFieldNumber min={1} placeholder="1000" value={pageSize} onChange={onChangePage} />
+            <EuiCompressedFieldNumber min={1} placeholder="1000" value={pageSize} onChange={onChangePage} />
           </EuiCompressedFormRow>
           <EuiSpacer size="m" />
           <EuiFlexGroup style={{ maxWidth: 400 }}>
@@ -194,7 +194,7 @@ export default class Schedule extends Component<ScheduleProps> {
                 </EuiFlexItem>
               </EuiFlexGroup>
               <EuiCompressedFormRow>
-                <EuiFieldNumber value={delayTime} onChange={onChangeDelayTime} />
+                <EuiCompressedFieldNumber value={delayTime} onChange={onChangeDelayTime} />
               </EuiCompressedFormRow>
             </EuiFlexItem>
             <EuiFlexItem>

--- a/public/pages/CreateRollup/components/Schedule/Schedule.tsx
+++ b/public/pages/CreateRollup/components/Schedule/Schedule.tsx
@@ -8,7 +8,7 @@ import moment from "moment-timezone";
 import {
   EuiSpacer,
   EuiCompressedCheckbox,
-  EuiRadioGroup,
+  EuiCompressedRadioGroup,
   EuiCompressedFormRow,
   EuiCompressedSelect,
   EuiCompressedFieldNumber,
@@ -91,7 +91,12 @@ const selectInterval = (
 const isContinuous = (continuousJob: string, onChangeContinuousJob: (optionId: string) => void) => (
   <React.Fragment>
     <EuiCompressedFormRow label="Continuous">
-      <EuiRadioGroup options={radios} idSelected={continuousJob} onChange={(id) => onChangeContinuousJob(id)} name="continuousJob" />
+      <EuiCompressedRadioGroup
+        options={radios}
+        idSelected={continuousJob}
+        onChange={(id) => onChangeContinuousJob(id)}
+        name="continuousJob"
+      />
     </EuiCompressedFormRow>
     <EuiSpacer size="m" />
   </React.Fragment>

--- a/public/pages/CreateRollup/components/TimeAggregations/TimeAggregation.tsx
+++ b/public/pages/CreateRollup/components/TimeAggregations/TimeAggregation.tsx
@@ -20,7 +20,7 @@ import {
   EuiText,
 } from "@elastic/eui";
 import moment from "moment-timezone";
-import EuiComboBox from "../../../../components/ComboBoxWithoutWarning";
+import EuiCompressedComboBox from "../../../../components/ComboBoxWithoutWarning";
 import { RollupService } from "../../../../services";
 import { FieldItem } from "../../../../../models/interfaces";
 import { CalendarTimeunitOptions, FixedTimeunitOptions } from "../../../../utils/constants";
@@ -93,7 +93,7 @@ export default class TimeAggregation extends Component<TimeAggregationProps, Tim
         <div style={{ paddingLeft: "10px" }}>
           <EuiSpacer size="s" />
           <EuiCompressedFormRow label="Timestamp field" error={timestampError} isInvalid={!!timestampError}>
-            <EuiComboBox
+            <EuiCompressedComboBox
               placeholder="Select timestamp"
               options={dateFields}
               selectedOptions={selectedTimestamp}

--- a/public/pages/CreateRollup/components/TimeAggregations/TimeAggregation.tsx
+++ b/public/pages/CreateRollup/components/TimeAggregations/TimeAggregation.tsx
@@ -6,7 +6,7 @@
 import React, { ChangeEvent, Component, Fragment } from "react";
 import {
   EuiSpacer,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSelect,
   EuiFlexGroup,
   EuiFlexItem,
@@ -92,7 +92,7 @@ export default class TimeAggregation extends Component<TimeAggregationProps, Tim
         <EuiHorizontalRule margin="xs" />
         <div style={{ paddingLeft: "10px" }}>
           <EuiSpacer size="s" />
-          <EuiFormRow label="Timestamp field" error={timestampError} isInvalid={!!timestampError}>
+          <EuiCompressedFormRow label="Timestamp field" error={timestampError} isInvalid={!!timestampError}>
             <EuiComboBox
               placeholder="Select timestamp"
               options={dateFields}
@@ -101,57 +101,57 @@ export default class TimeAggregation extends Component<TimeAggregationProps, Tim
               singleSelection={{ asPlainText: true }}
               isInvalid={!!timestampError}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
           <EuiSpacer size="m" />
-          <EuiFormRow label="Interval type">
+          <EuiCompressedFormRow label="Interval type">
             <EuiRadioGroup options={radios} idSelected={intervalType} onChange={(id) => onChangeIntervalType(id)} name="intervalType" />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
           <EuiFlexGroup style={{ maxWidth: 300 }}>
             {intervalType == "fixed" ? (
               <Fragment>
                 <EuiSpacer size="m" />
                 <EuiFlexItem grow={false} style={{ width: 100 }}>
-                  <EuiFormRow label="Interval">
+                  <EuiCompressedFormRow label="Interval">
                     <EuiFieldNumber min={1} value={intervalType == "fixed" ? intervalValue : 1} onChange={onChangeIntervalValue} />
-                  </EuiFormRow>
+                  </EuiCompressedFormRow>
                 </EuiFlexItem>
                 <EuiFlexItem>
-                  <EuiFormRow hasEmptyLabelSpace={true}>
+                  <EuiCompressedFormRow hasEmptyLabelSpace={true}>
                     <EuiSelect
                       id="selectTimeunit"
                       options={intervalType == "fixed" ? FixedTimeunitOptions : CalendarTimeunitOptions}
                       value={timeunit}
                       onChange={onChangeTimeunit}
                     />
-                  </EuiFormRow>
+                  </EuiCompressedFormRow>
                 </EuiFlexItem>
               </Fragment>
             ) : (
               <Fragment>
                 <EuiFlexItem grow={false}>
-                  <EuiFormRow hasEmptyLabelSpace={true}>
+                  <EuiCompressedFormRow hasEmptyLabelSpace={true}>
                     <EuiText size="m">
                       <dd>Every 1</dd>{" "}
                     </EuiText>
-                  </EuiFormRow>
+                  </EuiCompressedFormRow>
                 </EuiFlexItem>
                 <EuiFlexItem>
-                  <EuiFormRow hasEmptyLabelSpace={true}>
+                  <EuiCompressedFormRow hasEmptyLabelSpace={true}>
                     <EuiSelect
                       id="selectTimeunit"
                       options={intervalType == "fixed" ? FixedTimeunitOptions : CalendarTimeunitOptions}
                       value={timeunit}
                       onChange={onChangeTimeunit}
                     />
-                  </EuiFormRow>
+                  </EuiCompressedFormRow>
                 </EuiFlexItem>
               </Fragment>
             )}
           </EuiFlexGroup>
           <EuiSpacer size="m" />
-          <EuiFormRow label="Timezone" helpText="A day starts from 00:00:00 in the specified timezone.">
+          <EuiCompressedFormRow label="Timezone" helpText="A day starts from 00:00:00 in the specified timezone.">
             <EuiSelect id="timezone" options={timezones} value={timezone} onChange={onChangeTimezone} />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </div>
       </EuiPanel>
     );

--- a/public/pages/CreateRollup/components/TimeAggregations/TimeAggregation.tsx
+++ b/public/pages/CreateRollup/components/TimeAggregations/TimeAggregation.tsx
@@ -11,7 +11,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFieldNumber,
-  EuiRadioGroup,
+  EuiCompressedRadioGroup,
   EuiComboBoxOptionOption,
   EuiPanel,
   EuiTitle,
@@ -104,7 +104,12 @@ export default class TimeAggregation extends Component<TimeAggregationProps, Tim
           </EuiCompressedFormRow>
           <EuiSpacer size="m" />
           <EuiCompressedFormRow label="Interval type">
-            <EuiRadioGroup options={radios} idSelected={intervalType} onChange={(id) => onChangeIntervalType(id)} name="intervalType" />
+            <EuiCompressedRadioGroup
+              options={radios}
+              idSelected={intervalType}
+              onChange={(id) => onChangeIntervalType(id)}
+              name="intervalType"
+            />
           </EuiCompressedFormRow>
           <EuiFlexGroup style={{ maxWidth: 300 }}>
             {intervalType == "fixed" ? (

--- a/public/pages/CreateRollup/components/TimeAggregations/TimeAggregation.tsx
+++ b/public/pages/CreateRollup/components/TimeAggregations/TimeAggregation.tsx
@@ -7,7 +7,7 @@ import React, { ChangeEvent, Component, Fragment } from "react";
 import {
   EuiSpacer,
   EuiCompressedFormRow,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFieldNumber,
@@ -121,7 +121,7 @@ export default class TimeAggregation extends Component<TimeAggregationProps, Tim
                 </EuiFlexItem>
                 <EuiFlexItem>
                   <EuiCompressedFormRow hasEmptyLabelSpace={true}>
-                    <EuiSelect
+                    <EuiCompressedSelect
                       id="selectTimeunit"
                       options={intervalType == "fixed" ? FixedTimeunitOptions : CalendarTimeunitOptions}
                       value={timeunit}
@@ -141,7 +141,7 @@ export default class TimeAggregation extends Component<TimeAggregationProps, Tim
                 </EuiFlexItem>
                 <EuiFlexItem>
                   <EuiCompressedFormRow hasEmptyLabelSpace={true}>
-                    <EuiSelect
+                    <EuiCompressedSelect
                       id="selectTimeunit"
                       options={intervalType == "fixed" ? FixedTimeunitOptions : CalendarTimeunitOptions}
                       value={timeunit}
@@ -154,7 +154,7 @@ export default class TimeAggregation extends Component<TimeAggregationProps, Tim
           </EuiFlexGroup>
           <EuiSpacer size="m" />
           <EuiCompressedFormRow label="Timezone" helpText="A day starts from 00:00:00 in the specified timezone.">
-            <EuiSelect id="timezone" options={timezones} value={timezone} onChange={onChangeTimezone} />
+            <EuiCompressedSelect id="timezone" options={timezones} value={timezone} onChange={onChangeTimezone} />
           </EuiCompressedFormRow>
         </div>
       </EuiPanel>

--- a/public/pages/CreateRollup/components/TimeAggregations/TimeAggregation.tsx
+++ b/public/pages/CreateRollup/components/TimeAggregations/TimeAggregation.tsx
@@ -10,7 +10,7 @@ import {
   EuiSelect,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFieldNumber,
+  EuiCompressedFieldNumber,
   EuiRadioGroup,
   EuiComboBoxOptionOption,
   EuiPanel,
@@ -112,7 +112,11 @@ export default class TimeAggregation extends Component<TimeAggregationProps, Tim
                 <EuiSpacer size="m" />
                 <EuiFlexItem grow={false} style={{ width: 100 }}>
                   <EuiCompressedFormRow label="Interval">
-                    <EuiFieldNumber min={1} value={intervalType == "fixed" ? intervalValue : 1} onChange={onChangeIntervalValue} />
+                    <EuiCompressedFieldNumber
+                      min={1}
+                      value={intervalType == "fixed" ? intervalValue : 1}
+                      onChange={onChangeIntervalValue}
+                    />
                   </EuiCompressedFormRow>
                 </EuiFlexItem>
                 <EuiFlexItem>

--- a/public/pages/CreateRollup/containers/CreateRollupForm/CreateRollupForm.tsx
+++ b/public/pages/CreateRollup/containers/CreateRollupForm/CreateRollupForm.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, Component, useContext } from "react";
-import { EuiButton, EuiButtonEmpty, EuiComboBoxOptionOption, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiSmallButton, EuiButtonEmpty, EuiComboBoxOptionOption, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import { RouteComponentProps, useHistory } from "react-router-dom";
 import moment from "moment";
 import { RollupService } from "../../../../services";
@@ -707,23 +707,23 @@ export class CreateRollupForm extends Component<CreateRollupFormProps, CreateRol
           </EuiFlexItem>
           {currentStep != 1 && (
             <EuiFlexItem grow={false}>
-              <EuiButton onClick={this._prev} data-test-subj="createRollupPreviousButton">
+              <EuiSmallButton onClick={this._prev} data-test-subj="createRollupPreviousButton">
                 Previous
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           )}
 
           {currentStep == 4 ? (
             <EuiFlexItem grow={false}>
-              <EuiButton fill onClick={this.onSubmit} isLoading={isSubmitting} data-test-subj="createRollupSubmitButton">
+              <EuiSmallButton fill onClick={this.onSubmit} isLoading={isSubmitting} data-test-subj="createRollupSubmitButton">
                 Create
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           ) : (
             <EuiFlexItem grow={false}>
-              <EuiButton fill onClick={this._next} data-test-subj="createRollupNextButton">
+              <EuiSmallButton fill onClick={this._next} data-test-subj="createRollupNextButton">
                 Next
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           )}
         </EuiFlexGroup>

--- a/public/pages/CreateRollup/containers/CreateRollupForm/CreateRollupForm.tsx
+++ b/public/pages/CreateRollup/containers/CreateRollupForm/CreateRollupForm.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, Component, useContext } from "react";
-import { EuiSmallButton, EuiButtonEmpty, EuiComboBoxOptionOption, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiSmallButton, EuiSmallButtonEmpty, EuiComboBoxOptionOption, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import { RouteComponentProps, useHistory } from "react-router-dom";
 import moment from "moment";
 import { RollupService } from "../../../../services";
@@ -701,9 +701,9 @@ export class CreateRollupForm extends Component<CreateRollupFormProps, CreateRol
         />
         <EuiFlexGroup alignItems="center" justifyContent="flexEnd" style={{ padding: "5px 50px" }}>
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty onClick={this.onCancel} data-test-subj="createRollupCancelButton">
+            <EuiSmallButtonEmpty onClick={this.onCancel} data-test-subj="createRollupCancelButton">
               Cancel
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
           </EuiFlexItem>
           {currentStep != 1 && (
             <EuiFlexItem grow={false}>

--- a/public/pages/CreateRollup/containers/CreateRollupForm/__snapshots__/CreateRollupForm.test.tsx.snap
+++ b/public/pages/CreateRollup/containers/CreateRollupForm/__snapshots__/CreateRollupForm.test.tsx.snap
@@ -196,7 +196,7 @@ exports[`<CreateRollupForm /> spec renders the component 1`] = `
                   class="euiSpacer euiSpacer--s"
                 />
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
@@ -214,14 +214,14 @@ exports[`<CreateRollupForm /> spec renders the component 1`] = `
                     class="euiFormRow__fieldWrapper"
                   >
                     <div
-                      class="euiFormControlLayout"
+                      class="euiFormControlLayout euiFormControlLayout--compressed"
                     >
                       <div
                         class="euiFormControlLayout__childrenWrapper"
                       >
                         <input
                           aria-describedby="some_html_id-help-0"
-                          class="euiFieldText"
+                          class="euiFieldText euiFieldText--compressed"
                           id="some_html_id"
                           placeholder="my-rollupjob1"
                           type="text"
@@ -274,7 +274,7 @@ exports[`<CreateRollupForm /> spec renders the component 1`] = `
                   class="euiSpacer euiSpacer--xs"
                 />
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
@@ -349,7 +349,7 @@ exports[`<CreateRollupForm /> spec renders the component 1`] = `
                   class="euiSpacer euiSpacer--m"
                 />
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
@@ -370,18 +370,18 @@ exports[`<CreateRollupForm /> spec renders the component 1`] = `
                       aria-describedby="some_html_id-help-0"
                       aria-expanded="false"
                       aria-haspopup="listbox"
-                      class="euiComboBox"
+                      class="euiComboBox euiComboBox--compressed"
                       data-test-subj="sourceIndexCombobox"
                       role="combobox"
                     >
                       <div
-                        class="euiFormControlLayout"
+                        class="euiFormControlLayout euiFormControlLayout--compressed"
                       >
                         <div
                           class="euiFormControlLayout__childrenWrapper"
                         >
                           <div
-                            class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
+                            class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
                             data-test-subj="comboBoxInput"
                             tabindex="-1"
                           >
@@ -434,7 +434,7 @@ exports[`<CreateRollupForm /> spec renders the component 1`] = `
                   </div>
                 </div>
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
@@ -455,18 +455,18 @@ exports[`<CreateRollupForm /> spec renders the component 1`] = `
                       aria-describedby="some_html_id-help-0"
                       aria-expanded="false"
                       aria-haspopup="listbox"
-                      class="euiComboBox"
+                      class="euiComboBox euiComboBox--compressed"
                       data-test-subj="targetIndexCombobox"
                       role="combobox"
                     >
                       <div
-                        class="euiFormControlLayout"
+                        class="euiFormControlLayout euiFormControlLayout--compressed"
                       >
                         <div
                           class="euiFormControlLayout__childrenWrapper"
                         >
                           <div
-                            class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
+                            class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
                             data-test-subj="comboBoxInput"
                             tabindex="-1"
                           >
@@ -553,7 +553,7 @@ exports[`<CreateRollupForm /> spec renders the component 1`] = `
         class="euiFlexItem euiFlexItem--flexGrowZero"
       >
         <button
-          class="euiButtonEmpty euiButtonEmpty--primary"
+          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
           data-test-subj="createRollupCancelButton"
           type="button"
         >
@@ -572,7 +572,7 @@ exports[`<CreateRollupForm /> spec renders the component 1`] = `
         class="euiFlexItem euiFlexItem--flexGrowZero"
       >
         <button
-          class="euiButton euiButton--primary euiButton--fill"
+          class="euiButton euiButton--primary euiButton--small euiButton--fill"
           data-test-subj="createRollupNextButton"
           type="button"
         >

--- a/public/pages/CreateSnapshotPolicy/components/CronSchedule/CronSchedule.tsx
+++ b/public/pages/CreateSnapshotPolicy/components/CronSchedule/CronSchedule.tsx
@@ -7,7 +7,7 @@ import _ from "lodash";
 import React, { ChangeEvent, useEffect, useState } from "react";
 import {
   EuiCheckbox,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiDatePicker,
   EuiCompressedFieldNumber,
   EuiCompressedFieldText,
@@ -174,7 +174,12 @@ const CronSchedule = ({
   return (
     <>
       <CustomLabel title={frequencyTitle} />
-      <EuiCompressedSelect id="creationCronScheduleType" options={CRON_SCHEDULE_FREQUENCY_TYPE} value={frequencyType} onChange={onTypeChange} />
+      <EuiCompressedSelect
+        id="creationCronScheduleType"
+        options={CRON_SCHEDULE_FREQUENCY_TYPE}
+        value={frequencyType}
+        onChange={onTypeChange}
+      />
 
       <EuiSpacer size="m" />
 
@@ -208,7 +213,7 @@ const CronSchedule = ({
           <EuiFlexItem style={{ maxWidth: 250 }}>
             <CustomLabel title="Time zone" />
             <EuiCompressedFormRow isInvalid={!!timezoneError} error={timezoneError}>
-              <EuiComboBox
+              <EuiCompressedComboBox
                 placeholder="Select a time zone"
                 singleSelection={{ asPlainText: true }}
                 options={TIMEZONES}

--- a/public/pages/CreateSnapshotPolicy/components/CronSchedule/CronSchedule.tsx
+++ b/public/pages/CreateSnapshotPolicy/components/CronSchedule/CronSchedule.tsx
@@ -15,7 +15,7 @@ import {
   EuiFlexItem,
   EuiCompressedFormRow,
   EuiLink,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiSpacer,
   EuiText,
 } from "@elastic/eui";
@@ -143,7 +143,7 @@ const CronSchedule = ({
         <CustomLabel title="On the" />
         <EuiFlexGroup gutterSize="m">
           <EuiFlexItem>
-            <EuiSelect options={[{ value: "day", text: "Day" }]} defaultValue="Day" />
+            <EuiCompressedSelect options={[{ value: "day", text: "Day" }]} defaultValue="Day" />
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiCompressedFieldNumber
@@ -174,7 +174,7 @@ const CronSchedule = ({
   return (
     <>
       <CustomLabel title={frequencyTitle} />
-      <EuiSelect id="creationCronScheduleType" options={CRON_SCHEDULE_FREQUENCY_TYPE} value={frequencyType} onChange={onTypeChange} />
+      <EuiCompressedSelect id="creationCronScheduleType" options={CRON_SCHEDULE_FREQUENCY_TYPE} value={frequencyType} onChange={onTypeChange} />
 
       <EuiSpacer size="m" />
 

--- a/public/pages/CreateSnapshotPolicy/components/CronSchedule/CronSchedule.tsx
+++ b/public/pages/CreateSnapshotPolicy/components/CronSchedule/CronSchedule.tsx
@@ -9,8 +9,8 @@ import {
   EuiCheckbox,
   EuiComboBox,
   EuiDatePicker,
-  EuiFieldNumber,
-  EuiFieldText,
+  EuiCompressedFieldNumber,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
@@ -146,7 +146,7 @@ const CronSchedule = ({
             <EuiSelect options={[{ value: "day", text: "Day" }]} defaultValue="Day" />
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiFieldNumber
+            <EuiCompressedFieldNumber
               value={dayOfMonth}
               onChange={(e) => {
                 onDayOfMonthChange(parseInt(e.target.value));
@@ -184,7 +184,7 @@ const CronSchedule = ({
             <>
               <CustomLabel title="Cron expression" />
               <EuiCompressedFormRow helpText={cronExpressionHelpText}>
-                <EuiFieldText
+                <EuiCompressedFieldText
                   value={cronExpression}
                   onChange={(e) => {
                     onCronExpressionChange(e.target.value);

--- a/public/pages/CreateSnapshotPolicy/components/CronSchedule/CronSchedule.tsx
+++ b/public/pages/CreateSnapshotPolicy/components/CronSchedule/CronSchedule.tsx
@@ -13,7 +13,7 @@ import {
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiLink,
   EuiSelect,
   EuiSpacer,
@@ -183,14 +183,14 @@ const CronSchedule = ({
           {frequencyType === "custom" ? (
             <>
               <CustomLabel title="Cron expression" />
-              <EuiFormRow helpText={cronExpressionHelpText}>
+              <EuiCompressedFormRow helpText={cronExpressionHelpText}>
                 <EuiFieldText
                   value={cronExpression}
                   onChange={(e) => {
                     onCronExpressionChange(e.target.value);
                   }}
                 />
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </>
           ) : (
             <>
@@ -207,7 +207,7 @@ const CronSchedule = ({
         {showTimezone ? (
           <EuiFlexItem style={{ maxWidth: 250 }}>
             <CustomLabel title="Time zone" />
-            <EuiFormRow isInvalid={!!timezoneError} error={timezoneError}>
+            <EuiCompressedFormRow isInvalid={!!timezoneError} error={timezoneError}>
               <EuiComboBox
                 placeholder="Select a time zone"
                 singleSelection={{ asPlainText: true }}
@@ -220,7 +220,7 @@ const CronSchedule = ({
                   }
                 }}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiFlexItem>
         ) : null}
       </EuiFlexGroup>

--- a/public/pages/CreateSnapshotPolicy/components/Notification/Notification.tsx
+++ b/public/pages/CreateSnapshotPolicy/components/Notification/Notification.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiFormRow, EuiSelect, EuiSmallButton, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiSelect, EuiSmallButton, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import "brace/theme/github";
 import "brace/mode/json";
 import { FeatureChannelList } from "../../../../../server/models/interfaces";
@@ -24,7 +24,7 @@ const Notification = ({ channelId, channels, loadingChannels, onChangeChannelId,
       <CustomLabel title="Select notification channels" />
       <EuiFlexGroup gutterSize="s" style={{ maxWidth: 600 }}>
         <EuiFlexItem>
-          <EuiFormRow>
+          <EuiCompressedFormRow>
             <EuiSelect
               id="channel-id"
               placeholder="Select channel ID"
@@ -35,7 +35,7 @@ const Notification = ({ channelId, channels, loadingChannels, onChangeChannelId,
               onChange={onChangeChannelId}
               data-test-subj="create-policy-notification-channel-id"
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiSmallButton

--- a/public/pages/CreateSnapshotPolicy/components/Notification/Notification.tsx
+++ b/public/pages/CreateSnapshotPolicy/components/Notification/Notification.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiCompressedFormRow, EuiSelect, EuiSmallButton, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiCompressedSelect, EuiSmallButton, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import "brace/theme/github";
 import "brace/mode/json";
 import { FeatureChannelList } from "../../../../../server/models/interfaces";
@@ -25,7 +25,7 @@ const Notification = ({ channelId, channels, loadingChannels, onChangeChannelId,
       <EuiFlexGroup gutterSize="s" style={{ maxWidth: 600 }}>
         <EuiFlexItem>
           <EuiCompressedFormRow>
-            <EuiSelect
+            <EuiCompressedSelect
               id="channel-id"
               placeholder="Select channel ID"
               hasNoInitialSelection

--- a/public/pages/CreateSnapshotPolicy/components/Notification/Notification.tsx
+++ b/public/pages/CreateSnapshotPolicy/components/Notification/Notification.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiFormRow, EuiSelect, EuiButton, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiFormRow, EuiSelect, EuiSmallButton, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import "brace/theme/github";
 import "brace/mode/json";
 import { FeatureChannelList } from "../../../../../server/models/interfaces";
@@ -38,7 +38,7 @@ const Notification = ({ channelId, channels, loadingChannels, onChangeChannelId,
           </EuiFormRow>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             iconType="refresh"
             onClick={getChannels}
             disabled={loadingChannels}
@@ -47,9 +47,9 @@ const Notification = ({ channelId, channels, loadingChannels, onChangeChannelId,
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton iconType="popout" href="notifications-dashboards#/channels" target="_blank">
+          <EuiSmallButton iconType="popout" href="notifications-dashboards#/channels" target="_blank">
             Manage channels
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </>

--- a/public/pages/CreateSnapshotPolicy/components/SnapshotAdvancedSettings/SnapshotAdvancedSettings.tsx
+++ b/public/pages/CreateSnapshotPolicy/components/SnapshotAdvancedSettings/SnapshotAdvancedSettings.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiCheckbox, EuiSpacer } from "@elastic/eui";
+import { EuiCompressedCheckbox, EuiSpacer } from "@elastic/eui";
 import CustomLabel from "../../../../components/CustomLabel";
 import React, { ChangeEvent } from "react";
 
@@ -27,7 +27,7 @@ const SnapshotAdvancedSettings = ({
   width,
 }: SnapshotAdvancedSettingsProps) => (
   <div style={{ padding: "10px 10px", width: width }}>
-    <EuiCheckbox
+    <EuiCompressedCheckbox
       id="include_global_state"
       label={<CustomLabel title="Include cluster state in snapshots" />}
       checked={includeGlobalState}
@@ -36,7 +36,7 @@ const SnapshotAdvancedSettings = ({
 
     <EuiSpacer size="m" />
 
-    <EuiCheckbox
+    <EuiCompressedCheckbox
       id="ignore_unavailable"
       label={
         <CustomLabel
@@ -50,7 +50,7 @@ const SnapshotAdvancedSettings = ({
 
     <EuiSpacer size="m" />
 
-    <EuiCheckbox
+    <EuiCompressedCheckbox
       id="partial"
       label={<CustomLabel title="Allow partial snapshots" helpText="Allow partial snapshots if one or more shards failed to store." />}
       checked={partial}

--- a/public/pages/CreateSnapshotPolicy/components/SnapshotIndicesRepoInput/SnapshotIndicesRepoInput.tsx
+++ b/public/pages/CreateSnapshotPolicy/components/SnapshotIndicesRepoInput/SnapshotIndicesRepoInput.tsx
@@ -10,7 +10,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiSelectOption,
   EuiSpacer,
 } from "@elastic/eui";
@@ -82,7 +82,7 @@ const SnapshotIndicesRepoInput = ({
         <EuiFlexItem style={{ maxWidth: "400px" }}>
           <CustomLabel title="Select a repository for snapshots" />
           <EuiCompressedFormRow isInvalid={!!repoError} error={repoError}>
-            <EuiSelect
+            <EuiCompressedSelect
               placeholder="Select a repository"
               disabled={repoOptions.length === 0}
               options={repoOptions}

--- a/public/pages/CreateSnapshotPolicy/components/SnapshotIndicesRepoInput/SnapshotIndicesRepoInput.tsx
+++ b/public/pages/CreateSnapshotPolicy/components/SnapshotIndicesRepoInput/SnapshotIndicesRepoInput.tsx
@@ -9,7 +9,7 @@ import {
   EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSelect,
   EuiSelectOption,
   EuiSpacer,
@@ -81,7 +81,7 @@ const SnapshotIndicesRepoInput = ({
       <EuiFlexGroup alignItems="flexEnd">
         <EuiFlexItem style={{ maxWidth: "400px" }}>
           <CustomLabel title="Select a repository for snapshots" />
-          <EuiFormRow isInvalid={!!repoError} error={repoError}>
+          <EuiCompressedFormRow isInvalid={!!repoError} error={repoError}>
             <EuiSelect
               placeholder="Select a repository"
               disabled={repoOptions.length === 0}
@@ -89,7 +89,7 @@ const SnapshotIndicesRepoInput = ({
               value={selectedRepoValue}
               onChange={onRepoSelectionChange}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiFlexItem>
 
         {showFlyout != null && (

--- a/public/pages/CreateSnapshotPolicy/components/SnapshotIndicesRepoInput/SnapshotIndicesRepoInput.tsx
+++ b/public/pages/CreateSnapshotPolicy/components/SnapshotIndicesRepoInput/SnapshotIndicesRepoInput.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
@@ -65,7 +65,7 @@ const SnapshotIndicesRepoInput = ({
   return (
     <>
       <CustomLabel title="Select or input source indexes or index patterns" />
-      <EuiComboBox
+      <EuiCompressedComboBox
         placeholder="Select or input indexes or index patterns"
         options={indexOptions}
         selectedOptions={selectedIndexOptions}

--- a/public/pages/CreateSnapshotPolicy/components/SnapshotIndicesRepoInput/SnapshotIndicesRepoInput.tsx
+++ b/public/pages/CreateSnapshotPolicy/components/SnapshotIndicesRepoInput/SnapshotIndicesRepoInput.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiComboBox,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
@@ -94,7 +94,7 @@ const SnapshotIndicesRepoInput = ({
 
         {showFlyout != null && (
           <EuiFlexItem grow={false}>
-            <EuiButton onClick={openFlyout}>Create repository</EuiButton>
+            <EuiSmallButton onClick={openFlyout}>Create repository</EuiSmallButton>
           </EuiFlexItem>
         )}
       </EuiFlexGroup>

--- a/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
+++ b/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
@@ -8,7 +8,7 @@ import queryString from "query-string";
 import {
   EuiCompressedFormRow,
   EuiTextArea,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
@@ -686,7 +686,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
                   />
                 </EuiFlexItem>
                 <EuiFlexItem style={{ maxWidth: 100 }}>
-                  <EuiSelect
+                  <EuiCompressedSelect
                     options={MAX_AGE_UNIT_OPTIONS}
                     value={maxAgeUnit}
                     onChange={(e) => {

--- a/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
+++ b/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
@@ -6,7 +6,7 @@
 import _ from "lodash";
 import queryString from "query-string";
 import {
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiTextArea,
   EuiSelect,
   EuiFieldText,
@@ -585,14 +585,14 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
 
         <ContentPanel title="Policy settings" titleSize="s">
           <CustomLabel title="Policy name" />
-          <EuiFormRow isInvalid={!!policyIdError} error={policyIdError}>
+          <EuiCompressedFormRow isInvalid={!!policyIdError} error={policyIdError}>
             <EuiFieldText placeholder="e.g. daily-snapshot" value={policyId} onChange={this.onChangePolicyName} disabled={isEdit} />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
 
           <EuiSpacer />
 
           <CustomLabel title="Description" isOptional={true} />
-          <EuiFormRow>
+          <EuiCompressedFormRow>
             <EuiTextArea
               compressed={true}
               value={_.get(policy, "description", "")}
@@ -600,7 +600,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
               placeholder="Snapshot management daily policy."
               data-test-subj="description"
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </ContentPanel>
 
         <EuiSpacer />
@@ -700,19 +700,19 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
                 <EuiFlexGroup alignItems="flexStart">
                   <EuiFlexItem grow={false}>
                     <CustomLabel title="Minimum" />
-                    <EuiFormRow isInvalid={!!minCountError} error={minCountError}>
+                    <EuiCompressedFormRow isInvalid={!!minCountError} error={minCountError}>
                       <EuiFieldNumber
                         min={1}
                         value={_.get(policy, "deletion.condition.min_count") ?? "1"}
                         onChange={this.onChangeMinCount}
                       />
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
                     <CustomLabel title="Maximum" isOptional={true} />
-                    <EuiFormRow>
+                    <EuiCompressedFormRow>
                       <EuiFieldNumber min={1} value={_.get(policy, "deletion.condition.max_count", "")} onChange={this.onChangeMaxCount} />
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </EuiFlexItem>
                 </EuiFlexGroup>
 

--- a/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
+++ b/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
@@ -21,7 +21,7 @@ import {
   EuiAccordion,
   EuiRadioGroup,
   EuiText,
-  EuiCheckbox,
+  EuiCompressedCheckbox,
   EuiPanel,
   EuiHorizontalRule,
   EuiSmallButtonIcon,
@@ -733,7 +733,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
                 </span>
                 <EuiSpacer size="s" />
 
-                <EuiCheckbox
+                <EuiCompressedCheckbox
                   id="delete_schedule_checkbox"
                   label="Same as snapshot frequency"
                   checked={!deletionScheduleEnabled}
@@ -769,7 +769,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
             <EuiText>Notify on snapshot activities</EuiText>
 
             <EuiSpacer size="s" />
-            <EuiCheckbox
+            <EuiCompressedCheckbox
               id="notification-creation"
               label="When a snapshot has been created."
               checked={getNotifyCreation(policy)}
@@ -780,7 +780,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
 
             <EuiSpacer size="s" />
 
-            <EuiCheckbox
+            <EuiCompressedCheckbox
               id="notification-deletion"
               label="When a snapshots has been deleted."
               checked={getNotifyDeletion(policy)}
@@ -791,7 +791,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
 
             <EuiSpacer size="s" />
 
-            <EuiCheckbox
+            <EuiCompressedCheckbox
               id="notification-failure"
               label="When a snapshot has failed."
               checked={getNotifyFailure(policy)}

--- a/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
+++ b/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
@@ -19,7 +19,7 @@ import {
   EuiComboBoxOptionOption,
   EuiCompressedFieldNumber,
   EuiAccordion,
-  EuiRadioGroup,
+  EuiCompressedRadioGroup,
   EuiText,
   EuiCompressedCheckbox,
   EuiPanel,

--- a/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
+++ b/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
@@ -26,7 +26,6 @@ import {
   EuiHorizontalRule,
   EuiSmallButtonIcon,
   EuiLink,
-  EuiCompressedRadioGroup,
 } from "@elastic/eui";
 import React, { ChangeEvent, Component, useContext } from "react";
 import { RouteComponentProps } from "react-router-dom";

--- a/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
+++ b/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
@@ -15,7 +15,7 @@ import {
   EuiSpacer,
   EuiTitle,
   EuiButtonEmpty,
-  EuiButton,
+  EuiSmallButton,
   EuiComboBoxOptionOption,
   EuiFieldNumber,
   EuiAccordion,
@@ -888,9 +888,9 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
           </EuiFlexItem>
 
           <EuiFlexItem grow={false}>
-            <EuiButton fill onClick={this.onClickSubmit} isLoading={isSubmitting}>
+            <EuiSmallButton fill onClick={this.onClickSubmit} isLoading={isSubmitting}>
               {isEdit ? "Update" : "Create"}
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </div>

--- a/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
+++ b/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
@@ -9,7 +9,7 @@ import {
   EuiCompressedFormRow,
   EuiTextArea,
   EuiSelect,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
@@ -17,7 +17,7 @@ import {
   EuiSmallButtonEmpty,
   EuiSmallButton,
   EuiComboBoxOptionOption,
-  EuiFieldNumber,
+  EuiCompressedFieldNumber,
   EuiAccordion,
   EuiRadioGroup,
   EuiText,
@@ -586,7 +586,12 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
         <ContentPanel title="Policy settings" titleSize="s">
           <CustomLabel title="Policy name" />
           <EuiCompressedFormRow isInvalid={!!policyIdError} error={policyIdError}>
-            <EuiFieldText placeholder="e.g. daily-snapshot" value={policyId} onChange={this.onChangePolicyName} disabled={isEdit} />
+            <EuiCompressedFieldText
+              placeholder="e.g. daily-snapshot"
+              value={policyId}
+              onChange={this.onChangePolicyName}
+              disabled={isEdit}
+            />
           </EuiCompressedFormRow>
 
           <EuiSpacer />
@@ -672,7 +677,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
               <CustomLabel title="Maximum age of snapshots retained" />
               <EuiFlexGroup>
                 <EuiFlexItem grow={false}>
-                  <EuiFieldNumber
+                  <EuiCompressedFieldNumber
                     value={maxAgeNum}
                     min={1}
                     onChange={(e) => {
@@ -701,7 +706,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
                   <EuiFlexItem grow={false}>
                     <CustomLabel title="Minimum" />
                     <EuiCompressedFormRow isInvalid={!!minCountError} error={minCountError}>
-                      <EuiFieldNumber
+                      <EuiCompressedFieldNumber
                         min={1}
                         value={_.get(policy, "deletion.condition.min_count") ?? "1"}
                         onChange={this.onChangeMinCount}
@@ -711,7 +716,11 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
                   <EuiFlexItem grow={false}>
                     <CustomLabel title="Maximum" isOptional={true} />
                     <EuiCompressedFormRow>
-                      <EuiFieldNumber min={1} value={_.get(policy, "deletion.condition.max_count", "")} onChange={this.onChangeMaxCount} />
+                      <EuiCompressedFieldNumber
+                        min={1}
+                        value={_.get(policy, "deletion.condition.max_count", "")}
+                        onChange={this.onChangeMaxCount}
+                      />
                     </EuiCompressedFormRow>
                   </EuiFlexItem>
                 </EuiFlexGroup>
@@ -849,7 +858,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
                 <EuiSpacer size="s" />
 
                 <CustomLabel title="Timestamp format" />
-                <EuiFieldText
+                <EuiCompressedFieldText
                   value={dateFormat}
                   onChange={(e) => {
                     let dateFormat = e.target.value;

--- a/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
+++ b/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
@@ -14,7 +14,7 @@ import {
   EuiFlexItem,
   EuiSpacer,
   EuiTitle,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiSmallButton,
   EuiComboBoxOptionOption,
   EuiFieldNumber,
@@ -884,7 +884,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
 
         <EuiFlexGroup justifyContent="flexEnd">
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty onClick={this.onClickCancel}>Cancel</EuiButtonEmpty>
+            <EuiSmallButtonEmpty onClick={this.onClickCancel}>Cancel</EuiSmallButtonEmpty>
           </EuiFlexItem>
 
           <EuiFlexItem grow={false}>

--- a/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
+++ b/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
@@ -24,7 +24,7 @@ import {
   EuiCheckbox,
   EuiPanel,
   EuiHorizontalRule,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiLink,
   EuiCompressedRadioGroup,
 } from "@elastic/eui";
@@ -808,7 +808,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
         <EuiPanel style={{ paddingLeft: "0px", paddingRight: "0px" }}>
           <EuiFlexGroup style={{ padding: "0px 10px" }} justifyContent="flexStart" alignItems="center" gutterSize="none">
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon
+              <EuiSmallButtonIcon
                 iconType={advancedSettingsOpen ? "arrowDown" : "arrowRight"}
                 color="text"
                 onClick={() => {

--- a/public/pages/CreateTransform/components/ConfigureTransform/ConfigureTransform.tsx
+++ b/public/pages/CreateTransform/components/ConfigureTransform/ConfigureTransform.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiSpacer, EuiFormRow, EuiFieldText, EuiTextArea, EuiText, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiSpacer, EuiCompressedFormRow, EuiFieldText, EuiTextArea, EuiText, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
 
 interface ConfigureTransformProps {
@@ -26,7 +26,12 @@ const ConfigureTransform = ({
 }: ConfigureTransformProps) => (
   <ContentPanel panelStyles={{ padding: "20px 20px" }} bodyStyles={{ padding: "10px" }} title="Job name and description" titleSize="m">
     <div>
-      <EuiFormRow label="Name" helpText="Specify a unique, descriptive name." isInvalid={!!transformIdError} error={transformIdError}>
+      <EuiCompressedFormRow
+        label="Name"
+        helpText="Specify a unique, descriptive name."
+        isInvalid={!!transformIdError}
+        error={transformIdError}
+      >
         <EuiFieldText
           isInvalid={!!transformIdError}
           placeholder="my-transformjob1"
@@ -34,7 +39,7 @@ const ConfigureTransform = ({
           onChange={onChangeName}
           disabled={isEdit}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
       <EuiSpacer />
       <EuiFlexGroup gutterSize="xs">
         <EuiFlexItem grow={false}>
@@ -49,9 +54,9 @@ const ConfigureTransform = ({
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="xs" />
-      <EuiFormRow>
+      <EuiCompressedFormRow>
         <EuiTextArea compressed={true} value={description} onChange={onChangeDescription} data-test-subj="description" />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </div>
   </ContentPanel>
 );

--- a/public/pages/CreateTransform/components/ConfigureTransform/ConfigureTransform.tsx
+++ b/public/pages/CreateTransform/components/ConfigureTransform/ConfigureTransform.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiSpacer, EuiCompressedFormRow, EuiFieldText, EuiTextArea, EuiText, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiSpacer, EuiCompressedFormRow, EuiCompressedFieldText, EuiTextArea, EuiText, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
 
 interface ConfigureTransformProps {
@@ -32,7 +32,7 @@ const ConfigureTransform = ({
         isInvalid={!!transformIdError}
         error={transformIdError}
       >
-        <EuiFieldText
+        <EuiCompressedFieldText
           isInvalid={!!transformIdError}
           placeholder="my-transformjob1"
           value={transformId}

--- a/public/pages/CreateTransform/components/IndexFilterPopover/IndexFilterPopover.tsx
+++ b/public/pages/CreateTransform/components/IndexFilterPopover/IndexFilterPopover.tsx
@@ -7,7 +7,7 @@ import React, { ChangeEvent, useState } from "react";
 import {
   EuiForm,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSelect,
   EuiPopoverTitle,
   EuiSpacer,
@@ -52,7 +52,7 @@ export default function IndexFilterPopover({
       <div>
         <EuiFlexGroup>
           <EuiFlexItem grow={false}>
-            <EuiFormRow label="Field">
+            <EuiCompressedFormRow label="Field">
               <EuiSelect
                 id="selectField"
                 options={fields.map((item) => {
@@ -64,10 +64,10 @@ export default function IndexFilterPopover({
                 value={selectedField}
                 onChange={onChangeSelectedField}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiFormRow label="Operator">
+            <EuiCompressedFormRow label="Operator">
               <EuiSelect
                 id="selectOperator"
                 options={[]}
@@ -75,13 +75,13 @@ export default function IndexFilterPopover({
                 value={selectedOperator}
                 onChange={onChangeSelectedOperator}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiFlexItem>
         </EuiFlexGroup>
         <EuiFlexItem>
-          <EuiFormRow label="Value">
+          <EuiCompressedFormRow label="Value">
             <EuiSelect id="selectValue" options={[]} value={selectedValue} onChange={onChangeSelectedValue} />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiFlexItem>
       </div>
     );
@@ -89,14 +89,14 @@ export default function IndexFilterPopover({
 
   function customEditor() {
     return (
-      <EuiFormRow label="Custom query DSL">
+      <EuiCompressedFormRow label="Custom query DSL">
         <EuiCodeEditor
           style={{ width: 0.38 * window.innerWidth, height: 0.4 * window.innerHeight }}
           value={queryDsl}
           onChange={(string) => setQueryDsl(string)}
           mode="json"
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     );
   }
 

--- a/public/pages/CreateTransform/components/IndexFilterPopover/IndexFilterPopover.tsx
+++ b/public/pages/CreateTransform/components/IndexFilterPopover/IndexFilterPopover.tsx
@@ -14,7 +14,7 @@ import {
   EuiFlexGroup,
   EuiButtonEmpty,
   EuiCodeEditor,
-  EuiButton,
+  EuiSmallButton,
 } from "@elastic/eui";
 import { FieldItem, IndexItem } from "../../../../../models/interfaces";
 
@@ -114,7 +114,7 @@ export default function IndexFilterPopover({
         <EuiSpacer />
         <EuiFlexGroup direction="rowReverse" alignItems="center" responsive={false}>
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               fill
               onClick={() => {
                 onChangeSourceIndexFilter(queryDsl);
@@ -123,7 +123,7 @@ export default function IndexFilterPopover({
               data-test-subj="saveFilter"
             >
               Save
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiButtonEmpty flush="right" onClick={closePopover} data-test-subj="cancelSaveFilter">

--- a/public/pages/CreateTransform/components/IndexFilterPopover/IndexFilterPopover.tsx
+++ b/public/pages/CreateTransform/components/IndexFilterPopover/IndexFilterPopover.tsx
@@ -8,7 +8,7 @@ import {
   EuiForm,
   EuiFlexItem,
   EuiCompressedFormRow,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiPopoverTitle,
   EuiSpacer,
   EuiFlexGroup,
@@ -53,7 +53,7 @@ export default function IndexFilterPopover({
         <EuiFlexGroup>
           <EuiFlexItem grow={false}>
             <EuiCompressedFormRow label="Field">
-              <EuiSelect
+              <EuiCompressedSelect
                 id="selectField"
                 options={fields.map((item) => {
                   return {
@@ -68,7 +68,7 @@ export default function IndexFilterPopover({
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiCompressedFormRow label="Operator">
-              <EuiSelect
+              <EuiCompressedSelect
                 id="selectOperator"
                 options={[]}
                 // {getOperators(selectedField?.type)}
@@ -80,7 +80,7 @@ export default function IndexFilterPopover({
         </EuiFlexGroup>
         <EuiFlexItem>
           <EuiCompressedFormRow label="Value">
-            <EuiSelect id="selectValue" options={[]} value={selectedValue} onChange={onChangeSelectedValue} />
+            <EuiCompressedSelect id="selectValue" options={[]} value={selectedValue} onChange={onChangeSelectedValue} />
           </EuiCompressedFormRow>
         </EuiFlexItem>
       </div>

--- a/public/pages/CreateTransform/components/IndexFilterPopover/IndexFilterPopover.tsx
+++ b/public/pages/CreateTransform/components/IndexFilterPopover/IndexFilterPopover.tsx
@@ -12,7 +12,7 @@ import {
   EuiPopoverTitle,
   EuiSpacer,
   EuiFlexGroup,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiCodeEditor,
   EuiSmallButton,
 } from "@elastic/eui";
@@ -126,9 +126,9 @@ export default function IndexFilterPopover({
             </EuiSmallButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty flush="right" onClick={closePopover} data-test-subj="cancelSaveFilter">
+            <EuiSmallButtonEmpty flush="right" onClick={closePopover} data-test-subj="cancelSaveFilter">
               Cancel
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem />
         </EuiFlexGroup>

--- a/public/pages/CreateTransform/components/PreviewOptions/Panels/EditTransformPanel/EditTransformPanel.tsx
+++ b/public/pages/CreateTransform/components/PreviewOptions/Panels/EditTransformPanel/EditTransformPanel.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from "react";
-import { EuiSmallButton, EuiFieldText, EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiPanel, EuiSpacer, EuiText } from "@elastic/eui";
+import { EuiSmallButton, EuiFieldText, EuiFlexGroup, EuiFlexItem, EuiCompressedFormRow, EuiPanel, EuiSpacer, EuiText } from "@elastic/eui";
 import { TransformAggItem } from "../../../../../../../models/interfaces";
 
 interface EditTransformPanelProps {
@@ -30,7 +30,7 @@ export default function EditTransformPanel({ name, aggList, onEditTransformation
 
   return (
     <EuiPanel>
-      <EuiFormRow label="Transformation name" isInvalid={transformNameError !== ""} error={transformNameError}>
+      <EuiCompressedFormRow label="Transformation name" isInvalid={transformNameError !== ""} error={transformNameError}>
         <EuiFieldText
           value={transformName}
           isInvalid={transformNameError !== ""}
@@ -39,7 +39,7 @@ export default function EditTransformPanel({ name, aggList, onEditTransformation
             setTransformName(e.target.value);
           }}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
       <EuiSpacer size="s" />
       <EuiFlexGroup justifyContent={"flexEnd"} gutterSize={"m"}>
         <EuiFlexItem grow={false}>

--- a/public/pages/CreateTransform/components/PreviewOptions/Panels/EditTransformPanel/EditTransformPanel.tsx
+++ b/public/pages/CreateTransform/components/PreviewOptions/Panels/EditTransformPanel/EditTransformPanel.tsx
@@ -4,7 +4,16 @@
  */
 
 import React, { useState } from "react";
-import { EuiSmallButton, EuiFieldText, EuiFlexGroup, EuiFlexItem, EuiCompressedFormRow, EuiPanel, EuiSpacer, EuiText } from "@elastic/eui";
+import {
+  EuiSmallButton,
+  EuiCompressedFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiCompressedFormRow,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+} from "@elastic/eui";
 import { TransformAggItem } from "../../../../../../../models/interfaces";
 
 interface EditTransformPanelProps {
@@ -31,7 +40,7 @@ export default function EditTransformPanel({ name, aggList, onEditTransformation
   return (
     <EuiPanel>
       <EuiCompressedFormRow label="Transformation name" isInvalid={transformNameError !== ""} error={transformNameError}>
-        <EuiFieldText
+        <EuiCompressedFieldText
           value={transformName}
           isInvalid={transformNameError !== ""}
           onChange={(e) => {

--- a/public/pages/CreateTransform/components/PreviewOptions/Panels/EditTransformPanel/EditTransformPanel.tsx
+++ b/public/pages/CreateTransform/components/PreviewOptions/Panels/EditTransformPanel/EditTransformPanel.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from "react";
-import { EuiButton, EuiFieldText, EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiPanel, EuiSpacer, EuiText } from "@elastic/eui";
+import { EuiSmallButton, EuiFieldText, EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiPanel, EuiSpacer, EuiText } from "@elastic/eui";
 import { TransformAggItem } from "../../../../../../../models/interfaces";
 
 interface EditTransformPanelProps {
@@ -43,12 +43,12 @@ export default function EditTransformPanel({ name, aggList, onEditTransformation
       <EuiSpacer size="s" />
       <EuiFlexGroup justifyContent={"flexEnd"} gutterSize={"m"}>
         <EuiFlexItem grow={false}>
-          <EuiButton fullWidth={false} onClick={() => closePopover()} style={{ minWidth: 84 }}>
+          <EuiSmallButton fullWidth={false} onClick={() => closePopover()} style={{ minWidth: 84 }}>
             Cancel
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             fill
             fullWidth={false}
             disabled={transformNameError !== ""}
@@ -60,7 +60,7 @@ export default function EditTransformPanel({ name, aggList, onEditTransformation
             style={{ minWidth: 55 }}
           >
             OK
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiPanel>

--- a/public/pages/CreateTransform/components/PreviewOptions/PreviewOptions.tsx
+++ b/public/pages/CreateTransform/components/PreviewOptions/PreviewOptions.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import {
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiContextMenu,
   EuiContextMenuPanelDescriptor,
   EuiFlexGroup,
@@ -32,7 +32,7 @@ export default function PreviewOptions({ name, aggList, onEditTransformation, on
     setIsPopoverOpen(false);
   };
 
-  const button = <EuiButtonIcon color="primary" iconType="pencil" onClick={() => setIsPopoverOpen(!isPopoverOpen)} />;
+  const button = <EuiSmallButtonIcon color="primary" iconType="pencil" onClick={() => setIsPopoverOpen(!isPopoverOpen)} />;
 
   const panels: EuiContextMenuPanelDescriptor[] = [
     {

--- a/public/pages/CreateTransform/components/Schedule/Schedule.tsx
+++ b/public/pages/CreateTransform/components/Schedule/Schedule.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, Component } from "react";
-import { EuiSpacer, EuiCheckbox, EuiRadioGroup, EuiFormRow, EuiFieldNumber, EuiAccordion, EuiHorizontalRule } from "@elastic/eui";
+import { EuiSpacer, EuiCheckbox, EuiRadioGroup, EuiCompressedFormRow, EuiFieldNumber, EuiAccordion, EuiHorizontalRule } from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
 import { selectInterval } from "../../../Transforms/utils/metadataHelper";
 
@@ -38,9 +38,9 @@ const radios = [
 
 const isContinuous = (continuousJob: string, onChangeContinuousJob: (optionId: string) => void) => (
   <React.Fragment>
-    <EuiFormRow label="Continuous">
+    <EuiCompressedFormRow label="Continuous">
       <EuiRadioGroup options={radios} idSelected={continuousJob} onChange={(id) => onChangeContinuousJob(id)} name="continuousJob" />
-    </EuiFormRow>
+    </EuiCompressedFormRow>
     <EuiSpacer size="m" />
   </React.Fragment>
 );
@@ -88,7 +88,7 @@ export default class Schedule extends Component<ScheduleProps> {
           <EuiSpacer size="m" />
           <EuiAccordion id="pagePerExecution" buttonContent="Advanced">
             <EuiSpacer size="m" />
-            <EuiFormRow
+            <EuiCompressedFormRow
               label="Pages per execution"
               helpText={`Determines the number of transformed buckets that are
                         computed and indexed at a time. A larger number means
@@ -99,7 +99,7 @@ export default class Schedule extends Component<ScheduleProps> {
                         on your use case and shard size.`}
             >
               <EuiFieldNumber min={1} placeholder="1000" value={pageSize} onChange={onChangePage} />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiAccordion>
         </div>
       </ContentPanel>

--- a/public/pages/CreateTransform/components/Schedule/Schedule.tsx
+++ b/public/pages/CreateTransform/components/Schedule/Schedule.tsx
@@ -7,7 +7,7 @@ import React, { ChangeEvent, Component } from "react";
 import {
   EuiSpacer,
   EuiCompressedCheckbox,
-  EuiRadioGroup,
+  EuiCompressedRadioGroup,
   EuiCompressedFormRow,
   EuiCompressedFieldNumber,
   EuiAccordion,
@@ -47,7 +47,12 @@ const radios = [
 const isContinuous = (continuousJob: string, onChangeContinuousJob: (optionId: string) => void) => (
   <React.Fragment>
     <EuiCompressedFormRow label="Continuous">
-      <EuiRadioGroup options={radios} idSelected={continuousJob} onChange={(id) => onChangeContinuousJob(id)} name="continuousJob" />
+      <EuiCompressedRadioGroup
+        options={radios}
+        idSelected={continuousJob}
+        onChange={(id) => onChangeContinuousJob(id)}
+        name="continuousJob"
+      />
     </EuiCompressedFormRow>
     <EuiSpacer size="m" />
   </React.Fragment>

--- a/public/pages/CreateTransform/components/Schedule/Schedule.tsx
+++ b/public/pages/CreateTransform/components/Schedule/Schedule.tsx
@@ -6,7 +6,7 @@
 import React, { ChangeEvent, Component } from "react";
 import {
   EuiSpacer,
-  EuiCheckbox,
+  EuiCompressedCheckbox,
   EuiRadioGroup,
   EuiCompressedFormRow,
   EuiCompressedFieldNumber,
@@ -77,7 +77,7 @@ export default class Schedule extends Component<ScheduleProps> {
       <ContentPanel panelStyles={{ padding: "20px 20px" }} bodyStyles={{ padding: "10px" }} title="Schedule" titleSize="m">
         <div>
           {!isEdit && (
-            <EuiCheckbox
+            <EuiCompressedCheckbox
               id="jobEnabledByDefault"
               label="Job enabled by default"
               checked={jobEnabledByDefault}

--- a/public/pages/CreateTransform/components/Schedule/Schedule.tsx
+++ b/public/pages/CreateTransform/components/Schedule/Schedule.tsx
@@ -4,7 +4,15 @@
  */
 
 import React, { ChangeEvent, Component } from "react";
-import { EuiSpacer, EuiCheckbox, EuiRadioGroup, EuiCompressedFormRow, EuiFieldNumber, EuiAccordion, EuiHorizontalRule } from "@elastic/eui";
+import {
+  EuiSpacer,
+  EuiCheckbox,
+  EuiRadioGroup,
+  EuiCompressedFormRow,
+  EuiCompressedFieldNumber,
+  EuiAccordion,
+  EuiHorizontalRule,
+} from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
 import { selectInterval } from "../../../Transforms/utils/metadataHelper";
 
@@ -98,7 +106,7 @@ export default class Schedule extends Component<ScheduleProps> {
                         you to start with the default value, and adjust based
                         on your use case and shard size.`}
             >
-              <EuiFieldNumber min={1} placeholder="1000" value={pageSize} onChange={onChangePage} />
+              <EuiCompressedFieldNumber min={1} placeholder="1000" value={pageSize} onChange={onChangePage} />
             </EuiCompressedFormRow>
           </EuiAccordion>
         </div>

--- a/public/pages/CreateTransform/components/TransformIndices/TransformIndices.tsx
+++ b/public/pages/CreateTransform/components/TransformIndices/TransformIndices.tsx
@@ -6,7 +6,7 @@
 import React, { Component, Fragment } from "react";
 import {
   EuiSpacer,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiCallOut,
   EuiPopover,
   EuiFlexGroup,
@@ -172,7 +172,7 @@ export default class TransformIndices extends Component<TransformIndicesProps, T
                 </EuiCallOut>
               </Fragment>
             )}
-            <EuiFormRow
+            <EuiCompressedFormRow
               label="Source index"
               error={sourceIndexError}
               isInvalid={sourceIndexError != ""}
@@ -189,7 +189,7 @@ export default class TransformIndices extends Component<TransformIndicesProps, T
                 isInvalid={sourceIndexError != ""}
                 data-test-subj="sourceIndexCombobox"
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer size="s" />
             <EuiFlexGroup gutterSize="xs">
               <EuiFlexItem grow={false}>
@@ -252,7 +252,7 @@ export default class TransformIndices extends Component<TransformIndicesProps, T
             </EuiText>
             <EuiSpacer size="s" />
             <EuiHorizontalRule margin="xs" />
-            <EuiFormRow
+            <EuiCompressedFormRow
               label="Target index"
               error={targetIndexError}
               isInvalid={targetIndexError != ""}
@@ -270,7 +270,7 @@ export default class TransformIndices extends Component<TransformIndicesProps, T
                 isInvalid={targetIndexError != ""}
                 data-test-subj="targetIndexCombobox"
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </div>
         </ContentPanel>
         <Fragment>

--- a/public/pages/CreateTransform/components/TransformIndices/TransformIndices.tsx
+++ b/public/pages/CreateTransform/components/TransformIndices/TransformIndices.tsx
@@ -19,7 +19,7 @@ import {
   EuiLink,
 } from "@elastic/eui";
 import _ from "lodash";
-import EuiComboBox from "../../../../components/ComboBoxWithoutWarning";
+import EuiCompressedComboBox from "../../../../components/ComboBoxWithoutWarning";
 import { ContentPanel } from "../../../../components/ContentPanel";
 import IndexFilterPopover from "../IndexFilterPopover";
 import { FieldItem, IndexItem } from "../../../../../models/interfaces";
@@ -178,7 +178,7 @@ export default class TransformIndices extends Component<TransformIndicesProps, T
               isInvalid={sourceIndexError != ""}
               helpText="The index where this transform job is performed on. Type in * as wildcard for index pattern. Indices cannot be changed once the job is created. Please ensure that you select the right source index."
             >
-              <EuiComboBox
+              <EuiCompressedComboBox
                 placeholder="Select source index"
                 options={indexOptions}
                 selectedOptions={sourceIndex}
@@ -258,7 +258,7 @@ export default class TransformIndices extends Component<TransformIndicesProps, T
               isInvalid={targetIndexError != ""}
               helpText="The index stores transform results. You can look up an existing index to reuse or type to create a new index."
             >
-              <EuiComboBox
+              <EuiCompressedComboBox
                 placeholder="Select or create target index"
                 options={targetIndexOptions}
                 selectedOptions={targetIndex}

--- a/public/pages/CreateTransform/components/TransformOptions/Panels/DateHistogramPanel/DateHistogramPanel.tsx
+++ b/public/pages/CreateTransform/components/TransformOptions/Panels/DateHistogramPanel/DateHistogramPanel.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from "react";
-import { EuiButton, EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSelect, EuiSpacer, EuiText } from "@elastic/eui";
+import { EuiSmallButton, EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSelect, EuiSpacer, EuiText } from "@elastic/eui";
 import { getDateHistogramGroupItem } from "../../../../utils/helpers";
 import { CalendarTimeunitOptions, FixedTimeunitOptions, IntervalType } from "../../../../../../utils/constants";
 import { GROUP_TYPES, TRANSFORM_AGG_TYPE, TransformAggItem, TransformGroupItem } from "../../../../../../../models/interfaces";
@@ -71,17 +71,17 @@ export default function DateHistogramPanel({ name, handleGroupSelectionChange, c
       <EuiSpacer size="m" />
       <EuiFlexGroup justifyContent={"flexEnd"} gutterSize={"m"}>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             fullWidth={false}
             onClick={() => closePopover()}
             style={{ minWidth: 84 }}
             data-test-subj="dateHistogramPanelCancelButton"
           >
             Cancel
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             fill
             fullWidth={false}
             onClick={() => {
@@ -101,7 +101,7 @@ export default function DateHistogramPanel({ name, handleGroupSelectionChange, c
             data-test-subj="dateHistogramPanelOKButton"
           >
             OK
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiPanel>

--- a/public/pages/CreateTransform/components/TransformOptions/Panels/DateHistogramPanel/DateHistogramPanel.tsx
+++ b/public/pages/CreateTransform/components/TransformOptions/Panels/DateHistogramPanel/DateHistogramPanel.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from "react";
-import { EuiSmallButton, EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSelect, EuiSpacer, EuiText } from "@elastic/eui";
+import { EuiSmallButton, EuiCompressedFieldNumber, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSelect, EuiSpacer, EuiText } from "@elastic/eui";
 import { getDateHistogramGroupItem } from "../../../../utils/helpers";
 import { CalendarTimeunitOptions, FixedTimeunitOptions, IntervalType } from "../../../../../../utils/constants";
 import { GROUP_TYPES, TRANSFORM_AGG_TYPE, TransformAggItem, TransformGroupItem } from "../../../../../../../models/interfaces";
@@ -24,7 +24,7 @@ export default function DateHistogramPanel({ name, handleGroupSelectionChange, c
   let timeunitOptions, intervalDefinition;
   if (intervalType === IntervalType.FIXED) {
     intervalDefinition = (
-      <EuiFieldNumber
+      <EuiCompressedFieldNumber
         value={dateHistogramInterval}
         onChange={(e) => setDateHistogramInterval(e.target.valueAsNumber)}
         data-test-subj="dateHistogramValueInput"

--- a/public/pages/CreateTransform/components/TransformOptions/Panels/DateHistogramPanel/DateHistogramPanel.tsx
+++ b/public/pages/CreateTransform/components/TransformOptions/Panels/DateHistogramPanel/DateHistogramPanel.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from "react";
-import { EuiSmallButton, EuiCompressedFieldNumber, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSelect, EuiSpacer, EuiText } from "@elastic/eui";
+import { EuiSmallButton, EuiCompressedFieldNumber, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiCompressedSelect, EuiSpacer, EuiText } from "@elastic/eui";
 import { getDateHistogramGroupItem } from "../../../../utils/helpers";
 import { CalendarTimeunitOptions, FixedTimeunitOptions, IntervalType } from "../../../../../../utils/constants";
 import { GROUP_TYPES, TRANSFORM_AGG_TYPE, TransformAggItem, TransformGroupItem } from "../../../../../../../models/interfaces";
@@ -60,7 +60,7 @@ export default function DateHistogramPanel({ name, handleGroupSelectionChange, c
           {intervalDefinition}
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiSelect
+          <EuiCompressedSelect
             options={timeunitOptions}
             value={dateHistogramTimeunit}
             onChange={(e) => setDateHistogramTimeunit(e.target.value)}

--- a/public/pages/CreateTransform/components/TransformOptions/Panels/DateHistogramPanel/__snapshots__/DateHistogramPanel.test.tsx.snap
+++ b/public/pages/CreateTransform/components/TransformOptions/Panels/DateHistogramPanel/__snapshots__/DateHistogramPanel.test.tsx.snap
@@ -53,13 +53,13 @@ exports[`<DateHistogramPanel /> spec renders the component with calendar interva
       class="euiFlexItem"
     >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout euiFormControlLayout--compressed"
       >
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
           <select
-            class="euiSelect"
+            class="euiSelect euiSelect--compressed"
             data-test-subj="dateHistogramTimeunitSelect"
           >
             <option
@@ -121,7 +121,7 @@ exports[`<DateHistogramPanel /> spec renders the component with calendar interva
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButton euiButton--primary"
+        class="euiButton euiButton--primary euiButton--small"
         data-test-subj="dateHistogramPanelCancelButton"
         type="button"
       >
@@ -140,7 +140,7 @@ exports[`<DateHistogramPanel /> spec renders the component with calendar interva
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButton euiButton--primary euiButton--fill"
+        class="euiButton euiButton--primary euiButton--small euiButton--fill"
         data-test-subj="dateHistogramPanelOKButton"
         type="button"
       >
@@ -198,13 +198,13 @@ exports[`<DateHistogramPanel /> spec renders the component with fixed interval 1
       style="width: 100px;"
     >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout euiFormControlLayout--compressed"
       >
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
           <input
-            class="euiFieldNumber"
+            class="euiFieldNumber euiFieldNumber--compressed"
             data-test-subj="dateHistogramValueInput"
             type="number"
             value="1"
@@ -216,13 +216,13 @@ exports[`<DateHistogramPanel /> spec renders the component with fixed interval 1
       class="euiFlexItem"
     >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout euiFormControlLayout--compressed"
       >
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
           <select
-            class="euiSelect"
+            class="euiSelect euiSelect--compressed"
             data-test-subj="dateHistogramTimeunitSelect"
           >
             <option
@@ -274,7 +274,7 @@ exports[`<DateHistogramPanel /> spec renders the component with fixed interval 1
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButton euiButton--primary"
+        class="euiButton euiButton--primary euiButton--small"
         data-test-subj="dateHistogramPanelCancelButton"
         type="button"
       >
@@ -293,7 +293,7 @@ exports[`<DateHistogramPanel /> spec renders the component with fixed interval 1
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButton euiButton--primary euiButton--fill"
+        class="euiButton euiButton--primary euiButton--small euiButton--fill"
         data-test-subj="dateHistogramPanelOKButton"
         type="button"
       >

--- a/public/pages/CreateTransform/components/TransformOptions/Panels/HistogramPanel/HistogramPanel.tsx
+++ b/public/pages/CreateTransform/components/TransformOptions/Panels/HistogramPanel/HistogramPanel.tsx
@@ -5,7 +5,7 @@
 
 import { GROUP_TYPES, TRANSFORM_AGG_TYPE, TransformAggItem, TransformGroupItem } from "../../../../../../../models/interfaces";
 import React, { useState } from "react";
-import { EuiButton, EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiPanel, EuiSpacer } from "@elastic/eui";
+import { EuiSmallButton, EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiPanel, EuiSpacer } from "@elastic/eui";
 
 interface HistogramPanelProps {
   name: string;
@@ -30,12 +30,12 @@ export default function HistogramPanel({ name, handleGroupSelectionChange, close
       </EuiFlexGroup>
       <EuiFlexGroup justifyContent={"flexEnd"} gutterSize={"m"}>
         <EuiFlexItem grow={false}>
-          <EuiButton fullWidth={false} onClick={() => closePopover()} style={{ minWidth: 84 }}>
+          <EuiSmallButton fullWidth={false} onClick={() => closePopover()} style={{ minWidth: 84 }}>
             Cancel
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             fill
             fullWidth={false}
             onClick={() => {
@@ -55,7 +55,7 @@ export default function HistogramPanel({ name, handleGroupSelectionChange, close
             style={{ minWidth: 55 }}
           >
             OK
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiPanel>

--- a/public/pages/CreateTransform/components/TransformOptions/Panels/HistogramPanel/HistogramPanel.tsx
+++ b/public/pages/CreateTransform/components/TransformOptions/Panels/HistogramPanel/HistogramPanel.tsx
@@ -5,7 +5,15 @@
 
 import { GROUP_TYPES, TRANSFORM_AGG_TYPE, TransformAggItem, TransformGroupItem } from "../../../../../../../models/interfaces";
 import React, { useState } from "react";
-import { EuiSmallButton, EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiCompressedFormRow, EuiPanel, EuiSpacer } from "@elastic/eui";
+import {
+  EuiSmallButton,
+  EuiCompressedFieldNumber,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiCompressedFormRow,
+  EuiPanel,
+  EuiSpacer,
+} from "@elastic/eui";
 
 interface HistogramPanelProps {
   name: string;
@@ -22,7 +30,7 @@ export default function HistogramPanel({ name, handleGroupSelectionChange, close
       <EuiFlexGroup>
         <EuiFlexItem grow={false} style={{ width: 109 }}>
           <EuiCompressedFormRow label="Histogram interval">
-            <EuiFieldNumber value={histogramInterval} onChange={(e) => setHistogramInterval(e.target.valueAsNumber)} />
+            <EuiCompressedFieldNumber value={histogramInterval} onChange={(e) => setHistogramInterval(e.target.valueAsNumber)} />
           </EuiCompressedFormRow>
           <EuiSpacer size="s" />
         </EuiFlexItem>

--- a/public/pages/CreateTransform/components/TransformOptions/Panels/HistogramPanel/HistogramPanel.tsx
+++ b/public/pages/CreateTransform/components/TransformOptions/Panels/HistogramPanel/HistogramPanel.tsx
@@ -5,7 +5,7 @@
 
 import { GROUP_TYPES, TRANSFORM_AGG_TYPE, TransformAggItem, TransformGroupItem } from "../../../../../../../models/interfaces";
 import React, { useState } from "react";
-import { EuiSmallButton, EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiPanel, EuiSpacer } from "@elastic/eui";
+import { EuiSmallButton, EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiCompressedFormRow, EuiPanel, EuiSpacer } from "@elastic/eui";
 
 interface HistogramPanelProps {
   name: string;
@@ -21,9 +21,9 @@ export default function HistogramPanel({ name, handleGroupSelectionChange, close
     <EuiPanel>
       <EuiFlexGroup>
         <EuiFlexItem grow={false} style={{ width: 109 }}>
-          <EuiFormRow label="Histogram interval">
+          <EuiCompressedFormRow label="Histogram interval">
             <EuiFieldNumber value={histogramInterval} onChange={(e) => setHistogramInterval(e.target.valueAsNumber)} />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
           <EuiSpacer size="s" />
         </EuiFlexItem>
         <EuiFlexItem grow={false} />

--- a/public/pages/CreateTransform/components/TransformOptions/Panels/PercentilePanel/PercentilePanel.tsx
+++ b/public/pages/CreateTransform/components/TransformOptions/Panels/PercentilePanel/PercentilePanel.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from "react";
-import { EuiSmallButton, EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiPanel, EuiSpacer } from "@elastic/eui";
+import { EuiSmallButton, EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiCompressedFormRow, EuiPanel, EuiSpacer } from "@elastic/eui";
 import { TRANSFORM_AGG_TYPE, TransformAggItem } from "../../../../../../../models/interfaces";
 
 interface PercentilePanelProps {
@@ -57,7 +57,7 @@ export default function PercentilePanel({ name, aggSelection, handleAggSelection
     <EuiPanel>
       <EuiFlexGroup gutterSize={"none"}>
         <EuiFlexItem grow={false} style={{ width: 230 }}>
-          <EuiFormRow
+          <EuiCompressedFormRow
             fullWidth={true}
             label="Percents"
             helpText="Only numbers between 0-100 allowed."
@@ -73,7 +73,7 @@ export default function PercentilePanel({ name, aggSelection, handleAggSelection
               isInvalid={isInvalid}
               onSearchChange={onSearchChange}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
           <EuiSpacer size="m" />
         </EuiFlexItem>
         <EuiFlexItem grow={false}></EuiFlexItem>

--- a/public/pages/CreateTransform/components/TransformOptions/Panels/PercentilePanel/PercentilePanel.tsx
+++ b/public/pages/CreateTransform/components/TransformOptions/Panels/PercentilePanel/PercentilePanel.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from "react";
-import { EuiSmallButton, EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiCompressedFormRow, EuiPanel, EuiSpacer } from "@elastic/eui";
+import { EuiSmallButton, EuiCompressedComboBox, EuiFlexGroup, EuiFlexItem, EuiCompressedFormRow, EuiPanel, EuiSpacer } from "@elastic/eui";
 import { TRANSFORM_AGG_TYPE, TransformAggItem } from "../../../../../../../models/interfaces";
 
 interface PercentilePanelProps {
@@ -64,7 +64,7 @@ export default function PercentilePanel({ name, aggSelection, handleAggSelection
             isInvalid={isInvalid}
             error={isInvalid ? "Invalid input" : undefined}
           >
-            <EuiComboBox
+            <EuiCompressedComboBox
               fullWidth={true}
               noSuggestions
               selectedOptions={percents}

--- a/public/pages/CreateTransform/components/TransformOptions/Panels/PercentilePanel/PercentilePanel.tsx
+++ b/public/pages/CreateTransform/components/TransformOptions/Panels/PercentilePanel/PercentilePanel.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from "react";
-import { EuiButton, EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiPanel, EuiSpacer } from "@elastic/eui";
+import { EuiSmallButton, EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiPanel, EuiSpacer } from "@elastic/eui";
 import { TRANSFORM_AGG_TYPE, TransformAggItem } from "../../../../../../../models/interfaces";
 
 interface PercentilePanelProps {
@@ -80,12 +80,12 @@ export default function PercentilePanel({ name, aggSelection, handleAggSelection
       </EuiFlexGroup>
       <EuiFlexGroup justifyContent={"flexEnd"} gutterSize={"m"}>
         <EuiFlexItem grow={false}>
-          <EuiButton fullWidth={false} onClick={() => closePopover()} style={{ minWidth: 84 }}>
+          <EuiSmallButton fullWidth={false} onClick={() => closePopover()} style={{ minWidth: 84 }}>
             Cancel
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             fill
             fullWidth={false}
             onClick={() => {
@@ -110,7 +110,7 @@ export default function PercentilePanel({ name, aggSelection, handleAggSelection
             style={{ minWidth: 55 }}
           >
             OK
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiPanel>

--- a/public/pages/CreateTransform/components/TransformOptions/Panels/ScriptedMetricsPanel/ScriptedMetricsPanel.tsx
+++ b/public/pages/CreateTransform/components/TransformOptions/Panels/ScriptedMetricsPanel/ScriptedMetricsPanel.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from "react";
-import { EuiSmallButton, EuiFlexGroup, EuiFlexItem, EuiForm, EuiFormRow, EuiPanel, EuiCodeEditor, EuiSpacer } from "@elastic/eui";
+import { EuiSmallButton, EuiFlexGroup, EuiFlexItem, EuiForm, EuiCompressedFormRow, EuiPanel, EuiCodeEditor, EuiSpacer } from "@elastic/eui";
 import { TRANSFORM_AGG_TYPE, TransformAggItem } from "../../../../../../../models/interfaces";
 
 interface ScriptedMetricsPanelProps {
@@ -20,14 +20,14 @@ export default function ScriptedMetricsPanel({ name, aggSelection, handleAggSele
   return (
     <EuiPanel>
       <EuiForm>
-        <EuiFormRow label="Scripted metrics">
+        <EuiCompressedFormRow label="Scripted metrics">
           <EuiCodeEditor
             style={{ width: 0.38 * window.innerWidth, height: 0.4 * window.innerHeight }}
             value={script}
             onChange={(value: string) => setScript(value)}
             mode="json"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <EuiSpacer />
         <EuiFlexGroup justifyContent="flexEnd" gutterSize="m">
           <EuiFlexItem grow={false}>

--- a/public/pages/CreateTransform/components/TransformOptions/Panels/ScriptedMetricsPanel/ScriptedMetricsPanel.tsx
+++ b/public/pages/CreateTransform/components/TransformOptions/Panels/ScriptedMetricsPanel/ScriptedMetricsPanel.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from "react";
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiForm, EuiFormRow, EuiPanel, EuiCodeEditor, EuiSpacer } from "@elastic/eui";
+import { EuiSmallButton, EuiFlexGroup, EuiFlexItem, EuiForm, EuiFormRow, EuiPanel, EuiCodeEditor, EuiSpacer } from "@elastic/eui";
 import { TRANSFORM_AGG_TYPE, TransformAggItem } from "../../../../../../../models/interfaces";
 
 interface ScriptedMetricsPanelProps {
@@ -31,12 +31,12 @@ export default function ScriptedMetricsPanel({ name, aggSelection, handleAggSele
         <EuiSpacer />
         <EuiFlexGroup justifyContent="flexEnd" gutterSize="m">
           <EuiFlexItem grow={false}>
-            <EuiButton fullWidth={false} onClick={() => closePopover()}>
+            <EuiSmallButton fullWidth={false} onClick={() => closePopover()}>
               Cancel
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               fill
               fullWidth={false}
               onClick={() => {
@@ -55,7 +55,7 @@ export default function ScriptedMetricsPanel({ name, aggSelection, handleAggSele
               style={{ minWidth: 55 }}
             >
               OK
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiForm>

--- a/public/pages/CreateTransform/components/TransformOptions/TransformOptions.tsx
+++ b/public/pages/CreateTransform/components/TransformOptions/TransformOptions.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState } from "react";
 import {
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiContextMenu,
   EuiContextMenuPanelDescriptor,
   EuiFlexGroup,
@@ -368,7 +368,7 @@ export default function TransformOptions({
   ];
 
   const button = (
-    <EuiButtonIcon
+    <EuiSmallButtonIcon
       iconType="plusInCircleFilled"
       onClick={() => setIsPopoverOpen(!isPopoverOpen)}
       data-test-subj={`${name}OptionsPopover`}

--- a/public/pages/CreateTransform/containers/CreateTransformForm/CreateTransformForm.tsx
+++ b/public/pages/CreateTransform/containers/CreateTransformForm/CreateTransformForm.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, Component, useContext } from "react";
-import { EuiButton, EuiButtonEmpty, EuiComboBoxOptionOption, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiSmallButton, EuiButtonEmpty, EuiComboBoxOptionOption, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import { RouteComponentProps } from "react-router-dom";
 import moment from "moment";
 import { RollupService, TransformService } from "../../../../services";
@@ -685,23 +685,23 @@ export class CreateTransformForm extends Component<CreateTransformFormProps, Cre
           </EuiFlexItem>
           {currentStep != 1 && (
             <EuiFlexItem grow={false}>
-              <EuiButton onClick={this._prev} data-test-subj="createTransformPreviousButton">
+              <EuiSmallButton onClick={this._prev} data-test-subj="createTransformPreviousButton">
                 Previous
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           )}
 
           {currentStep == 4 ? (
             <EuiFlexItem grow={false}>
-              <EuiButton fill onClick={this.onSubmit} isLoading={isSubmitting} data-test-subj="createTransformSubmitButton">
+              <EuiSmallButton fill onClick={this.onSubmit} isLoading={isSubmitting} data-test-subj="createTransformSubmitButton">
                 Create
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           ) : (
             <EuiFlexItem grow={false}>
-              <EuiButton fill onClick={this._next} isLoading={isLoading} data-test-subj="createTransformNextButton">
+              <EuiSmallButton fill onClick={this._next} isLoading={isLoading} data-test-subj="createTransformNextButton">
                 Next
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           )}
         </EuiFlexGroup>

--- a/public/pages/CreateTransform/containers/CreateTransformForm/CreateTransformForm.tsx
+++ b/public/pages/CreateTransform/containers/CreateTransformForm/CreateTransformForm.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, Component, useContext } from "react";
-import { EuiSmallButton, EuiButtonEmpty, EuiComboBoxOptionOption, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiSmallButton, EuiSmallButtonEmpty, EuiComboBoxOptionOption, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import { RouteComponentProps } from "react-router-dom";
 import moment from "moment";
 import { RollupService, TransformService } from "../../../../services";
@@ -679,9 +679,9 @@ export class CreateTransformForm extends Component<CreateTransformFormProps, Cre
         />
         <EuiFlexGroup alignItems="center" justifyContent="flexEnd" style={{ padding: "5px 50px" }}>
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty onClick={this.onCancel} data-test-subj="createTransformCancelButton">
+            <EuiSmallButtonEmpty onClick={this.onCancel} data-test-subj="createTransformCancelButton">
               Cancel
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
           </EuiFlexItem>
           {currentStep != 1 && (
             <EuiFlexItem grow={false}>

--- a/public/pages/CreateTransform/containers/CreateTransformForm/__snapshots__/CreateTransformForm.test.tsx.snap
+++ b/public/pages/CreateTransform/containers/CreateTransformForm/__snapshots__/CreateTransformForm.test.tsx.snap
@@ -193,7 +193,7 @@ exports[`<CreateTransformForm /> spec renders the component 1`] = `
             >
               <div>
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
@@ -211,14 +211,14 @@ exports[`<CreateTransformForm /> spec renders the component 1`] = `
                     class="euiFormRow__fieldWrapper"
                   >
                     <div
-                      class="euiFormControlLayout"
+                      class="euiFormControlLayout euiFormControlLayout--compressed"
                     >
                       <div
                         class="euiFormControlLayout__childrenWrapper"
                       >
                         <input
                           aria-describedby="some_html_id-help-0"
-                          class="euiFieldText"
+                          class="euiFieldText euiFieldText--compressed"
                           id="some_html_id"
                           placeholder="my-transformjob1"
                           type="text"
@@ -271,7 +271,7 @@ exports[`<CreateTransformForm /> spec renders the component 1`] = `
                   class="euiSpacer euiSpacer--xs"
                 />
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
@@ -324,7 +324,7 @@ exports[`<CreateTransformForm /> spec renders the component 1`] = `
               >
                 <div>
                   <div
-                    class="euiFormRow"
+                    class="euiFormRow euiFormRow--compressed"
                     id="some_html_id-row"
                   >
                     <div
@@ -345,18 +345,18 @@ exports[`<CreateTransformForm /> spec renders the component 1`] = `
                         aria-describedby="some_html_id-help-0"
                         aria-expanded="false"
                         aria-haspopup="listbox"
-                        class="euiComboBox"
+                        class="euiComboBox euiComboBox--compressed"
                         data-test-subj="sourceIndexCombobox"
                         role="combobox"
                       >
                         <div
-                          class="euiFormControlLayout"
+                          class="euiFormControlLayout euiFormControlLayout--compressed"
                         >
                           <div
                             class="euiFormControlLayout__childrenWrapper"
                           >
                             <div
-                              class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
+                              class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
                               data-test-subj="comboBoxInput"
                               tabindex="-1"
                             >
@@ -531,7 +531,7 @@ exports[`<CreateTransformForm /> spec renders the component 1`] = `
                     class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
                   />
                   <div
-                    class="euiFormRow"
+                    class="euiFormRow euiFormRow--compressed"
                     id="some_html_id-row"
                   >
                     <div
@@ -552,18 +552,18 @@ exports[`<CreateTransformForm /> spec renders the component 1`] = `
                         aria-describedby="some_html_id-help-0"
                         aria-expanded="false"
                         aria-haspopup="listbox"
-                        class="euiComboBox"
+                        class="euiComboBox euiComboBox--compressed"
                         data-test-subj="targetIndexCombobox"
                         role="combobox"
                       >
                         <div
-                          class="euiFormControlLayout"
+                          class="euiFormControlLayout euiFormControlLayout--compressed"
                         >
                           <div
                             class="euiFormControlLayout__childrenWrapper"
                           >
                             <div
-                              class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
+                              class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
                               data-test-subj="comboBoxInput"
                               tabindex="-1"
                             >
@@ -651,7 +651,7 @@ exports[`<CreateTransformForm /> spec renders the component 1`] = `
         class="euiFlexItem euiFlexItem--flexGrowZero"
       >
         <button
-          class="euiButtonEmpty euiButtonEmpty--primary"
+          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
           data-test-subj="createTransformCancelButton"
           type="button"
         >
@@ -670,7 +670,7 @@ exports[`<CreateTransformForm /> spec renders the component 1`] = `
         class="euiFlexItem euiFlexItem--flexGrowZero"
       >
         <button
-          class="euiButton euiButton--primary euiButton--fill"
+          class="euiButton euiButton--primary euiButton--small euiButton--fill"
           data-test-subj="createTransformNextButton"
           type="button"
         >

--- a/public/pages/DataStreams/components/IndexControls/IndexControls.tsx
+++ b/public/pages/DataStreams/components/IndexControls/IndexControls.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useEffect, useState } from "react";
-import { EuiFieldSearch, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiCompressedFieldSearch, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 
 export interface SearchControlsProps {
   value: {
@@ -30,12 +30,11 @@ export default function SearchControls(props: SearchControlsProps) {
   return (
     <EuiFlexGroup style={{ padding: "0px 5px" }} alignItems="center">
       <EuiFlexItem>
-        <EuiFieldSearch
+        <EuiCompressedFieldSearch
           fullWidth
           placeholder="Search..."
           value={state.search}
           onChange={(e) => onChange("search", e.target.value)}
-          compressed={props.useNewUX}
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/public/pages/DataStreams/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
+++ b/public/pages/DataStreams/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
@@ -9,13 +9,13 @@ exports[`<IndexControls /> spec renders the component 1`] = `
     class="euiFlexItem"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <input
-          class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
+          class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch-isClearable"
           placeholder="Search..."
           type="search"
           value="testing"
@@ -34,7 +34,7 @@ exports[`<IndexControls /> spec renders the component 1`] = `
         >
           <button
             aria-label="Clear input"
-            class="euiFormControlLayoutClearButton"
+            class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
             type="button"
           >
             EuiIconMock

--- a/public/pages/DataStreams/containers/DataStreams/DataStreams.tsx
+++ b/public/pages/DataStreams/containers/DataStreams/DataStreams.tsx
@@ -25,7 +25,6 @@ import {
   EuiToolTip,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiSmallButton,
 } from "@elastic/eui";
 import { ContentPanel, ContentPanelActions } from "../../../../components/ContentPanel";
 import { DEFAULT_PAGE_SIZE_OPTIONS, DEFAULT_QUERY_PARAMS, HEALTH_TO_COLOR } from "../../utils/constants";

--- a/public/pages/DataStreams/containers/DataStreams/DataStreams.tsx
+++ b/public/pages/DataStreams/containers/DataStreams/DataStreams.tsx
@@ -18,7 +18,7 @@ import {
   EuiSmallButton,
   EuiLink,
   EuiTitle,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiEmptyPrompt,
   EuiText,
   EuiHealth,
@@ -471,7 +471,7 @@ class DataStreams extends MDSEnabledComponent<DataStreamsProps, DataStreamsState
               <EuiTitle size="s">
                 <span>Data streams</span>
               </EuiTitle>
-              <EuiFormRow
+              <EuiCompressedFormRow
                 fullWidth
                 helpText={
                   <div>
@@ -484,7 +484,7 @@ class DataStreams extends MDSEnabledComponent<DataStreamsProps, DataStreamsState
                 }
               >
                 <></>
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </>
           }
         >

--- a/public/pages/DataStreams/containers/DataStreams/DataStreams.tsx
+++ b/public/pages/DataStreams/containers/DataStreams/DataStreams.tsx
@@ -15,7 +15,7 @@ import {
   Direction,
   Pagination,
   EuiTableSelectionType,
-  EuiButton,
+  EuiSmallButton,
   EuiLink,
   EuiTitle,
   EuiFormRow,
@@ -578,14 +578,14 @@ class DataStreams extends MDSEnabledComponent<DataStreamsProps, DataStreamsState
                     </EuiText>
                   }
                   actions={[
-                    <EuiButton
+                    <EuiSmallButton
                       fill
                       onClick={() => {
                         this.props.history.push(ROUTES.CREATE_DATA_STREAM);
                       }}
                     >
                       Create data stream
-                    </EuiButton>,
+                    </EuiSmallButton>,
                   ]}
                 />
               ) : (
@@ -596,7 +596,7 @@ class DataStreams extends MDSEnabledComponent<DataStreamsProps, DataStreamsState
                     </EuiText>
                   }
                   actions={[
-                    <EuiButton
+                    <EuiSmallButton
                       fill
                       onClick={() => {
                         this.setState(defaultFilter, () => {
@@ -605,7 +605,7 @@ class DataStreams extends MDSEnabledComponent<DataStreamsProps, DataStreamsState
                       }}
                     >
                       Reset filters
-                    </EuiButton>,
+                    </EuiSmallButton>,
                   ]}
                 />
               )

--- a/public/pages/DataStreams/containers/DataStreams/__snapshots__/DataStreams.test.tsx.snap
+++ b/public/pages/DataStreams/containers/DataStreams/__snapshots__/DataStreams.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`<DataStreams /> spec renders the component 1`] = `
         Data streams
       </span>
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -65,7 +65,7 @@ exports[`<DataStreams /> spec renders the component 1`] = `
                   class="euiPopover__anchor"
                 >
                   <button
-                    class="euiButton euiButton--primary"
+                    class="euiButton euiButton--primary euiButton--small"
                     type="button"
                   >
                     <span
@@ -86,7 +86,7 @@ exports[`<DataStreams /> spec renders the component 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButton euiButton--primary euiButton--fill"
+                class="euiButton euiButton--primary euiButton--small euiButton--fill"
                 data-test-subj="Create data streamButton"
                 type="button"
               >
@@ -120,13 +120,13 @@ exports[`<DataStreams /> spec renders the component 1`] = `
         class="euiFlexItem"
       >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+          class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
         >
           <div
             class="euiFormControlLayout__childrenWrapper"
           >
             <input
-              class="euiFieldSearch euiFieldSearch--fullWidth"
+              class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
               placeholder="Search..."
               type="search"
               value=""
@@ -419,7 +419,7 @@ exports[`<DataStreams /> spec renders the component 1`] = `
                           class="euiFlexItem euiFlexItem--flexGrowZero"
                         >
                           <button
-                            class="euiButton euiButton--primary euiButton--fill"
+                            class="euiButton euiButton--primary euiButton--small euiButton--fill"
                             type="button"
                           >
                             <span

--- a/public/pages/DataStreams/containers/DataStreamsActions/__snapshots__/DataStreamsActions.test.tsx.snap
+++ b/public/pages/DataStreams/containers/DataStreamsActions/__snapshots__/DataStreamsActions.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`<DataStreamsActions /> spec cannot clear cache for data streams if they
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -36,7 +36,7 @@ exports[`<DataStreamsActions /> spec clear cache for data streams by calling com
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -63,7 +63,7 @@ exports[`<DataStreamsActions /> spec delete data streams by calling commonServic
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -90,7 +90,7 @@ exports[`<DataStreamsActions /> spec filter data streams failed when clearing ca
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -124,7 +124,7 @@ exports[`<DataStreamsActions /> spec refresh data streams by calling commonServi
         class="euiPopover__anchor"
       >
         <button
-          class="euiButton euiButton--primary"
+          class="euiButton euiButton--primary euiButton--small"
           type="button"
         >
           <span
@@ -242,7 +242,7 @@ exports[`<DataStreamsActions /> spec refresh data streams by calling commonServi
             class="euiModalFooter"
           >
             <button
-              class="euiButtonEmpty euiButtonEmpty--primary"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
               type="button"
             >
               <span
@@ -256,7 +256,7 @@ exports[`<DataStreamsActions /> spec refresh data streams by calling commonServi
               </span>
             </button>
             <button
-              class="euiButton euiButton--primary euiButton--fill"
+              class="euiButton euiButton--primary euiButton--small euiButton--fill"
               data-test-subj="refreshConfirmButton"
               type="button"
             >
@@ -299,7 +299,7 @@ HTMLCollection [
         class="euiPopover__anchor"
       >
         <button
-          class="euiButton euiButton--primary"
+          class="euiButton euiButton--primary euiButton--small"
           type="button"
         >
           <span
@@ -412,7 +412,7 @@ HTMLCollection [
             class="euiModalFooter"
           >
             <button
-              class="euiButtonEmpty euiButtonEmpty--primary"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
               data-test-subj="flushCancelButton"
               type="button"
             >
@@ -427,7 +427,7 @@ HTMLCollection [
               </span>
             </button>
             <button
-              class="euiButton euiButton--primary euiButton--fill"
+              class="euiButton euiButton--primary euiButton--small euiButton--fill"
               data-test-subj="flushConfirmButton"
               type="button"
             >
@@ -465,7 +465,7 @@ exports[`<DataStreamsActions /> spec renders the component and all the actions s
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span

--- a/public/pages/DataStreams/containers/DataStreamsActions/index.tsx
+++ b/public/pages/DataStreams/containers/DataStreamsActions/index.tsx
@@ -21,7 +21,7 @@ export interface DataStreamsActionsProps {
 }
 
 export default function DataStreamsActions(props: DataStreamsActionsProps) {
-  const { selectedItems, onDelete, history, useNewUX } = props;
+  const { selectedItems, onDelete, history } = props;
   const [deleteIndexModalVisible, setDeleteIndexModalVisible] = useState(false);
   const [clearCacheModalVisible, setClearCacheModalVisible] = useState(false);
   const [flushDataStreamModalVisible, setFlushDataStreamModalVisible] = useState(false);
@@ -52,7 +52,7 @@ export default function DataStreamsActions(props: DataStreamsActionsProps) {
         data-test-subj="moreAction"
         panelPaddingSize="s"
         button={
-          <EuiButton iconType="arrowDown" iconSide="right" size={useNewUX ? "s" : undefined}>
+          <EuiButton iconType="arrowDown" iconSide="right">
             Actions
           </EuiButton>
         }

--- a/public/pages/DataStreams/containers/DataStreamsActions/index.tsx
+++ b/public/pages/DataStreams/containers/DataStreamsActions/index.tsx
@@ -4,7 +4,7 @@
  */
 import React, { useMemo, useState } from "react";
 import { RouteComponentProps } from "react-router-dom";
-import { EuiButton, EuiContextMenu } from "@elastic/eui";
+import { EuiSmallButton, EuiContextMenu } from "@elastic/eui";
 import SimplePopover from "../../../../components/SimplePopover";
 import ClearCacheModal from "../../../../containers/ClearCacheModal";
 import FlushIndexModal from "../../../../containers/FlushIndexModal";
@@ -52,9 +52,9 @@ export default function DataStreamsActions(props: DataStreamsActionsProps) {
         data-test-subj="moreAction"
         panelPaddingSize="s"
         button={
-          <EuiButton iconType="arrowDown" iconSide="right">
+          <EuiSmallButton iconType="arrowDown" iconSide="right">
             Actions
-          </EuiButton>
+          </EuiSmallButton>
         }
       >
         <EuiContextMenu

--- a/public/pages/DataStreams/containers/DeleteDataStreamsModal/__snapshots__/DeleteDataStreamsModal.test.tsx.snap
+++ b/public/pages/DataStreams/containers/DeleteDataStreamsModal/__snapshots__/DeleteDataStreamsModal.test.tsx.snap
@@ -76,13 +76,13 @@ HTMLCollection [
                   </div>
                 </div>
                 <div
-                  class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                  class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <input
-                      class="euiFieldText euiFieldText--fullWidth"
+                      class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
                       data-test-subj="deleteInput"
                       placeholder="delete"
                       type="text"
@@ -97,7 +97,7 @@ HTMLCollection [
             class="euiModalFooter"
           >
             <button
-              class="euiButtonEmpty euiButtonEmpty--primary"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
               data-test-subj="deletaCancelButton"
               type="button"
             >
@@ -112,7 +112,7 @@ HTMLCollection [
               </span>
             </button>
             <button
-              class="euiButton euiButton--danger euiButton--fill euiButton-isDisabled"
+              class="euiButton euiButton--danger euiButton--small euiButton--fill euiButton-isDisabled"
               data-test-subj="deleteConfirmButton"
               disabled=""
               type="button"

--- a/public/pages/EditRollup/containers/EditRollup.tsx
+++ b/public/pages/EditRollup/containers/EditRollup.tsx
@@ -7,7 +7,7 @@ import React, { ChangeEvent, Component, useContext } from "react";
 import { RouteComponentProps } from "react-router-dom";
 import moment from "moment";
 import queryString from "query-string";
-import { EuiFlexItem, EuiFlexGroup, EuiButton, EuiTitle, EuiSpacer, EuiButtonEmpty } from "@elastic/eui";
+import { EuiFlexItem, EuiFlexGroup, EuiSmallButton, EuiTitle, EuiSpacer, EuiButtonEmpty } from "@elastic/eui";
 import ConfigureRollup from "../../CreateRollup/components/ConfigureRollup";
 import Schedule from "../../CreateRollup/components/Schedule";
 import { getErrorMessage } from "../../../utils/helpers";
@@ -356,9 +356,9 @@ export class EditRollup extends Component<EditRollupProps, EditRollupState> {
             </EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton fill onClick={this.onSubmit} isLoading={isSubmitting} data-test-subj="editRollupSaveChangesButton">
+            <EuiSmallButton fill onClick={this.onSubmit} isLoading={isSubmitting} data-test-subj="editRollupSaveChangesButton">
               Save changes
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </div>

--- a/public/pages/EditRollup/containers/EditRollup.tsx
+++ b/public/pages/EditRollup/containers/EditRollup.tsx
@@ -7,7 +7,7 @@ import React, { ChangeEvent, Component, useContext } from "react";
 import { RouteComponentProps } from "react-router-dom";
 import moment from "moment";
 import queryString from "query-string";
-import { EuiFlexItem, EuiFlexGroup, EuiSmallButton, EuiTitle, EuiSpacer, EuiButtonEmpty } from "@elastic/eui";
+import { EuiFlexItem, EuiFlexGroup, EuiSmallButton, EuiTitle, EuiSpacer, EuiSmallButtonEmpty } from "@elastic/eui";
 import ConfigureRollup from "../../CreateRollup/components/ConfigureRollup";
 import Schedule from "../../CreateRollup/components/Schedule";
 import { getErrorMessage } from "../../../utils/helpers";
@@ -351,9 +351,9 @@ export class EditRollup extends Component<EditRollupProps, EditRollupState> {
 
         <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty onClick={this.onCancel} data-test-subj="editRollupCancelButton">
+            <EuiSmallButtonEmpty onClick={this.onCancel} data-test-subj="editRollupCancelButton">
               Cancel
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiSmallButton fill onClick={this.onSubmit} isLoading={isSubmitting} data-test-subj="editRollupSaveChangesButton">

--- a/public/pages/EditRollup/containers/__snapshots__/EditRollup.test.tsx.snap
+++ b/public/pages/EditRollup/containers/__snapshots__/EditRollup.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`<EditRollup /> spec renders the component 1`] = `
           class="euiSpacer euiSpacer--s"
         />
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -67,14 +67,14 @@ exports[`<EditRollup /> spec renders the component 1`] = `
             class="euiFormRow__fieldWrapper"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
                   aria-describedby="some_html_id-help-0"
-                  class="euiFieldText"
+                  class="euiFieldText euiFieldText--compressed"
                   disabled=""
                   id="some_html_id"
                   placeholder="my-rollupjob1"
@@ -128,7 +128,7 @@ exports[`<EditRollup /> spec renders the component 1`] = `
           class="euiSpacer euiSpacer--xs"
         />
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -185,7 +185,7 @@ exports[`<EditRollup /> spec renders the component 1`] = `
           class="euiSpacer euiSpacer--m"
         />
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -202,13 +202,13 @@ exports[`<EditRollup /> spec renders the component 1`] = `
             class="euiFormRow__fieldWrapper"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <select
-                  class="euiSelect"
+                  class="euiSelect euiSelect--compressed"
                   id="some_html_id"
                 >
                   <option
@@ -247,7 +247,7 @@ exports[`<EditRollup /> spec renders the component 1`] = `
             style="width: 200px;"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
@@ -265,13 +265,13 @@ exports[`<EditRollup /> spec renders the component 1`] = `
                 class="euiFormRow__fieldWrapper"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <input
-                      class="euiFieldNumber"
+                      class="euiFieldNumber euiFieldNumber--compressed"
                       id="some_html_id"
                       type="number"
                       value="2"
@@ -285,20 +285,20 @@ exports[`<EditRollup /> spec renders the component 1`] = `
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow euiFormRow--hasEmptyLabelSpace"
+              class="euiFormRow euiFormRow--hasEmptyLabelSpace euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
                 class="euiFormRow__fieldWrapper"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <select
-                      class="euiSelect"
+                      class="euiSelect euiSelect--compressed"
                       id="some_html_id"
                     >
                       <option
@@ -336,7 +336,7 @@ exports[`<EditRollup /> spec renders the component 1`] = `
           class="euiSpacer euiSpacer--m"
         />
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -353,14 +353,14 @@ exports[`<EditRollup /> spec renders the component 1`] = `
             class="euiFormRow__fieldWrapper"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
                   aria-describedby="some_html_id-help-0"
-                  class="euiFieldNumber"
+                  class="euiFieldNumber euiFieldNumber--compressed"
                   id="some_html_id"
                   min="1"
                   placeholder="1000"
@@ -419,20 +419,20 @@ exports[`<EditRollup /> spec renders the component 1`] = `
               </div>
             </div>
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
                 class="euiFormRow__fieldWrapper"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <input
-                      class="euiFieldNumber"
+                      class="euiFieldNumber euiFieldNumber--compressed"
                       id="some_html_id"
                       type="number"
                       value=""
@@ -446,20 +446,20 @@ exports[`<EditRollup /> spec renders the component 1`] = `
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow euiFormRow--hasEmptyLabelSpace"
+              class="euiFormRow euiFormRow--hasEmptyLabelSpace euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
                 class="euiFormRow__fieldWrapper"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <select
-                      class="euiSelect"
+                      class="euiSelect euiSelect--compressed"
                       id="some_html_id"
                     >
                       <option
@@ -517,7 +517,7 @@ exports[`<EditRollup /> spec renders the component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButtonEmpty euiButtonEmpty--primary"
+        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
         data-test-subj="editRollupCancelButton"
         type="button"
       >
@@ -536,7 +536,7 @@ exports[`<EditRollup /> spec renders the component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButton euiButton--primary euiButton--fill"
+        class="euiButton euiButton--primary euiButton--small euiButton--fill"
         data-test-subj="editRollupSaveChangesButton"
         type="button"
       >

--- a/public/pages/ForceMerge/components/ForceMergeAdvancedOptions/__snapshots__/ForceMergeAdvancedOptions.test.tsx.snap
+++ b/public/pages/ForceMerge/components/ForceMergeAdvancedOptions/__snapshots__/ForceMergeAdvancedOptions.test.tsx.snap
@@ -7,7 +7,7 @@ Object {
     <div>
       <div>
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -32,7 +32,7 @@ Object {
             </div>
             <div>
               <div
-                class="euiRadio euiRadioGroup__item"
+                class="euiRadio euiRadio--compressed euiRadioGroup__item"
               >
                 <input
                   checked=""
@@ -52,7 +52,7 @@ Object {
                 </label>
               </div>
               <div
-                class="euiRadio euiRadioGroup__item"
+                class="euiRadio euiRadio--compressed euiRadioGroup__item"
               >
                 <input
                   class="euiRadio__input"
@@ -77,7 +77,7 @@ Object {
           class="euiSpacer euiSpacer--l"
         />
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -103,7 +103,7 @@ Object {
               class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
             >
               <div
-                class="euiCheckbox"
+                class="euiCheckbox euiCheckbox--compressed"
               >
                 <input
                   class="euiCheckbox__input"
@@ -127,7 +127,7 @@ Object {
           class="euiSpacer euiSpacer--l"
         />
         <div
-          class="euiFormRow euiFormRow--fullWidth"
+          class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -153,7 +153,7 @@ Object {
               class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
             >
               <div
-                class="euiCheckbox"
+                class="euiCheckbox euiCheckbox--compressed"
               >
                 <input
                   class="euiCheckbox__input"
@@ -179,7 +179,7 @@ Object {
   "container": <div>
     <div>
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -204,7 +204,7 @@ Object {
           </div>
           <div>
             <div
-              class="euiRadio euiRadioGroup__item"
+              class="euiRadio euiRadio--compressed euiRadioGroup__item"
             >
               <input
                 checked=""
@@ -224,7 +224,7 @@ Object {
               </label>
             </div>
             <div
-              class="euiRadio euiRadioGroup__item"
+              class="euiRadio euiRadio--compressed euiRadioGroup__item"
             >
               <input
                 class="euiRadio__input"
@@ -249,7 +249,7 @@ Object {
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -275,7 +275,7 @@ Object {
             class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
           >
             <div
-              class="euiCheckbox"
+              class="euiCheckbox euiCheckbox--compressed"
             >
               <input
                 class="euiCheckbox__input"
@@ -299,7 +299,7 @@ Object {
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -325,7 +325,7 @@ Object {
             class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
           >
             <div
-              class="euiCheckbox"
+              class="euiCheckbox euiCheckbox--compressed"
             >
               <input
                 class="euiCheckbox__input"

--- a/public/pages/ForceMerge/components/IndexSelect/__snapshots__/IndexSelect.test.tsx.snap
+++ b/public/pages/ForceMerge/components/IndexSelect/__snapshots__/IndexSelect.test.tsx.snap
@@ -9,17 +9,17 @@ Object {
         <div
           aria-expanded="false"
           aria-haspopup="listbox"
-          class="euiComboBox"
+          class="euiComboBox euiComboBox--compressed"
           role="combobox"
         >
           <div
-            class="euiFormControlLayout"
+            class="euiFormControlLayout euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <div
-                class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                 data-test-subj="comboBoxInput"
                 tabindex="-1"
               >
@@ -62,17 +62,17 @@ Object {
       <div
         aria-expanded="false"
         aria-haspopup="listbox"
-        class="euiComboBox"
+        class="euiComboBox euiComboBox--compressed"
         role="combobox"
       >
         <div
-          class="euiFormControlLayout"
+          class="euiFormControlLayout euiFormControlLayout--compressed"
         >
           <div
             class="euiFormControlLayout__childrenWrapper"
           >
             <div
-              class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+              class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
               data-test-subj="comboBoxInput"
               tabindex="-1"
             >

--- a/public/pages/ForceMerge/components/SwitchNumber/index.tsx
+++ b/public/pages/ForceMerge/components/SwitchNumber/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React, { useState } from "react";
-import { EuiRadioGroup, EuiSpacer } from "@elastic/eui";
+import { EuiCompressedRadioGroup, EuiSpacer } from "@elastic/eui";
 import CustomFormRow from "../../../../components/CustomFormRow";
 import { AllBuiltInComponents } from "../../../../components/FormGenerator";
 
@@ -16,7 +16,7 @@ export default function SwitchNumber(props: SwitchNumberProps) {
   const [id, setId] = useState(props.value && props.value > 0 ? "1" : "0");
   return (
     <>
-      <EuiRadioGroup
+      <EuiCompressedRadioGroup
         options={[
           {
             id: "0",

--- a/public/pages/ForceMerge/container/ForceMerge/ForceMerge.tsx
+++ b/public/pages/ForceMerge/container/ForceMerge/ForceMerge.tsx
@@ -6,7 +6,7 @@
 import {
   EuiSmallButton,
   EuiButtonEmpty,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
@@ -140,7 +140,7 @@ export default function ForceMergeWrapper(props: Omit<ForceMergeProps, "services
   const advanceTitle = (
     <EuiFlexGroup gutterSize="none" justifyContent="flexStart" alignItems="center">
       <EuiFlexItem grow={false}>
-        <EuiButtonIcon
+        <EuiSmallButtonIcon
           iconType={advancedSettingsOpen ? "arrowDown" : "arrowRight"}
           color="text"
           data-test-subj="advanceOptionToggle"

--- a/public/pages/ForceMerge/container/ForceMerge/ForceMerge.tsx
+++ b/public/pages/ForceMerge/container/ForceMerge/ForceMerge.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiButtonIcon,
   EuiCallOut,
@@ -273,9 +273,9 @@ export default function ForceMergeWrapper(props: Omit<ForceMergeProps, "services
           </EuiButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton fill onClick={onClickAction} isLoading={executing} data-test-subj="forceMergeConfirmButton">
+          <EuiSmallButton fill onClick={onClickAction} isLoading={executing} data-test-subj="forceMergeConfirmButton">
             Force merge
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </div>

--- a/public/pages/ForceMerge/container/ForceMerge/ForceMerge.tsx
+++ b/public/pages/ForceMerge/container/ForceMerge/ForceMerge.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiSmallButtonIcon,
   EuiCallOut,
   EuiFlexGroup,
@@ -268,9 +268,9 @@ export default function ForceMergeWrapper(props: Omit<ForceMergeProps, "services
 
       <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
         <EuiFlexItem grow={false}>
-          <EuiButtonEmpty onClick={onCancel} data-test-subj="reindexCancelButton">
+          <EuiSmallButtonEmpty onClick={onCancel} data-test-subj="reindexCancelButton">
             Cancel
-          </EuiButtonEmpty>
+          </EuiSmallButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiSmallButton fill onClick={onClickAction} isLoading={executing} data-test-subj="forceMergeConfirmButton">

--- a/public/pages/ForceMerge/container/ForceMerge/__snapshots__/ForceMerge.test.tsx.snap
+++ b/public/pages/ForceMerge/container/ForceMerge/__snapshots__/ForceMerge.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`<ForceMerge /> spec renders the component 1`] = `
     Force merge
   </h1>
   <div
-    class="euiFormRow euiFormRow--fullWidth"
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
     id="some_html_id-row"
   >
     <div
@@ -61,7 +61,7 @@ exports[`<ForceMerge /> spec renders the component 1`] = `
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -88,18 +88,18 @@ exports[`<ForceMerge /> spec renders the component 1`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              class="euiComboBox"
+              class="euiComboBox euiComboBox--compressed"
               data-test-subj="sourceSelector"
               role="combobox"
             >
               <div
-                class="euiFormControlLayout"
+                class="euiFormControlLayout euiFormControlLayout--compressed"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <div
-                    class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                    class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                     data-test-subj="comboBoxInput"
                     tabindex="-1"
                   >
@@ -169,7 +169,7 @@ exports[`<ForceMerge /> spec renders the component 1`] = `
           >
             <button
               aria-label="drop down icon"
-              class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+              class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small"
               data-test-subj="advanceOptionToggle"
               type="button"
             >
@@ -202,7 +202,7 @@ exports[`<ForceMerge /> spec renders the component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButtonEmpty euiButtonEmpty--primary"
+        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
         data-test-subj="reindexCancelButton"
         type="button"
       >
@@ -221,7 +221,7 @@ exports[`<ForceMerge /> spec renders the component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButton euiButton--primary euiButton--fill"
+        class="euiButton euiButton--primary euiButton--small euiButton--fill"
         data-test-subj="forceMergeConfirmButton"
         type="button"
       >

--- a/public/pages/IndexDetail/containers/IndexDetail/IndexDetail.tsx
+++ b/public/pages/IndexDetail/containers/IndexDetail/IndexDetail.tsx
@@ -11,7 +11,7 @@ import {
   EuiDescriptionListDescription,
   EuiSpacer,
   EuiTitle,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiLink,
   EuiTabbedContentTab,
 } from "@elastic/eui";
@@ -168,7 +168,7 @@ export default function IndexDetail(props: IndexDetailModalProps) {
                   <EuiTitle size="s">
                     <span>Index mappings</span>
                   </EuiTitle>
-                  <EuiFormRow
+                  <EuiCompressedFormRow
                     fullWidth
                     helpText={
                       <>
@@ -187,7 +187,7 @@ export default function IndexDetail(props: IndexDetailModalProps) {
                     }
                   >
                     <></>
-                  </EuiFormRow>
+                  </EuiCompressedFormRow>
                 </>
               }
             >

--- a/public/pages/Indices/components/ApplyPolicyModal/ApplyPolicyModal.tsx
+++ b/public/pages/Indices/components/ApplyPolicyModal/ApplyPolicyModal.tsx
@@ -7,7 +7,7 @@ import React, { Component, Fragment } from "react";
 import _ from "lodash";
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
@@ -312,9 +312,9 @@ export default class ApplyPolicyModal extends Component<ApplyPolicyModalProps, A
           </EuiModalBody>
 
           <EuiModalFooter>
-            <EuiButtonEmpty onClick={onClose} data-test-subj="applyPolicyModalCloseButton">
+            <EuiSmallButtonEmpty onClick={onClose} data-test-subj="applyPolicyModalCloseButton">
               Cancel
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
 
             <EuiSmallButton onClick={this.onSubmit} fill data-test-subj="applyPolicyModalEditButton">
               Apply

--- a/public/pages/Indices/components/ApplyPolicyModal/ApplyPolicyModal.tsx
+++ b/public/pages/Indices/components/ApplyPolicyModal/ApplyPolicyModal.tsx
@@ -15,7 +15,7 @@ import {
   EuiModalHeaderTitle,
   EuiOverlayMask,
   EuiComboBox,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiFieldText,
   EuiCallOut,
   EuiText,
@@ -200,7 +200,7 @@ export default class ApplyPolicyModal extends Component<ApplyPolicyModalProps, A
 
     if (hasSingleIndexSelected) {
       return (
-        <EuiFormRow
+        <EuiCompressedFormRow
           label="Rollover alias"
           helpText={
             <EuiText size="xs" grow={false}>
@@ -223,7 +223,7 @@ export default class ApplyPolicyModal extends Component<ApplyPolicyModalProps, A
             onChange={this.onChangeRolloverAlias}
             fullWidth
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       );
     }
 
@@ -293,7 +293,7 @@ export default class ApplyPolicyModal extends Component<ApplyPolicyModalProps, A
               </p>
             </EuiText>
             <EuiSpacer size="m" />
-            <EuiFormRow label="Policy ID" isInvalid={hasSubmitted && !!selectedPolicyError} error={selectedPolicyError} fullWidth>
+            <EuiCompressedFormRow label="Policy ID" isInvalid={hasSubmitted && !!selectedPolicyError} error={selectedPolicyError} fullWidth>
               <EuiComboBox
                 placeholder="Search policies"
                 async
@@ -306,7 +306,7 @@ export default class ApplyPolicyModal extends Component<ApplyPolicyModalProps, A
                 onSearchChange={this.onPolicySearchChange}
                 fullWidth
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             {this.renderPreview()}
             {this.renderRollover()}
           </EuiModalBody>

--- a/public/pages/Indices/components/ApplyPolicyModal/ApplyPolicyModal.tsx
+++ b/public/pages/Indices/components/ApplyPolicyModal/ApplyPolicyModal.tsx
@@ -6,7 +6,7 @@
 import React, { Component, Fragment } from "react";
 import _ from "lodash";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiModal,
   EuiModalBody,
@@ -316,9 +316,9 @@ export default class ApplyPolicyModal extends Component<ApplyPolicyModalProps, A
               Cancel
             </EuiButtonEmpty>
 
-            <EuiButton onClick={this.onSubmit} fill data-test-subj="applyPolicyModalEditButton">
+            <EuiSmallButton onClick={this.onSubmit} fill data-test-subj="applyPolicyModalEditButton">
               Apply
-            </EuiButton>
+            </EuiSmallButton>
           </EuiModalFooter>
         </EuiModal>
       </EuiOverlayMask>

--- a/public/pages/Indices/components/ApplyPolicyModal/ApplyPolicyModal.tsx
+++ b/public/pages/Indices/components/ApplyPolicyModal/ApplyPolicyModal.tsx
@@ -16,7 +16,7 @@ import {
   EuiOverlayMask,
   EuiComboBox,
   EuiCompressedFormRow,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiCallOut,
   EuiText,
   EuiSpacer,
@@ -216,7 +216,7 @@ export default class ApplyPolicyModal extends Component<ApplyPolicyModalProps, A
           error={rolloverAliasError}
           fullWidth
         >
-          <EuiFieldText
+          <EuiCompressedFieldText
             isInvalid={hasSubmitted && !!rolloverAliasError}
             placeholder="Rollover alias"
             value={rolloverAlias}

--- a/public/pages/Indices/components/ApplyPolicyModal/ApplyPolicyModal.tsx
+++ b/public/pages/Indices/components/ApplyPolicyModal/ApplyPolicyModal.tsx
@@ -14,7 +14,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiOverlayMask,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiCompressedFormRow,
   EuiCompressedFieldText,
   EuiCallOut,
@@ -294,7 +294,7 @@ export default class ApplyPolicyModal extends Component<ApplyPolicyModalProps, A
             </EuiText>
             <EuiSpacer size="m" />
             <EuiCompressedFormRow label="Policy ID" isInvalid={hasSubmitted && !!selectedPolicyError} error={selectedPolicyError} fullWidth>
-              <EuiComboBox
+              <EuiCompressedComboBox
                 placeholder="Search policies"
                 async
                 options={policyOptions}

--- a/public/pages/Indices/components/ApplyPolicyModal/__snapshots__/ApplyPolicyModal.test.tsx.snap
+++ b/public/pages/Indices/components/ApplyPolicyModal/__snapshots__/ApplyPolicyModal.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`<ApplyPolicyModal /> spec renders the component 1`] = `
               class="euiSpacer euiSpacer--m"
             />
             <div
-              class="euiFormRow euiFormRow--fullWidth"
+              class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
@@ -74,17 +74,17 @@ exports[`<ApplyPolicyModal /> spec renders the component 1`] = `
                 <div
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  class="euiComboBox euiComboBox--fullWidth"
+                  class="euiComboBox euiComboBox--compressed euiComboBox--fullWidth"
                   role="combobox"
                 >
                   <div
-                    class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                    class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                   >
                     <div
                       class="euiFormControlLayout__childrenWrapper"
                     >
                       <div
-                        class="euiComboBox__inputWrap euiComboBox__inputWrap--fullWidth euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
+                        class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--fullWidth euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
                         data-test-subj="comboBoxInput"
                         tabindex="-1"
                       >
@@ -136,7 +136,7 @@ exports[`<ApplyPolicyModal /> spec renders the component 1`] = `
           class="euiModalFooter"
         >
           <button
-            class="euiButtonEmpty euiButtonEmpty--primary"
+            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
             data-test-subj="applyPolicyModalCloseButton"
             type="button"
           >
@@ -151,7 +151,7 @@ exports[`<ApplyPolicyModal /> spec renders the component 1`] = `
             </span>
           </button>
           <button
-            class="euiButton euiButton--primary euiButton--fill"
+            class="euiButton euiButton--primary euiButton--small euiButton--fill"
             data-test-subj="applyPolicyModalEditButton"
             type="button"
           >

--- a/public/pages/Indices/components/CloseIndexModal/CloseIndexModal.tsx
+++ b/public/pages/Indices/components/CloseIndexModal/CloseIndexModal.tsx
@@ -7,7 +7,7 @@ import React, { useEffect, useState } from "react";
 import {
   EuiSmallButton,
   EuiSmallButtonEmpty,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
@@ -65,7 +65,7 @@ export default function CloseIndexModal(props: CloseIndexModalProps) {
           <EuiText color="subdued">
             To confirm your action, type <b style={{ color: "#000" }}>close</b>.
           </EuiText>
-          <EuiFieldText placeholder="close" fullWidth value={value} onChange={(e) => setValue(e.target.value)} />
+          <EuiCompressedFieldText placeholder="close" fullWidth value={value} onChange={(e) => setValue(e.target.value)} />
         </div>
       </EuiModalBody>
 

--- a/public/pages/Indices/components/CloseIndexModal/CloseIndexModal.tsx
+++ b/public/pages/Indices/components/CloseIndexModal/CloseIndexModal.tsx
@@ -6,7 +6,7 @@
 import React, { useEffect, useState } from "react";
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFieldText,
   EuiModal,
   EuiModalBody,
@@ -70,9 +70,9 @@ export default function CloseIndexModal(props: CloseIndexModalProps) {
       </EuiModalBody>
 
       <EuiModalFooter>
-        <EuiButtonEmpty data-test-subj="Close Cancel button" onClick={onClose}>
+        <EuiSmallButtonEmpty data-test-subj="Close Cancel button" onClick={onClose}>
           Cancel
-        </EuiButtonEmpty>
+        </EuiSmallButtonEmpty>
         <EuiSmallButton data-test-subj="Close Confirm button" onClick={onConfirm} fill disabled={value !== "close"}>
           Close
         </EuiSmallButton>

--- a/public/pages/Indices/components/CloseIndexModal/CloseIndexModal.tsx
+++ b/public/pages/Indices/components/CloseIndexModal/CloseIndexModal.tsx
@@ -5,7 +5,7 @@
 
 import React, { useEffect, useState } from "react";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiFieldText,
   EuiModal,
@@ -73,9 +73,9 @@ export default function CloseIndexModal(props: CloseIndexModalProps) {
         <EuiButtonEmpty data-test-subj="Close Cancel button" onClick={onClose}>
           Cancel
         </EuiButtonEmpty>
-        <EuiButton data-test-subj="Close Confirm button" onClick={onConfirm} fill disabled={value !== "close"}>
+        <EuiSmallButton data-test-subj="Close Confirm button" onClick={onConfirm} fill disabled={value !== "close"}>
           Close
-        </EuiButton>
+        </EuiSmallButton>
       </EuiModalFooter>
     </EuiModal>
   );

--- a/public/pages/Indices/components/CloseIndexModal/__snapshots__/CloseIndexModal.test.tsx.snap
+++ b/public/pages/Indices/components/CloseIndexModal/__snapshots__/CloseIndexModal.test.tsx.snap
@@ -93,13 +93,13 @@ HTMLCollection [
                   </div>
                 </div>
                 <div
-                  class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                  class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <input
-                      class="euiFieldText euiFieldText--fullWidth"
+                      class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
                       placeholder="close"
                       type="text"
                       value=""
@@ -113,7 +113,7 @@ HTMLCollection [
             class="euiModalFooter"
           >
             <button
-              class="euiButtonEmpty euiButtonEmpty--primary"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
               data-test-subj="Close Cancel button"
               type="button"
             >
@@ -128,7 +128,7 @@ HTMLCollection [
               </span>
             </button>
             <button
-              class="euiButton euiButton--primary euiButton--fill euiButton-isDisabled"
+              class="euiButton euiButton--primary euiButton--small euiButton--fill euiButton-isDisabled"
               data-test-subj="Close Confirm button"
               disabled=""
               type="button"

--- a/public/pages/Indices/components/DeleteIndexModal/DeleteIndexModal.tsx
+++ b/public/pages/Indices/components/DeleteIndexModal/DeleteIndexModal.tsx
@@ -5,7 +5,7 @@
 
 import React, { useEffect, useState } from "react";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiCallOut,
   EuiFieldText,
@@ -73,9 +73,9 @@ export default function DeleteIndexModal(props: DeleteIndexModalProps) {
 
       <EuiModalFooter>
         <EuiButtonEmpty onClick={onClose}>Cancel</EuiButtonEmpty>
-        <EuiButton data-test-subj="Delete Confirm button" onClick={onConfirm} fill color="danger" disabled={value !== "delete"}>
+        <EuiSmallButton data-test-subj="Delete Confirm button" onClick={onConfirm} fill color="danger" disabled={value !== "delete"}>
           Delete
-        </EuiButton>
+        </EuiSmallButton>
       </EuiModalFooter>
     </EuiModal>
   );

--- a/public/pages/Indices/components/DeleteIndexModal/DeleteIndexModal.tsx
+++ b/public/pages/Indices/components/DeleteIndexModal/DeleteIndexModal.tsx
@@ -8,7 +8,7 @@ import {
   EuiSmallButton,
   EuiSmallButtonEmpty,
   EuiCallOut,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
@@ -67,7 +67,7 @@ export default function DeleteIndexModal(props: DeleteIndexModalProps) {
           <EuiText color="subdued">
             To confirm your action, type <b style={{ color: "#000" }}>delete</b>.
           </EuiText>
-          <EuiFieldText placeholder="delete" fullWidth value={value} onChange={(e) => setValue(e.target.value)} />
+          <EuiCompressedFieldText placeholder="delete" fullWidth value={value} onChange={(e) => setValue(e.target.value)} />
         </div>
       </EuiModalBody>
 

--- a/public/pages/Indices/components/DeleteIndexModal/DeleteIndexModal.tsx
+++ b/public/pages/Indices/components/DeleteIndexModal/DeleteIndexModal.tsx
@@ -6,7 +6,7 @@
 import React, { useEffect, useState } from "react";
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiCallOut,
   EuiFieldText,
   EuiModal,
@@ -72,7 +72,7 @@ export default function DeleteIndexModal(props: DeleteIndexModalProps) {
       </EuiModalBody>
 
       <EuiModalFooter>
-        <EuiButtonEmpty onClick={onClose}>Cancel</EuiButtonEmpty>
+        <EuiSmallButtonEmpty onClick={onClose}>Cancel</EuiSmallButtonEmpty>
         <EuiSmallButton data-test-subj="Delete Confirm button" onClick={onConfirm} fill color="danger" disabled={value !== "delete"}>
           Delete
         </EuiSmallButton>

--- a/public/pages/Indices/components/DeleteIndexModal/__snapshots__/DeleteIndexModal.test.tsx.snap
+++ b/public/pages/Indices/components/DeleteIndexModal/__snapshots__/DeleteIndexModal.test.tsx.snap
@@ -99,13 +99,13 @@ HTMLCollection [
                   </div>
                 </div>
                 <div
-                  class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                  class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <input
-                      class="euiFieldText euiFieldText--fullWidth"
+                      class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
                       placeholder="delete"
                       type="text"
                       value=""
@@ -119,7 +119,7 @@ HTMLCollection [
             class="euiModalFooter"
           >
             <button
-              class="euiButtonEmpty euiButtonEmpty--primary"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
               type="button"
             >
               <span
@@ -133,7 +133,7 @@ HTMLCollection [
               </span>
             </button>
             <button
-              class="euiButton euiButton--danger euiButton--fill euiButton-isDisabled"
+              class="euiButton euiButton--danger euiButton--small euiButton--fill euiButton-isDisabled"
               data-test-subj="Delete Confirm button"
               disabled=""
               type="button"

--- a/public/pages/Indices/components/IndexControls/IndexControls.tsx
+++ b/public/pages/Indices/components/IndexControls/IndexControls.tsx
@@ -13,7 +13,7 @@ import {
   EuiSpacer,
   EuiFlexItem,
   EuiSearchBar,
-  EuiSwitch,
+  EuiCompressedSwitch,
   EuiButtonEmpty,
 } from "@elastic/eui";
 import { DataStream, ManagedCatIndex } from "../../../../../server/models/interfaces";
@@ -106,8 +106,7 @@ export default class IndexControls extends Component<IndexControlsProps, IndexCo
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiSwitch
-            compressed
+          <EuiCompressedSwitch
             label="Show data stream indexes"
             checked={showDataStreams}
             onChange={toggleShowDataStreams}
@@ -126,7 +125,7 @@ export default class IndexControls extends Component<IndexControlsProps, IndexCo
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiSwitch
+          <EuiCompressedSwitch
             label="Show data stream indexes"
             checked={showDataStreams}
             onChange={toggleShowDataStreams}

--- a/public/pages/Indices/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
+++ b/public/pages/Indices/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`<IndexControls /> spec renders data streams selection field 1`] = `
     class="euiFlexItem euiFlexItem--flexGrowZero"
   >
     <div
-      class="euiSwitch euiSwitch--primary"
+      class="euiSwitch euiSwitch--primary euiSwitch--compressed"
     >
       <button
         aria-checked="true"
@@ -113,10 +113,7 @@ exports[`<IndexControls /> spec renders data streams selection field 1`] = `
           />
           <span
             class="euiSwitch__track"
-          >
-            EuiIconMock
-            EuiIconMock
-          </span>
+          />
         </span>
       </button>
       <span
@@ -186,7 +183,7 @@ exports[`<IndexControls /> spec renders the component 1`] = `
     class="euiFlexItem euiFlexItem--flexGrowZero"
   >
     <div
-      class="euiSwitch euiSwitch--primary"
+      class="euiSwitch euiSwitch--primary euiSwitch--compressed"
     >
       <button
         aria-checked="false"
@@ -205,10 +202,7 @@ exports[`<IndexControls /> spec renders the component 1`] = `
           />
           <span
             class="euiSwitch__track"
-          >
-            EuiIconMock
-            EuiIconMock
-          </span>
+          />
         </span>
       </button>
       <span

--- a/public/pages/Indices/components/IndexEmptyPrompt/IndexEmptyPrompt.tsx
+++ b/public/pages/Indices/components/IndexEmptyPrompt/IndexEmptyPrompt.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { EuiButton, EuiEmptyPrompt, EuiText } from "@elastic/eui";
+import { EuiSmallButton, EuiEmptyPrompt, EuiText } from "@elastic/eui";
 
 export const TEXT = {
   RESET_FILTERS: "There are no indices matching your applied filters. Reset your filters to view your indices.",
@@ -25,9 +25,9 @@ const getActions: React.SFC<IndexEmptyPromptProps> = ({ filterIsApplied, loading
 
   if (filterIsApplied) {
     return (
-      <EuiButton fill onClick={resetFilters} data-test-subj="indexEmptyPromptResetFilters">
+      <EuiSmallButton fill onClick={resetFilters} data-test-subj="indexEmptyPromptResetFilters">
         Reset Filters
-      </EuiButton>
+      </EuiSmallButton>
     );
   }
 
@@ -40,7 +40,7 @@ interface IndexEmptyPromptProps {
   resetFilters: () => void;
 }
 
-const IndexEmptyPrompt: React.SFC<IndexEmptyPromptProps> = props => (
+const IndexEmptyPrompt: React.SFC<IndexEmptyPromptProps> = (props) => (
   <EuiEmptyPrompt
     style={{ maxWidth: "45em" }}
     body={

--- a/public/pages/Indices/components/OpenIndexModal/OpenIndexModal.tsx
+++ b/public/pages/Indices/components/OpenIndexModal/OpenIndexModal.tsx
@@ -6,7 +6,7 @@
 import React from "react";
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
@@ -47,9 +47,9 @@ export default function OpenIndexModal(props: OpenIndexModalProps) {
       </EuiModalBody>
 
       <EuiModalFooter>
-        <EuiButtonEmpty data-test-subj="Open Cancel button" onClick={onClose}>
+        <EuiSmallButtonEmpty data-test-subj="Open Cancel button" onClick={onClose}>
           Cancel
-        </EuiButtonEmpty>
+        </EuiSmallButtonEmpty>
         <EuiSmallButton data-test-subj="Open Confirm button" onClick={onConfirm} fill>
           Open
         </EuiSmallButton>

--- a/public/pages/Indices/components/OpenIndexModal/OpenIndexModal.tsx
+++ b/public/pages/Indices/components/OpenIndexModal/OpenIndexModal.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiModal,
   EuiModalBody,
@@ -50,9 +50,9 @@ export default function OpenIndexModal(props: OpenIndexModalProps) {
         <EuiButtonEmpty data-test-subj="Open Cancel button" onClick={onClose}>
           Cancel
         </EuiButtonEmpty>
-        <EuiButton data-test-subj="Open Confirm button" onClick={onConfirm} fill>
+        <EuiSmallButton data-test-subj="Open Confirm button" onClick={onConfirm} fill>
           Open
-        </EuiButton>
+        </EuiSmallButton>
       </EuiModalFooter>
     </EuiModal>
   );

--- a/public/pages/Indices/components/OpenIndexModal/__snapshots__/OpenIndexModal.test.tsx.snap
+++ b/public/pages/Indices/components/OpenIndexModal/__snapshots__/OpenIndexModal.test.tsx.snap
@@ -67,7 +67,7 @@ HTMLCollection [
             class="euiModalFooter"
           >
             <button
-              class="euiButtonEmpty euiButtonEmpty--primary"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
               data-test-subj="Open Cancel button"
               type="button"
             >
@@ -82,7 +82,7 @@ HTMLCollection [
               </span>
             </button>
             <button
-              class="euiButton euiButton--primary euiButton--fill"
+              class="euiButton euiButton--primary euiButton--small euiButton--fill"
               data-test-subj="Open Confirm button"
               type="button"
             >

--- a/public/pages/Indices/containers/Indices/__snapshots__/Indices.test.tsx.snap
+++ b/public/pages/Indices/containers/Indices/__snapshots__/Indices.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`<Indices /> spec renders the component 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButton euiButton--primary"
+                class="euiButton euiButton--primary euiButton--small"
                 data-test-subj="RefreshButton"
                 type="button"
               >
@@ -67,7 +67,7 @@ exports[`<Indices /> spec renders the component 1`] = `
                   class="euiPopover__anchor"
                 >
                   <button
-                    class="euiButton euiButton--primary"
+                    class="euiButton euiButton--primary euiButton--small"
                     type="button"
                   >
                     <span
@@ -88,7 +88,7 @@ exports[`<Indices /> spec renders the component 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButton euiButton--primary euiButton--fill"
+                class="euiButton euiButton--primary euiButton--small euiButton--fill"
                 data-test-subj="Create IndexButton"
                 type="button"
               >
@@ -158,7 +158,7 @@ exports[`<Indices /> spec renders the component 1`] = `
         class="euiFlexItem euiFlexItem--flexGrowZero"
       >
         <div
-          class="euiSwitch euiSwitch--primary"
+          class="euiSwitch euiSwitch--primary euiSwitch--compressed"
         >
           <button
             aria-checked="false"
@@ -177,10 +177,7 @@ exports[`<Indices /> spec renders the component 1`] = `
               />
               <span
                 class="euiSwitch__track"
-              >
-                EuiIconMock
-                EuiIconMock
-              </span>
+              />
             </span>
           </button>
           <span

--- a/public/pages/Indices/containers/IndicesActions/__snapshots__/IndicesActions.test.tsx.snap
+++ b/public/pages/Indices/containers/IndicesActions/__snapshots__/IndicesActions.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`<IndicesActions /> spec Split index by calling commonService 1`] = `
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -36,7 +36,7 @@ exports[`<IndicesActions /> spec clear cache for all indexes failed if some inde
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -63,7 +63,7 @@ exports[`<IndicesActions /> spec clear cache for all indexes successfully by cal
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -90,7 +90,7 @@ exports[`<IndicesActions /> spec clear cache for mulitple indexes by calling com
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -117,7 +117,7 @@ exports[`<IndicesActions /> spec close index by calling commonService 1`] = `
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -144,7 +144,7 @@ exports[`<IndicesActions /> spec delete index by calling commonService 1`] = `
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -171,7 +171,7 @@ exports[`<IndicesActions /> spec filter indices failed when clearing caches for 
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -198,7 +198,7 @@ exports[`<IndicesActions /> spec filter some closed or blocked indices when clea
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -225,7 +225,7 @@ exports[`<IndicesActions /> spec open index by calling commonService 1`] = `
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -259,7 +259,7 @@ exports[`<IndicesActions /> spec refresh selected indexes by calling commonServi
         class="euiPopover__anchor"
       >
         <button
-          class="euiButton euiButton--primary"
+          class="euiButton euiButton--primary euiButton--small"
           type="button"
         >
           <span
@@ -377,7 +377,7 @@ exports[`<IndicesActions /> spec refresh selected indexes by calling commonServi
             class="euiModalFooter"
           >
             <button
-              class="euiButtonEmpty euiButtonEmpty--primary"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
               type="button"
             >
               <span
@@ -391,7 +391,7 @@ exports[`<IndicesActions /> spec refresh selected indexes by calling commonServi
               </span>
             </button>
             <button
-              class="euiButton euiButton--primary euiButton--fill"
+              class="euiButton euiButton--primary euiButton--small euiButton--fill"
               data-test-subj="refreshConfirmButton"
               type="button"
             >
@@ -434,7 +434,7 @@ HTMLCollection [
         class="euiPopover__anchor"
       >
         <button
-          class="euiButton euiButton--primary"
+          class="euiButton euiButton--primary euiButton--small"
           type="button"
         >
           <span
@@ -550,7 +550,7 @@ HTMLCollection [
             class="euiModalFooter"
           >
             <button
-              class="euiButtonEmpty euiButtonEmpty--primary"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
               data-test-subj="flushCancelButton"
               type="button"
             >
@@ -565,7 +565,7 @@ HTMLCollection [
               </span>
             </button>
             <button
-              class="euiButton euiButton--primary euiButton--fill"
+              class="euiButton euiButton--primary euiButton--small euiButton--fill"
               data-test-subj="flushConfirmButton"
               type="button"
             >
@@ -603,7 +603,7 @@ exports[`<IndicesActions /> spec renders the component and all the actions shoul
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -630,7 +630,7 @@ exports[`<IndicesActions /> spec shrink action is disabled if multiple indices a
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -657,7 +657,7 @@ exports[`<IndicesActions /> spec shrink action is disabled if the selected index
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -684,7 +684,7 @@ exports[`<IndicesActions /> spec shrink index by calling commonService 1`] = `
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -711,7 +711,7 @@ exports[`<IndicesActions /> spec split action is disabled if multiple indices ar
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -738,7 +738,7 @@ exports[`<IndicesActions /> spec split action is disabled if the selected index 
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -765,7 +765,7 @@ exports[`<IndicesActions /> spec unable to clear cache when clearing cache for a
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span

--- a/public/pages/Indices/containers/IndicesActions/index.tsx
+++ b/public/pages/Indices/containers/IndicesActions/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React, { useCallback, useContext, useMemo, useState } from "react";
-import { EuiButton, EuiContextMenu } from "@elastic/eui";
+import { EuiSmallButton, EuiContextMenu } from "@elastic/eui";
 
 import { ManagedCatIndex } from "../../../../../server/models/interfaces";
 import ApplyPolicyModal from "../../components/ApplyPolicyModal";
@@ -139,9 +139,9 @@ export default function IndicesActions(props: IndicesActionsProps) {
             data-test-subj="moreAction"
             panelPaddingSize="none"
             button={
-              <EuiButton iconType="arrowDown" iconSide="right" size={size}>
+              <EuiSmallButton iconType="arrowDown" iconSide="right">
                 Actions
-              </EuiButton>
+              </EuiSmallButton>
             }
           >
             <EuiContextMenu

--- a/public/pages/ManagedIndices/components/InfoModal/InfoModal.tsx
+++ b/public/pages/ManagedIndices/components/InfoModal/InfoModal.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
@@ -36,9 +36,9 @@ const InfoModal = ({ info, onClose }: InfoModalProps) => (
       </EuiModalBody>
 
       <EuiModalFooter>
-        <EuiButton fill onClick={onClose} data-test-subj="infoModalCloseButton">
+        <EuiSmallButton fill onClick={onClose} data-test-subj="infoModalCloseButton">
           Close
-        </EuiButton>
+        </EuiSmallButton>
       </EuiModalFooter>
     </EuiModal>
   </EuiOverlayMask>

--- a/public/pages/ManagedIndices/components/InfoModal/__snapshots__/InfoModal.test.tsx.snap
+++ b/public/pages/ManagedIndices/components/InfoModal/__snapshots__/InfoModal.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`<InfoModal /> spec renders the component 1`] = `
           class="euiModalFooter"
         >
           <button
-            class="euiButton euiButton--primary euiButton--fill"
+            class="euiButton euiButton--primary euiButton--small euiButton--fill"
             data-test-subj="infoModalCloseButton"
             type="button"
           >

--- a/public/pages/ManagedIndices/components/ManagedIndexControls/ManagedIndexControls.tsx
+++ b/public/pages/ManagedIndices/components/ManagedIndexControls/ManagedIndexControls.tsx
@@ -11,7 +11,7 @@ import {
   EuiFlexItem,
   EuiPagination,
   EuiSearchBar,
-  EuiSwitch,
+  EuiCompressedSwitch,
   EuiButton,
   EuiPopover,
   EuiContextMenuPanel,
@@ -102,8 +102,7 @@ export default class ManagedIndexControls extends Component<ManagedIndexControls
         </EuiFlexItem>
         <EuiFlexItem grow={false}>{Actions}</EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiSwitch
-            compressed
+          <EuiCompressedSwitch
             label="Show data stream indexes"
             checked={showDataStreams}
             onChange={toggleShowDataStreams}
@@ -122,7 +121,7 @@ export default class ManagedIndexControls extends Component<ManagedIndexControls
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiSwitch
+          <EuiCompressedSwitch
             label="Show data stream indexes"
             checked={showDataStreams}
             onChange={toggleShowDataStreams}

--- a/public/pages/ManagedIndices/components/ManagedIndexControls/__snapshots__/ManagedIndexControls.test.tsx.snap
+++ b/public/pages/ManagedIndices/components/ManagedIndexControls/__snapshots__/ManagedIndexControls.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`<ManagedIndexControls /> spec renders data streams selection field 1`] 
     class="euiFlexItem euiFlexItem--flexGrowZero"
   >
     <div
-      class="euiSwitch euiSwitch--primary"
+      class="euiSwitch euiSwitch--primary euiSwitch--compressed"
     >
       <button
         aria-checked="true"
@@ -102,10 +102,7 @@ exports[`<ManagedIndexControls /> spec renders data streams selection field 1`] 
           />
           <span
             class="euiSwitch__track"
-          >
-            EuiIconMock
-            EuiIconMock
-          </span>
+          />
         </span>
       </button>
       <span
@@ -175,7 +172,7 @@ exports[`<ManagedIndexControls /> spec renders the component 1`] = `
     class="euiFlexItem euiFlexItem--flexGrowZero"
   >
     <div
-      class="euiSwitch euiSwitch--primary"
+      class="euiSwitch euiSwitch--primary euiSwitch--compressed"
     >
       <button
         aria-checked="false"
@@ -194,10 +191,7 @@ exports[`<ManagedIndexControls /> spec renders the component 1`] = `
           />
           <span
             class="euiSwitch__track"
-          >
-            EuiIconMock
-            EuiIconMock
-          </span>
+          />
         </span>
       </button>
       <span

--- a/public/pages/ManagedIndices/components/ManagedIndexEmptyPrompt/ManagedIndexEmptyPrompt.tsx
+++ b/public/pages/ManagedIndices/components/ManagedIndexEmptyPrompt/ManagedIndexEmptyPrompt.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import * as H from "history";
-import { EuiButton, EuiEmptyPrompt, EuiText } from "@elastic/eui";
+import { EuiSmallButton, EuiEmptyPrompt, EuiText } from "@elastic/eui";
 import { ModalConsumer } from "../../../../components/Modal";
 import CreatePolicyModal from "../../../../components/CreatePolicyModal";
 import { ROUTES } from "../../../../utils/constants";
@@ -27,9 +27,9 @@ const getActions: React.SFC<ManagedIndexEmptyPromptProps> = ({ history, filterIs
 
   if (filterIsApplied) {
     return (
-      <EuiButton fill onClick={resetFilters} data-test-subj="managedIndexEmptyPromptResetFilters">
+      <EuiSmallButton fill onClick={resetFilters} data-test-subj="managedIndexEmptyPromptResetFilters">
         Reset Filters
-      </EuiButton>
+      </EuiSmallButton>
     );
   }
 
@@ -40,9 +40,9 @@ const getActions: React.SFC<ManagedIndexEmptyPromptProps> = ({ history, filterIs
   return (
     <ModalConsumer>
       {({ onShow }) => (
-        <EuiButton fill onClick={() => onShow(CreatePolicyModal, { history, onClickContinue: onClickCreate })}>
+        <EuiSmallButton fill onClick={() => onShow(CreatePolicyModal, { history, onClickContinue: onClickCreate })}>
           Create policy
-        </EuiButton>
+        </EuiSmallButton>
       )}
     </ModalConsumer>
   );

--- a/public/pages/ManagedIndices/components/ManagedIndexEmptyPrompt/__snapshots__/ManagedIndexEmptyPrompt.test.tsx.snap
+++ b/public/pages/ManagedIndices/components/ManagedIndexEmptyPrompt/__snapshots__/ManagedIndexEmptyPrompt.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`<ManagedIndexEmptyPrompt /> spec renders the component 1`] = `
     class="euiSpacer euiSpacer--l"
   />
   <button
-    class="euiButton euiButton--primary euiButton--fill"
+    class="euiButton euiButton--primary euiButton--small euiButton--fill"
     type="button"
   >
     <span

--- a/public/pages/ManagedIndices/components/RetryModal/RetryModal.tsx
+++ b/public/pages/ManagedIndices/components/RetryModal/RetryModal.tsx
@@ -14,7 +14,7 @@ import {
   EuiModalHeaderTitle,
   EuiOverlayMask,
   EuiRadioGroup,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiSpacer,
   EuiCompressedFormRow,
 } from "@elastic/eui";
@@ -143,7 +143,7 @@ export default class RetryModal extends Component<RetryModalProps, RetryModalSta
 
             <EuiSpacer size="s" />
             <EuiCompressedFormRow label="Start state" helpText="Only common states shared across all selected indexes are available">
-              <EuiSelect
+              <EuiCompressedSelect
                 disabled={radioIdSelected !== Radio.State}
                 options={stateOptions}
                 value={stateSelected}

--- a/public/pages/ManagedIndices/components/RetryModal/RetryModal.tsx
+++ b/public/pages/ManagedIndices/components/RetryModal/RetryModal.tsx
@@ -13,7 +13,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiOverlayMask,
-  EuiRadioGroup,
+  EuiCompressedRadioGroup,
   EuiCompressedSelect,
   EuiSpacer,
   EuiCompressedFormRow,
@@ -139,7 +139,7 @@ export default class RetryModal extends Component<RetryModalProps, RetryModalSta
           </EuiModalHeader>
 
           <EuiModalBody>
-            <EuiRadioGroup options={radioOptions} idSelected={radioIdSelected} onChange={this.onChange} />
+            <EuiCompressedRadioGroup options={radioOptions} idSelected={radioIdSelected} onChange={this.onChange} />
 
             <EuiSpacer size="s" />
             <EuiCompressedFormRow label="Start state" helpText="Only common states shared across all selected indexes are available">

--- a/public/pages/ManagedIndices/components/RetryModal/RetryModal.tsx
+++ b/public/pages/ManagedIndices/components/RetryModal/RetryModal.tsx
@@ -6,7 +6,7 @@
 import React, { Component } from "react";
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
@@ -154,9 +154,9 @@ export default class RetryModal extends Component<RetryModalProps, RetryModalSta
           </EuiModalBody>
 
           <EuiModalFooter>
-            <EuiButtonEmpty onClick={onClose} data-test-subj="retryModalCloseButton">
+            <EuiSmallButtonEmpty onClick={onClose} data-test-subj="retryModalCloseButton">
               Close
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
 
             <EuiSmallButton onClick={this.onRetry} disabled={!retryItems.length} fill data-test-subj="retryModalRetryButton">
               Retry

--- a/public/pages/ManagedIndices/components/RetryModal/RetryModal.tsx
+++ b/public/pages/ManagedIndices/components/RetryModal/RetryModal.tsx
@@ -5,7 +5,7 @@
 
 import React, { Component } from "react";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiModal,
   EuiModalBody,
@@ -158,9 +158,9 @@ export default class RetryModal extends Component<RetryModalProps, RetryModalSta
               Close
             </EuiButtonEmpty>
 
-            <EuiButton onClick={this.onRetry} disabled={!retryItems.length} fill data-test-subj="retryModalRetryButton">
+            <EuiSmallButton onClick={this.onRetry} disabled={!retryItems.length} fill data-test-subj="retryModalRetryButton">
               Retry
-            </EuiButton>
+            </EuiSmallButton>
           </EuiModalFooter>
         </EuiModal>
       </EuiOverlayMask>

--- a/public/pages/ManagedIndices/components/RetryModal/RetryModal.tsx
+++ b/public/pages/ManagedIndices/components/RetryModal/RetryModal.tsx
@@ -16,7 +16,7 @@ import {
   EuiRadioGroup,
   EuiSelect,
   EuiSpacer,
-  EuiFormRow,
+  EuiCompressedFormRow,
 } from "@elastic/eui";
 import { ManagedIndexItem, State } from "../../../../../models/interfaces";
 import { BrowserServices } from "../../../../models/interfaces";
@@ -142,7 +142,7 @@ export default class RetryModal extends Component<RetryModalProps, RetryModalSta
             <EuiRadioGroup options={radioOptions} idSelected={radioIdSelected} onChange={this.onChange} />
 
             <EuiSpacer size="s" />
-            <EuiFormRow label="Start state" helpText="Only common states shared across all selected indexes are available">
+            <EuiCompressedFormRow label="Start state" helpText="Only common states shared across all selected indexes are available">
               <EuiSelect
                 disabled={radioIdSelected !== Radio.State}
                 options={stateOptions}
@@ -150,7 +150,7 @@ export default class RetryModal extends Component<RetryModalProps, RetryModalSta
                 onChange={this.onSelectChange}
                 aria-label="Retry failed policy from"
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiModalBody>
 
           <EuiModalFooter>

--- a/public/pages/ManagedIndices/components/RetryModal/__snapshots__/RetryModal.test.tsx.snap
+++ b/public/pages/ManagedIndices/components/RetryModal/__snapshots__/RetryModal.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`<RetryModal /> spec renders the component 1`] = `
           >
             <div>
               <div
-                class="euiRadio euiRadioGroup__item"
+                class="euiRadio euiRadio--compressed euiRadioGroup__item"
               >
                 <input
                   checked=""
@@ -65,7 +65,7 @@ exports[`<RetryModal /> spec renders the component 1`] = `
                 </label>
               </div>
               <div
-                class="euiRadio euiRadioGroup__item"
+                class="euiRadio euiRadio--compressed euiRadioGroup__item"
               >
                 <input
                   class="euiRadio__input"
@@ -88,7 +88,7 @@ exports[`<RetryModal /> spec renders the component 1`] = `
               class="euiSpacer euiSpacer--s"
             />
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
@@ -105,7 +105,7 @@ exports[`<RetryModal /> spec renders the component 1`] = `
                 class="euiFormRow__fieldWrapper"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
@@ -113,7 +113,7 @@ exports[`<RetryModal /> spec renders the component 1`] = `
                     <select
                       aria-describedby="some_html_id-help-0"
                       aria-label="Retry failed policy from"
-                      class="euiSelect"
+                      class="euiSelect euiSelect--compressed"
                       disabled=""
                       id="some_html_id"
                     >
@@ -153,7 +153,7 @@ exports[`<RetryModal /> spec renders the component 1`] = `
           class="euiModalFooter"
         >
           <button
-            class="euiButtonEmpty euiButtonEmpty--primary"
+            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
             data-test-subj="retryModalCloseButton"
             type="button"
           >
@@ -168,7 +168,7 @@ exports[`<RetryModal /> spec renders the component 1`] = `
             </span>
           </button>
           <button
-            class="euiButton euiButton--primary euiButton--fill"
+            class="euiButton euiButton--primary euiButton--small euiButton--fill"
             data-test-subj="retryModalRetryButton"
             type="button"
           >

--- a/public/pages/ManagedIndices/components/RolloverAliasModal/RolloverAliasModal.tsx
+++ b/public/pages/ManagedIndices/components/RolloverAliasModal/RolloverAliasModal.tsx
@@ -14,7 +14,7 @@ import {
   EuiModalHeaderTitle,
   EuiOverlayMask,
   EuiCompressedFormRow,
-  EuiFieldText,
+  EuiCompressedFieldText,
 } from "@elastic/eui";
 import { BrowserServices } from "../../../../models/interfaces";
 import { getErrorMessage } from "../../../../utils/helpers";
@@ -78,7 +78,7 @@ export default class RolloverAliasModal extends Component<RolloverAliasModalProp
 
           <EuiModalBody>
             <EuiCompressedFormRow label="Rollover alias" helpText="A rollover alias is required when using the rollover action.">
-              <EuiFieldText placeholder="Rollover alias" value={rolloverAlias} onChange={this.onChange} />
+              <EuiCompressedFieldText placeholder="Rollover alias" value={rolloverAlias} onChange={this.onChange} />
             </EuiCompressedFormRow>
           </EuiModalBody>
 

--- a/public/pages/ManagedIndices/components/RolloverAliasModal/RolloverAliasModal.tsx
+++ b/public/pages/ManagedIndices/components/RolloverAliasModal/RolloverAliasModal.tsx
@@ -5,7 +5,7 @@
 
 import React, { Component } from "react";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiModal,
   EuiModalBody,
@@ -87,9 +87,14 @@ export default class RolloverAliasModal extends Component<RolloverAliasModalProp
               Close
             </EuiButtonEmpty>
 
-            <EuiButton onClick={this.onEditRolloverAlias} disabled={!rolloverAlias} fill data-test-subj="editRolloverAliasModalAddButton">
+            <EuiSmallButton
+              onClick={this.onEditRolloverAlias}
+              disabled={!rolloverAlias}
+              fill
+              data-test-subj="editRolloverAliasModalAddButton"
+            >
               Edit
-            </EuiButton>
+            </EuiSmallButton>
           </EuiModalFooter>
         </EuiModal>
       </EuiOverlayMask>

--- a/public/pages/ManagedIndices/components/RolloverAliasModal/RolloverAliasModal.tsx
+++ b/public/pages/ManagedIndices/components/RolloverAliasModal/RolloverAliasModal.tsx
@@ -13,7 +13,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiOverlayMask,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiFieldText,
 } from "@elastic/eui";
 import { BrowserServices } from "../../../../models/interfaces";
@@ -77,9 +77,9 @@ export default class RolloverAliasModal extends Component<RolloverAliasModalProp
           </EuiModalHeader>
 
           <EuiModalBody>
-            <EuiFormRow label="Rollover alias" helpText="A rollover alias is required when using the rollover action.">
+            <EuiCompressedFormRow label="Rollover alias" helpText="A rollover alias is required when using the rollover action.">
               <EuiFieldText placeholder="Rollover alias" value={rolloverAlias} onChange={this.onChange} />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiModalBody>
 
           <EuiModalFooter>

--- a/public/pages/ManagedIndices/components/RolloverAliasModal/RolloverAliasModal.tsx
+++ b/public/pages/ManagedIndices/components/RolloverAliasModal/RolloverAliasModal.tsx
@@ -6,7 +6,7 @@
 import React, { Component } from "react";
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
@@ -83,9 +83,9 @@ export default class RolloverAliasModal extends Component<RolloverAliasModalProp
           </EuiModalBody>
 
           <EuiModalFooter>
-            <EuiButtonEmpty onClick={onClose} data-test-subj="editRolloverAliasModalCloseButton">
+            <EuiSmallButtonEmpty onClick={onClose} data-test-subj="editRolloverAliasModalCloseButton">
               Close
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
 
             <EuiSmallButton
               onClick={this.onEditRolloverAlias}

--- a/public/pages/ManagedIndices/components/RolloverAliasModal/__snapshots__/RolloverAliasModal.test.tsx.snap
+++ b/public/pages/ManagedIndices/components/RolloverAliasModal/__snapshots__/RolloverAliasModal.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`<RolloverAliasModal /> spec renders the component 1`] = `
             class="euiModalBody__overflow"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
@@ -61,14 +61,14 @@ exports[`<RolloverAliasModal /> spec renders the component 1`] = `
                 class="euiFormRow__fieldWrapper"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <input
                       aria-describedby="some_html_id-help-0"
-                      class="euiFieldText"
+                      class="euiFieldText euiFieldText--compressed"
                       id="some_html_id"
                       placeholder="Rollover alias"
                       type="text"
@@ -90,7 +90,7 @@ exports[`<RolloverAliasModal /> spec renders the component 1`] = `
           class="euiModalFooter"
         >
           <button
-            class="euiButtonEmpty euiButtonEmpty--primary"
+            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
             data-test-subj="editRolloverAliasModalCloseButton"
             type="button"
           >
@@ -105,7 +105,7 @@ exports[`<RolloverAliasModal /> spec renders the component 1`] = `
             </span>
           </button>
           <button
-            class="euiButton euiButton--primary euiButton--fill euiButton-isDisabled"
+            class="euiButton euiButton--primary euiButton--small euiButton--fill euiButton-isDisabled"
             data-test-subj="editRolloverAliasModalAddButton"
             disabled=""
             type="button"

--- a/public/pages/ManagedIndices/containers/ManagedIndices/ManagedIndices.tsx
+++ b/public/pages/ManagedIndices/containers/ManagedIndices/ManagedIndices.tsx
@@ -548,16 +548,15 @@ export class ManagedIndices extends MDSEnabledComponent<ManagedIndicesProps, Man
     };
 
     const actionsButton = (
-      <EuiButton
+      <EuiSmallButton
         iconType="arrowDown"
         iconSide="right"
         disabled={!selectedItems.length}
         onClick={this.onActionButtonClick}
         data-test-subj="actionButton"
-        size="s"
       >
         Actions
-      </EuiButton>
+      </EuiSmallButton>
     );
 
     const popoverActionItems = [

--- a/public/pages/ManagedIndices/containers/ManagedIndices/ManagedIndices.tsx
+++ b/public/pages/ManagedIndices/containers/ManagedIndices/ManagedIndices.tsx
@@ -11,7 +11,7 @@ import {
   EuiLink,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiButton,
+  EuiSmallButton,
   EuiTitle,
   EuiSpacer,
   EuiTableFieldDataColumnType,
@@ -682,14 +682,14 @@ export class ManagedIndices extends MDSEnabledComponent<ManagedIndicesProps, Man
         <EuiFlexGroup alignItems="center">
           <EuiFlexItem></EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton iconType="refresh" onClick={this.getManagedIndices} data-test-subj="refreshButton">
+            <EuiSmallButton iconType="refresh" onClick={this.getManagedIndices} data-test-subj="refreshButton">
               Refresh
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton href={`${PLUGIN_NAME}#/change-policy`} data-test-subj="changePolicyButton">
+            <EuiSmallButton href={`${PLUGIN_NAME}#/change-policy`} data-test-subj="changePolicyButton">
               Change policy
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
 

--- a/public/pages/ManagedIndices/containers/ManagedIndices/__snapshots__/ManagedIndices.test.tsx.snap
+++ b/public/pages/ManagedIndices/containers/ManagedIndices/__snapshots__/ManagedIndices.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButton euiButton--primary"
+        class="euiButton euiButton--primary euiButton--small"
         data-test-subj="refreshButton"
         type="button"
       >
@@ -34,7 +34,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <a
-        class="euiButton euiButton--primary"
+        class="euiButton euiButton--primary euiButton--small"
         data-test-subj="changePolicyButton"
         href="opensearch_index_management_dashboards#/change-policy"
         rel="noreferrer"
@@ -93,7 +93,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
                 class="euiFlexItem euiFlexItem--flexGrowZero"
               >
                 <button
-                  class="euiButton euiButton--primary euiButton-isDisabled"
+                  class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
                   data-test-subj="Edit rollover aliasButton"
                   disabled=""
                   type="button"
@@ -113,7 +113,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
                 class="euiFlexItem euiFlexItem--flexGrowZero"
               >
                 <button
-                  class="euiButton euiButton--primary euiButton-isDisabled"
+                  class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
                   data-test-subj="Remove policyButton"
                   disabled=""
                   type="button"
@@ -133,7 +133,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
                 class="euiFlexItem euiFlexItem--flexGrowZero"
               >
                 <button
-                  class="euiButton euiButton--primary euiButton-isDisabled"
+                  class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
                   data-test-subj="Retry policyButton"
                   disabled=""
                   type="button"
@@ -204,7 +204,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
           class="euiFlexItem euiFlexItem--flexGrowZero"
         >
           <div
-            class="euiSwitch euiSwitch--primary"
+            class="euiSwitch euiSwitch--primary euiSwitch--compressed"
           >
             <button
               aria-checked="false"
@@ -223,10 +223,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
                 />
                 <span
                   class="euiSwitch__track"
-                >
-                  EuiIconMock
-                  EuiIconMock
-                </span>
+                />
               </span>
             </button>
             <span

--- a/public/pages/Notifications/containers/Notifications/Notifications.tsx
+++ b/public/pages/Notifications/containers/Notifications/Notifications.tsx
@@ -5,7 +5,7 @@
 
 import React, { ReactChild, useContext, useEffect, useRef, useState } from "react";
 import { unstable_batchedUpdates } from "react-dom";
-import { EuiButton, EuiCallOut, EuiEmptyPrompt, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer, EuiText, EuiTitle } from "@elastic/eui";
+import { EuiSmallButton, EuiCallOut, EuiEmptyPrompt, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer, EuiText, EuiTitle } from "@elastic/eui";
 import { get } from "lodash";
 import { CoreStart } from "opensearch-dashboards/public";
 import useField from "../../../../lib/field";
@@ -216,9 +216,9 @@ const Notifications = (props: NotificationsProps) => {
               </CustomFormRow>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton iconType="popout" href="notifications-dashboards#/channels" target="_blank">
+              <EuiSmallButton iconType="popout" href="notifications-dashboards#/channels" target="_blank">
                 Manage channels
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
           <EuiSpacer />

--- a/public/pages/Notifications/containers/Notifications/__snapshots__/Notifications.test.tsx.snap
+++ b/public/pages/Notifications/containers/Notifications/__snapshots__/Notifications.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`<Notifications /> spec View without permission 1`] = `
         Notification settings
       </h1>
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -33,7 +33,7 @@ exports[`<Notifications /> spec View without permission 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <a
-        class="euiButton euiButton--primary"
+        class="euiButton euiButton--primary euiButton--small"
         href="notifications-dashboards#/channels"
         rel="noopener noreferrer"
         target="_blank"
@@ -102,7 +102,7 @@ exports[`<Notifications /> spec renders 1`] = `
         Notification settings
       </h1>
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -121,7 +121,7 @@ exports[`<Notifications /> spec renders 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <a
-        class="euiButton euiButton--primary"
+        class="euiButton euiButton--primary euiButton--small"
         href="notifications-dashboards#/channels"
         rel="noopener noreferrer"
         target="_blank"
@@ -189,14 +189,14 @@ exports[`<Notifications /> spec renders 1`] = `
           class="euiFlexItem euiDescribedFormGroup__fields euiDescribedFormGroup__fieldPadding--xsmall"
         >
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             id="some_html_id-row"
           >
             <div
               class="euiFormRow__fieldWrapper"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -222,7 +222,7 @@ exports[`<Notifications /> spec renders 1`] = `
                         class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
                       >
                         <div
-                          class="euiCheckbox"
+                          class="euiCheckbox euiCheckbox--compressed"
                         >
                           <input
                             class="euiCheckbox__input"
@@ -249,7 +249,7 @@ exports[`<Notifications /> spec renders 1`] = `
                         class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
                       >
                         <div
-                          class="euiCheckbox"
+                          class="euiCheckbox euiCheckbox--compressed"
                         >
                           <input
                             class="euiCheckbox__input"
@@ -311,14 +311,14 @@ exports[`<Notifications /> spec renders 1`] = `
           class="euiFlexItem euiDescribedFormGroup__fields euiDescribedFormGroup__fieldPadding--xsmall"
         >
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             id="some_html_id-row"
           >
             <div
               class="euiFormRow__fieldWrapper"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -344,7 +344,7 @@ exports[`<Notifications /> spec renders 1`] = `
                         class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
                       >
                         <div
-                          class="euiCheckbox"
+                          class="euiCheckbox euiCheckbox--compressed"
                         >
                           <input
                             class="euiCheckbox__input"
@@ -371,7 +371,7 @@ exports[`<Notifications /> spec renders 1`] = `
                         class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
                       >
                         <div
-                          class="euiCheckbox"
+                          class="euiCheckbox euiCheckbox--compressed"
                         >
                           <input
                             class="euiCheckbox__input"
@@ -433,14 +433,14 @@ exports[`<Notifications /> spec renders 1`] = `
           class="euiFlexItem euiDescribedFormGroup__fields euiDescribedFormGroup__fieldPadding--xsmall"
         >
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             id="some_html_id-row"
           >
             <div
               class="euiFormRow__fieldWrapper"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -466,7 +466,7 @@ exports[`<Notifications /> spec renders 1`] = `
                         class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
                       >
                         <div
-                          class="euiCheckbox"
+                          class="euiCheckbox euiCheckbox--compressed"
                         >
                           <input
                             class="euiCheckbox__input"
@@ -493,7 +493,7 @@ exports[`<Notifications /> spec renders 1`] = `
                         class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
                       >
                         <div
-                          class="euiCheckbox"
+                          class="euiCheckbox euiCheckbox--compressed"
                         >
                           <input
                             class="euiCheckbox__input"
@@ -555,14 +555,14 @@ exports[`<Notifications /> spec renders 1`] = `
           class="euiFlexItem euiDescribedFormGroup__fields euiDescribedFormGroup__fieldPadding--xsmall"
         >
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             id="some_html_id-row"
           >
             <div
               class="euiFormRow__fieldWrapper"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -588,7 +588,7 @@ exports[`<Notifications /> spec renders 1`] = `
                         class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
                       >
                         <div
-                          class="euiCheckbox"
+                          class="euiCheckbox euiCheckbox--compressed"
                         >
                           <input
                             class="euiCheckbox__input"
@@ -615,7 +615,7 @@ exports[`<Notifications /> spec renders 1`] = `
                         class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
                       >
                         <div
-                          class="euiCheckbox"
+                          class="euiCheckbox euiCheckbox--compressed"
                         >
                           <input
                             class="euiCheckbox__input"

--- a/public/pages/Policies/components/PolicyControls/PolicyControls.tsx
+++ b/public/pages/Policies/components/PolicyControls/PolicyControls.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { Component } from "react";
-import { EuiFieldSearch, EuiFlexGroup, EuiFlexItem, EuiPagination } from "@elastic/eui";
+import { EuiCompressedFieldSearch, EuiFlexGroup, EuiFlexItem, EuiPagination } from "@elastic/eui";
 
 interface PolicyControlsProps {
   activePage: number;
@@ -35,7 +35,7 @@ export default class PolicyControls extends Component<PolicyControlsProps, Polic
     return (
       <EuiFlexGroup style={{ padding: "0px 5px" }}>
         <EuiFlexItem>
-          <EuiFieldSearch fullWidth={true} value={search} placeholder="Search" onChange={onSearchChange} />
+          <EuiCompressedFieldSearch fullWidth={true} value={search} placeholder="Search" onChange={onSearchChange} />
         </EuiFlexItem>
         {pageCount > 1 && (
           <EuiFlexItem grow={false} style={{ justifyContent: "center" }}>

--- a/public/pages/Policies/components/PolicyControls/__snapshots__/PolicyControls.test.tsx.snap
+++ b/public/pages/Policies/components/PolicyControls/__snapshots__/PolicyControls.test.tsx.snap
@@ -9,13 +9,13 @@ exports[`<PolicyControls /> spec renders the component 1`] = `
     class="euiFlexItem"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <input
-          class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
+          class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch-isClearable"
           placeholder="Search"
           type="search"
           value="testing"
@@ -34,7 +34,7 @@ exports[`<PolicyControls /> spec renders the component 1`] = `
         >
           <button
             aria-label="Clear input"
-            class="euiFormControlLayoutClearButton"
+            class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
             type="button"
           >
             EuiIconMock

--- a/public/pages/Policies/components/PolicyEmptyPrompt/PolicyEmptyPrompt.tsx
+++ b/public/pages/Policies/components/PolicyEmptyPrompt/PolicyEmptyPrompt.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { EuiButton, EuiEmptyPrompt, EuiText } from "@elastic/eui";
+import { EuiSmallButton, EuiEmptyPrompt, EuiText } from "@elastic/eui";
 import { ROUTES } from "../../../../utils/constants";
 import { ModalConsumer } from "../../../../components/Modal";
 import CreatePolicyModal from "../../../../components/CreatePolicyModal";
@@ -27,9 +27,9 @@ const getActions: React.SFC<PolicyEmptyPromptProps> = ({ history, filterIsApplie
   }
   if (filterIsApplied) {
     return (
-      <EuiButton fill onClick={resetFilters} data-test-subj="policyEmptyPromptRestFilters">
+      <EuiSmallButton fill onClick={resetFilters} data-test-subj="policyEmptyPromptRestFilters">
         Reset Filters
-      </EuiButton>
+      </EuiSmallButton>
     );
   }
 
@@ -40,9 +40,9 @@ const getActions: React.SFC<PolicyEmptyPromptProps> = ({ history, filterIsApplie
   return (
     <ModalConsumer>
       {({ onShow }) => (
-        <EuiButton fill onClick={() => onShow(CreatePolicyModal, { history, onClickContinue: onClickCreate })}>
+        <EuiSmallButton fill onClick={() => onShow(CreatePolicyModal, { history, onClickContinue: onClickCreate })}>
           Create policy
-        </EuiButton>
+        </EuiSmallButton>
       )}
     </ModalConsumer>
   );

--- a/public/pages/Policies/components/PolicyEmptyPrompt/__snapshots__/PolicyEmptyPrompt.test.tsx.snap
+++ b/public/pages/Policies/components/PolicyEmptyPrompt/__snapshots__/PolicyEmptyPrompt.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`<PolicyEmptyPrompt /> spec renders the component 1`] = `
     class="euiSpacer euiSpacer--l"
   />
   <button
-    class="euiButton euiButton--primary euiButton--fill"
+    class="euiButton euiButton--primary euiButton--small euiButton--fill"
     type="button"
   >
     <span

--- a/public/pages/Policies/containers/Policies/Policies.tsx
+++ b/public/pages/Policies/containers/Policies/Policies.tsx
@@ -18,7 +18,7 @@ import {
   // @ts-ignore
   Pagination,
   EuiTableSelectionType,
-  EuiButton,
+  EuiSmallButton,
   EuiContextMenuItem,
   EuiTextColor,
   EuiFlexGroup,
@@ -432,16 +432,15 @@ export class Policies extends MDSEnabledComponent<PoliciesProps, PoliciesState> 
     };
 
     const actionsButton = (
-      <EuiButton
+      <EuiSmallButton
         iconType="arrowDown"
         iconSide="right"
         disabled={!selectedItems.length}
         onClick={this.onActionButtonClick}
         data-test-subj="actionButton"
-        size="s"
       >
         Actions
-      </EuiButton>
+      </EuiSmallButton>
     );
 
     const popoverItems = [

--- a/public/pages/Policies/containers/Policies/__snapshots__/Policies.test.tsx.snap
+++ b/public/pages/Policies/containers/Policies/__snapshots__/Policies.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`<IndexPolicies /> spec renders the component 1`] = `
                 class="euiFlexItem euiFlexItem--flexGrowZero"
               >
                 <button
-                  class="euiButton euiButton--primary euiButton-isDisabled"
+                  class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
                   data-test-subj="DeleteButton"
                   disabled=""
                   type="button"
@@ -63,7 +63,7 @@ exports[`<IndexPolicies /> spec renders the component 1`] = `
                 class="euiFlexItem euiFlexItem--flexGrowZero"
               >
                 <button
-                  class="euiButton euiButton--primary euiButton-isDisabled"
+                  class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
                   data-test-subj="EditButton"
                   disabled=""
                   type="button"
@@ -83,7 +83,7 @@ exports[`<IndexPolicies /> spec renders the component 1`] = `
                 class="euiFlexItem euiFlexItem--flexGrowZero"
               >
                 <button
-                  class="euiButton euiButton--primary"
+                  class="euiButton euiButton--primary euiButton--small"
                   data-test-subj="Create policyButton"
                   type="button"
                 >
@@ -117,13 +117,13 @@ exports[`<IndexPolicies /> spec renders the component 1`] = `
           class="euiFlexItem"
         >
           <div
-            class="euiFormControlLayout euiFormControlLayout--fullWidth"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <input
-                class="euiFieldSearch euiFieldSearch--fullWidth"
+                class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
                 placeholder="Search"
                 type="search"
                 value=""

--- a/public/pages/PolicyDetails/components/DeleteModal/DeleteModal.tsx
+++ b/public/pages/PolicyDetails/components/DeleteModal/DeleteModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, Component, Fragment } from "react";
-import { EuiConfirmModal, EuiForm, EuiCompressedFormRow, EuiFieldText, EuiOverlayMask, EuiSpacer } from "@elastic/eui";
+import { EuiConfirmModal, EuiForm, EuiCompressedFormRow, EuiCompressedFieldText, EuiOverlayMask, EuiSpacer } from "@elastic/eui";
 
 interface DeleteModalProps {
   policyId: string;
@@ -45,7 +45,12 @@ export default class DeleteModal extends Component<DeleteModalProps, DeleteModal
             </Fragment>
             <EuiSpacer size="s" />
             <EuiCompressedFormRow helpText={`To confirm deletion, type "delete".`}>
-              <EuiFieldText value={confirmDeleteText} placeholder="delete" onChange={this.onChange} data-test-subj="deleteTextField" />
+              <EuiCompressedFieldText
+                value={confirmDeleteText}
+                placeholder="delete"
+                onChange={this.onChange}
+                data-test-subj="deleteTextField"
+              />
             </EuiCompressedFormRow>
           </EuiForm>
         </EuiConfirmModal>

--- a/public/pages/PolicyDetails/components/DeleteModal/DeleteModal.tsx
+++ b/public/pages/PolicyDetails/components/DeleteModal/DeleteModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, Component, Fragment } from "react";
-import { EuiConfirmModal, EuiForm, EuiFormRow, EuiFieldText, EuiOverlayMask, EuiSpacer } from "@elastic/eui";
+import { EuiConfirmModal, EuiForm, EuiCompressedFormRow, EuiFieldText, EuiOverlayMask, EuiSpacer } from "@elastic/eui";
 
 interface DeleteModalProps {
   policyId: string;
@@ -44,9 +44,9 @@ export default class DeleteModal extends Component<DeleteModalProps, DeleteModal
               Delete "<strong>{policyId}</strong>" permanently? Indices will no longer be managed using this policy.
             </Fragment>
             <EuiSpacer size="s" />
-            <EuiFormRow helpText={`To confirm deletion, type "delete".`}>
+            <EuiCompressedFormRow helpText={`To confirm deletion, type "delete".`}>
               <EuiFieldText value={confirmDeleteText} placeholder="delete" onChange={this.onChange} data-test-subj="deleteTextField" />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiForm>
         </EuiConfirmModal>
       </EuiOverlayMask>

--- a/public/pages/PolicyDetails/components/DeleteModal/__snapshots__/DeleteModal.test.tsx.snap
+++ b/public/pages/PolicyDetails/components/DeleteModal/__snapshots__/DeleteModal.test.tsx.snap
@@ -72,21 +72,21 @@ exports[`<DeleteModal /> spec renders the component 1`] = `
                     class="euiSpacer euiSpacer--s"
                   />
                   <div
-                    class="euiFormRow"
+                    class="euiFormRow euiFormRow--compressed"
                     id="some_html_id-row"
                   >
                     <div
                       class="euiFormRow__fieldWrapper"
                     >
                       <div
-                        class="euiFormControlLayout"
+                        class="euiFormControlLayout euiFormControlLayout--compressed"
                       >
                         <div
                           class="euiFormControlLayout__childrenWrapper"
                         >
                           <input
                             aria-describedby="some_html_id-help-0"
-                            class="euiFieldText"
+                            class="euiFieldText euiFieldText--compressed"
                             data-test-subj="deleteTextField"
                             id="some_html_id"
                             placeholder="delete"

--- a/public/pages/PolicyDetails/containers/PolicyDetails/PolicyDetails.tsx
+++ b/public/pages/PolicyDetails/containers/PolicyDetails/PolicyDetails.tsx
@@ -9,7 +9,7 @@ import {
   EuiTitle,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiButton,
+  EuiSmallButton,
   EuiLoadingSpinner,
   EuiBasicTable,
   EuiTableFieldDataColumnType,
@@ -288,24 +288,24 @@ export class PolicyDetails extends Component<PolicyDetailsProps, PolicyDetailsSt
                   <EuiFlexItem grow={false}>
                     <ModalConsumer>
                       {({ onShow }) => (
-                        <EuiButton
+                        <EuiSmallButton
                           onClick={() => onShow(CreatePolicyModal, { isEdit: true, onClickContinue: this.onEdit })}
                           data-test-subj="policy-details-edit-button"
                         >
                           Edit
-                        </EuiButton>
+                        </EuiSmallButton>
                       )}
                     </ModalConsumer>
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
-                    <EuiButton onClick={this.showDeleteModal} color="danger" data-test-subj="deleteButton">
+                    <EuiSmallButton onClick={this.showDeleteModal} color="danger" data-test-subj="deleteButton">
                       Delete
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                   <EuiFlexItem>
-                    <EuiButton onClick={this.showJSONModal} data-test-subj="viewButton">
+                    <EuiSmallButton onClick={this.showJSONModal} data-test-subj="viewButton">
                       View JSON
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                 </EuiFlexGroup>
               </EuiFlexItem>

--- a/public/pages/Reindex/components/CreateIndexFlyout/__snapshots__/CreateIndexFlyout.test.tsx.snap
+++ b/public/pages/Reindex/components/CreateIndexFlyout/__snapshots__/CreateIndexFlyout.test.tsx.snap
@@ -84,7 +84,7 @@ Object {
                       class="euiForm"
                     >
                       <div
-                        class="euiFormRow"
+                        class="euiFormRow euiFormRow--compressed"
                         data-test-subj="form-name-index"
                         id="some_html_id-row"
                       >
@@ -106,13 +106,13 @@ Object {
                             class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
                           >
                             <div
-                              class="euiFormControlLayout"
+                              class="euiFormControlLayout euiFormControlLayout--compressed"
                             >
                               <div
                                 class="euiFormControlLayout__childrenWrapper"
                               >
                                 <input
-                                  class="euiFieldText"
+                                  class="euiFieldText euiFieldText--compressed"
                                   placeholder="Specify a name for the new index."
                                   type="text"
                                   value=""
@@ -131,7 +131,7 @@ Object {
                         </div>
                       </div>
                       <div
-                        class="euiFormRow euiFormRow--fullWidth"
+                        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                         data-test-subj="form-name-templateMessage"
                         id="some_html_id-row"
                       >
@@ -140,7 +140,7 @@ Object {
                         />
                       </div>
                       <div
-                        class="euiFormRow"
+                        class="euiFormRow euiFormRow--compressed"
                         data-test-subj="form-name-aliases"
                         id="some_html_id-row"
                       >
@@ -173,17 +173,17 @@ Object {
                             <div
                               aria-expanded="false"
                               aria-haspopup="listbox"
-                              class="euiComboBox"
+                              class="euiComboBox euiComboBox--compressed"
                               role="combobox"
                             >
                               <div
-                                class="euiFormControlLayout"
+                                class="euiFormControlLayout euiFormControlLayout--compressed"
                               >
                                 <div
                                   class="euiFormControlLayout__childrenWrapper"
                                 >
                                   <div
-                                    class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                                    class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                                     data-test-subj="comboBoxInput"
                                     tabindex="-1"
                                   >
@@ -266,7 +266,7 @@ Object {
                       class="euiForm"
                     >
                       <div
-                        class="euiFormRow"
+                        class="euiFormRow euiFormRow--compressed"
                         data-test-subj="form-name-index.number_of_shards"
                         id="some_html_id-row"
                       >
@@ -299,13 +299,13 @@ Object {
                             class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
                           >
                             <div
-                              class="euiFormControlLayout"
+                              class="euiFormControlLayout euiFormControlLayout--compressed"
                             >
                               <div
                                 class="euiFormControlLayout__childrenWrapper"
                               >
                                 <input
-                                  class="euiFieldNumber"
+                                  class="euiFieldNumber euiFieldNumber--compressed"
                                   placeholder="Specify primary shard count."
                                   type="number"
                                   value="1"
@@ -316,7 +316,7 @@ Object {
                         </div>
                       </div>
                       <div
-                        class="euiFormRow"
+                        class="euiFormRow euiFormRow--compressed"
                         data-test-subj="form-name-index.number_of_replicas"
                         id="some_html_id-row"
                       >
@@ -344,13 +344,13 @@ Object {
                             class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
                           >
                             <div
-                              class="euiFormControlLayout"
+                              class="euiFormControlLayout euiFormControlLayout--compressed"
                             >
                               <div
                                 class="euiFormControlLayout__childrenWrapper"
                               >
                                 <input
-                                  class="euiFieldNumber"
+                                  class="euiFieldNumber euiFieldNumber--compressed"
                                   placeholder="Specify number of replicas."
                                   type="number"
                                   value="1"
@@ -361,7 +361,7 @@ Object {
                         </div>
                       </div>
                       <div
-                        class="euiFormRow"
+                        class="euiFormRow euiFormRow--compressed"
                         data-test-subj="form-name-index.refresh_interval"
                         id="some_html_id-row"
                       >
@@ -389,13 +389,13 @@ Object {
                             class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
                           >
                             <div
-                              class="euiFormControlLayout"
+                              class="euiFormControlLayout euiFormControlLayout--compressed"
                             >
                               <div
                                 class="euiFormControlLayout__childrenWrapper"
                               >
                                 <input
-                                  class="euiFieldText"
+                                  class="euiFieldText euiFieldText--compressed"
                                   placeholder="Can be set to -1 to disable refreshing."
                                   type="text"
                                   value="1s"
@@ -451,7 +451,7 @@ Object {
                                 class="euiSpacer euiSpacer--s"
                               />
                               <div
-                                class="euiFormRow euiFormRow--fullWidth"
+                                class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                                 data-test-subj="formNameAdvancedSettings"
                                 id="some_html_id-row"
                               >
@@ -664,7 +664,7 @@ Object {
                         </i>
                       </div>
                       <div
-                        class="euiFormRow euiFormRow--fullWidth"
+                        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                         id="some_html_id-row"
                       >
                         <div
@@ -707,7 +707,7 @@ Object {
                     style="padding: 0px 10px;"
                   >
                     <div
-                      class="euiFormRow euiFormRow--fullWidth"
+                      class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                       id="some_html_id-row"
                     >
                       <div
@@ -787,7 +787,7 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <button
-                          class="euiButton euiButton--primary"
+                          class="euiButton euiButton--primary euiButton--small"
                           data-test-subj="createIndexAddFieldButton"
                           style="margin-right: 8px;"
                           type="button"
@@ -803,7 +803,7 @@ Object {
                           </span>
                         </button>
                         <button
-                          class="euiButton euiButton--primary"
+                          class="euiButton euiButton--primary euiButton--small"
                           data-test-subj="createIndexAddObjectFieldButton"
                           type="button"
                         >
@@ -834,7 +834,7 @@ Object {
                 class="euiFlexItem euiFlexItem--flexGrowZero"
               >
                 <button
-                  class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--flushLeft"
+                  class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiButtonEmpty--flushLeft"
                   data-test-subj="flyout-footer-cancel-button"
                   type="button"
                 >
@@ -853,7 +853,7 @@ Object {
                 class="euiFlexItem euiFlexItem--flexGrowZero"
               >
                 <button
-                  class="euiButton euiButton--primary euiButton--fill"
+                  class="euiButton euiButton--primary euiButton--small euiButton--fill"
                   data-test-subj="flyout-footer-action-button"
                   type="button"
                 >

--- a/public/pages/Reindex/components/IndexSelect/__snapshots__/IndexSelect.test.tsx.snap
+++ b/public/pages/Reindex/components/IndexSelect/__snapshots__/IndexSelect.test.tsx.snap
@@ -9,17 +9,17 @@ Object {
         <div
           aria-expanded="false"
           aria-haspopup="listbox"
-          class="euiComboBox"
+          class="euiComboBox euiComboBox--compressed"
           role="combobox"
         >
           <div
-            class="euiFormControlLayout"
+            class="euiFormControlLayout euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <div
-                class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                 data-test-subj="comboBoxInput"
                 tabindex="-1"
               >
@@ -49,7 +49,7 @@ Object {
               >
                 <button
                   aria-label="Clear input"
-                  class="euiFormControlLayoutClearButton"
+                  class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                   data-test-subj="comboBoxClearButton"
                   type="button"
                 >
@@ -75,17 +75,17 @@ Object {
       <div
         aria-expanded="false"
         aria-haspopup="listbox"
-        class="euiComboBox"
+        class="euiComboBox euiComboBox--compressed"
         role="combobox"
       >
         <div
-          class="euiFormControlLayout"
+          class="euiFormControlLayout euiFormControlLayout--compressed"
         >
           <div
             class="euiFormControlLayout__childrenWrapper"
           >
             <div
-              class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+              class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
               data-test-subj="comboBoxInput"
               tabindex="-1"
             >
@@ -115,7 +115,7 @@ Object {
             >
               <button
                 aria-label="Clear input"
-                class="euiFormControlLayoutClearButton"
+                class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                 data-test-subj="comboBoxClearButton"
                 type="button"
               >

--- a/public/pages/Reindex/components/ReindexAdvancedOptions/ReindexAdvancedOptions.tsx
+++ b/public/pages/Reindex/components/ReindexAdvancedOptions/ReindexAdvancedOptions.tsx
@@ -11,7 +11,7 @@ import {
   EuiComboBoxOptionOption,
   EuiCompressedFieldNumber,
   EuiLink,
-  EuiRadioGroup,
+  EuiCompressedRadioGroup,
   EuiSpacer,
 } from "@elastic/eui";
 import { CoreServicesContext } from "../../../../components/core_services";
@@ -123,7 +123,7 @@ const ReindexAdvancedOptions = (props: ReindexOptionsProps) => {
           {sliceEnabled ? (
             <>
               <EuiSpacer />
-              <EuiRadioGroup
+              <EuiCompressedRadioGroup
                 options={[
                   {
                     id: "auto",

--- a/public/pages/Reindex/components/ReindexAdvancedOptions/ReindexAdvancedOptions.tsx
+++ b/public/pages/Reindex/components/ReindexAdvancedOptions/ReindexAdvancedOptions.tsx
@@ -5,7 +5,15 @@
 
 import React, { ChangeEvent, useContext, useEffect, useState } from "react";
 import CustomFormRow, { OptionalLabel } from "../../../../components/CustomFormRow";
-import { EuiCheckbox, EuiComboBox, EuiComboBoxOptionOption, EuiFieldNumber, EuiLink, EuiRadioGroup, EuiSpacer } from "@elastic/eui";
+import {
+  EuiCheckbox,
+  EuiComboBox,
+  EuiComboBoxOptionOption,
+  EuiCompressedFieldNumber,
+  EuiLink,
+  EuiRadioGroup,
+  EuiSpacer,
+} from "@elastic/eui";
 import { CoreServicesContext } from "../../../../components/core_services";
 import { CoreStart } from "opensearch-dashboards/public";
 
@@ -147,7 +155,7 @@ const ReindexAdvancedOptions = (props: ReindexOptionsProps) => {
             label="Number of subtasks"
             helpText="Specify the number of subtasks to divide this operation into."
           >
-            <EuiFieldNumber
+            <EuiCompressedFieldNumber
               data-test-subj="slices"
               value={slices}
               placeholder="Specify a number"

--- a/public/pages/Reindex/components/ReindexAdvancedOptions/ReindexAdvancedOptions.tsx
+++ b/public/pages/Reindex/components/ReindexAdvancedOptions/ReindexAdvancedOptions.tsx
@@ -6,7 +6,7 @@
 import React, { ChangeEvent, useContext, useEffect, useState } from "react";
 import CustomFormRow, { OptionalLabel } from "../../../../components/CustomFormRow";
 import {
-  EuiCheckbox,
+  EuiCompressedCheckbox,
   EuiComboBox,
   EuiComboBoxOptionOption,
   EuiCompressedFieldNumber,
@@ -76,7 +76,7 @@ const ReindexAdvancedOptions = (props: ReindexOptionsProps) => {
           </>
         }
       >
-        <EuiCheckbox
+        <EuiCompressedCheckbox
           id="uniqueCheckbox"
           label="Reindex only unique documents"
           checked={reindexUniqueDocuments}
@@ -96,7 +96,7 @@ const ReindexAdvancedOptions = (props: ReindexOptionsProps) => {
           </>
         }
       >
-        <EuiCheckbox
+        <EuiCompressedCheckbox
           id="ConflictsOptionCheckbox"
           label="Ignore conflicts during reindexing"
           checked={ignoreConflicts}
@@ -110,7 +110,7 @@ const ReindexAdvancedOptions = (props: ReindexOptionsProps) => {
         helpText="Divide this reindexing operation into smaller subtasks to run in parallel."
       >
         <>
-          <EuiCheckbox
+          <EuiCompressedCheckbox
             id="sliceEnabledCheckBox"
             data-test-subj="sliceEnabled"
             label="Slice this reindexing operation"

--- a/public/pages/Reindex/components/ReindexAdvancedOptions/ReindexAdvancedOptions.tsx
+++ b/public/pages/Reindex/components/ReindexAdvancedOptions/ReindexAdvancedOptions.tsx
@@ -7,7 +7,7 @@ import React, { ChangeEvent, useContext, useEffect, useState } from "react";
 import CustomFormRow, { OptionalLabel } from "../../../../components/CustomFormRow";
 import {
   EuiCompressedCheckbox,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiCompressedFieldNumber,
   EuiLink,
@@ -184,7 +184,7 @@ const ReindexAdvancedOptions = (props: ReindexOptionsProps) => {
           </>
         }
       >
-        <EuiComboBox
+        <EuiCompressedComboBox
           aria-label="Ingest Pipeline"
           placeholder="Select an ingest pipeline"
           data-test-subj="pipelineCombobox"

--- a/public/pages/Reindex/components/ReindexAdvancedOptions/__snapshots__/ReindexAdvancedOptions.test.tsx.snap
+++ b/public/pages/Reindex/components/ReindexAdvancedOptions/__snapshots__/ReindexAdvancedOptions.test.tsx.snap
@@ -7,7 +7,7 @@ Object {
     <div>
       <div>
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -37,7 +37,7 @@ Object {
               </button>
             </div>
             <div
-              class="euiCheckbox"
+              class="euiCheckbox euiCheckbox--compressed"
             >
               <input
                 checked=""
@@ -61,7 +61,7 @@ Object {
           class="euiSpacer euiSpacer--l"
         />
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -91,7 +91,7 @@ Object {
               </button>
             </div>
             <div
-              class="euiCheckbox"
+              class="euiCheckbox euiCheckbox--compressed"
             >
               <input
                 checked=""
@@ -115,7 +115,7 @@ Object {
           class="euiSpacer euiSpacer--l"
         />
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -138,7 +138,7 @@ Object {
               Divide this reindexing operation into smaller subtasks to run in parallel.
             </div>
             <div
-              class="euiCheckbox"
+              class="euiCheckbox euiCheckbox--compressed"
             >
               <input
                 checked=""
@@ -164,7 +164,7 @@ Object {
               data-test-subj="sliceOption"
             >
               <div
-                class="euiRadio euiRadioGroup__item"
+                class="euiRadio euiRadio--compressed euiRadioGroup__item"
               >
                 <input
                   class="euiRadio__input"
@@ -184,7 +184,7 @@ Object {
                 </label>
               </div>
               <div
-                class="euiRadio euiRadioGroup__item"
+                class="euiRadio euiRadio--compressed euiRadioGroup__item"
               >
                 <input
                   checked=""
@@ -211,7 +211,7 @@ Object {
           class="euiSpacer euiSpacer--l"
         />
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -235,13 +235,13 @@ Object {
               Specify the number of subtasks to divide this operation into.
             </div>
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
-                  class="euiFieldNumber"
+                  class="euiFieldNumber euiFieldNumber--compressed"
                   data-test-subj="slices"
                   min="2"
                   placeholder="Specify a number"
@@ -256,7 +256,7 @@ Object {
           class="euiSpacer euiSpacer--l"
         />
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -300,18 +300,18 @@ Object {
               aria-expanded="false"
               aria-haspopup="listbox"
               aria-label="Ingest Pipeline"
-              class="euiComboBox"
+              class="euiComboBox euiComboBox--compressed"
               data-test-subj="pipelineCombobox"
               role="combobox"
             >
               <div
-                class="euiFormControlLayout"
+                class="euiFormControlLayout euiFormControlLayout--compressed"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <div
-                    class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                    class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                     data-test-subj="comboBoxInput"
                     tabindex="-1"
                   >
@@ -359,7 +359,7 @@ Object {
   "container": <div>
     <div>
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -389,7 +389,7 @@ Object {
             </button>
           </div>
           <div
-            class="euiCheckbox"
+            class="euiCheckbox euiCheckbox--compressed"
           >
             <input
               checked=""
@@ -413,7 +413,7 @@ Object {
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -443,7 +443,7 @@ Object {
             </button>
           </div>
           <div
-            class="euiCheckbox"
+            class="euiCheckbox euiCheckbox--compressed"
           >
             <input
               checked=""
@@ -467,7 +467,7 @@ Object {
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -490,7 +490,7 @@ Object {
             Divide this reindexing operation into smaller subtasks to run in parallel.
           </div>
           <div
-            class="euiCheckbox"
+            class="euiCheckbox euiCheckbox--compressed"
           >
             <input
               checked=""
@@ -516,7 +516,7 @@ Object {
             data-test-subj="sliceOption"
           >
             <div
-              class="euiRadio euiRadioGroup__item"
+              class="euiRadio euiRadio--compressed euiRadioGroup__item"
             >
               <input
                 class="euiRadio__input"
@@ -536,7 +536,7 @@ Object {
               </label>
             </div>
             <div
-              class="euiRadio euiRadioGroup__item"
+              class="euiRadio euiRadio--compressed euiRadioGroup__item"
             >
               <input
                 checked=""
@@ -563,7 +563,7 @@ Object {
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -587,13 +587,13 @@ Object {
             Specify the number of subtasks to divide this operation into.
           </div>
           <div
-            class="euiFormControlLayout"
+            class="euiFormControlLayout euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <input
-                class="euiFieldNumber"
+                class="euiFieldNumber euiFieldNumber--compressed"
                 data-test-subj="slices"
                 min="2"
                 placeholder="Specify a number"
@@ -608,7 +608,7 @@ Object {
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -652,18 +652,18 @@ Object {
             aria-expanded="false"
             aria-haspopup="listbox"
             aria-label="Ingest Pipeline"
-            class="euiComboBox"
+            class="euiComboBox euiComboBox--compressed"
             data-test-subj="pipelineCombobox"
             role="combobox"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <div
-                  class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                  class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                   data-test-subj="comboBoxInput"
                   tabindex="-1"
                 >

--- a/public/pages/Reindex/container/Reindex/Reindex.tsx
+++ b/public/pages/Reindex/container/Reindex/Reindex.tsx
@@ -6,7 +6,7 @@
 import {
   EuiSmallButton,
   EuiButtonEmpty,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
@@ -515,7 +515,7 @@ class Reindex extends Component<ReindexProps, ReindexState> {
     const advanceTitle = (
       <EuiFlexGroup gutterSize="none" justifyContent="flexStart" alignItems="center">
         <EuiFlexItem grow={false}>
-          <EuiButtonIcon
+          <EuiSmallButtonIcon
             iconType={advancedSettingsOpen ? "arrowDown" : "arrowRight"}
             color="text"
             data-test-subj="advanceOptionToggle"

--- a/public/pages/Reindex/container/Reindex/Reindex.tsx
+++ b/public/pages/Reindex/container/Reindex/Reindex.tsx
@@ -11,7 +11,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiLink,
-  EuiRadioGroup,
+  EuiCompressedRadioGroup,
   EuiSpacer,
   EuiSwitchEvent,
   EuiText,
@@ -583,7 +583,7 @@ class Reindex extends Component<ReindexProps, ReindexState> {
 
           <EuiSpacer />
           <CustomFormRow>
-            <EuiRadioGroup
+            <EuiCompressedRadioGroup
               options={[
                 {
                   id: "all",

--- a/public/pages/Reindex/container/Reindex/Reindex.tsx
+++ b/public/pages/Reindex/container/Reindex/Reindex.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiSmallButtonIcon,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
@@ -689,9 +689,9 @@ class Reindex extends Component<ReindexProps, ReindexState> {
 
         <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty onClick={this.onCancel} data-test-subj="reindexCancelButton">
+            <EuiSmallButtonEmpty onClick={this.onCancel} data-test-subj="reindexCancelButton">
               Cancel
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiSmallButton fill onClick={this.onClickAction} isLoading={executing} data-test-subj="reindexConfirmButton">

--- a/public/pages/Reindex/container/Reindex/Reindex.tsx
+++ b/public/pages/Reindex/container/Reindex/Reindex.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiButtonIcon,
   EuiComboBoxOptionOption,
@@ -654,9 +654,9 @@ class Reindex extends Component<ReindexProps, ReindexState> {
               </CustomFormRow>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton data-test-subj="createIndexButton" onClick={() => this.setState({ showCreateIndexFlyout: true })}>
+              <EuiSmallButton data-test-subj="createIndexButton" onClick={() => this.setState({ showCreateIndexFlyout: true })}>
                 Create index
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
         </ContentPanel>
@@ -694,9 +694,9 @@ class Reindex extends Component<ReindexProps, ReindexState> {
             </EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton fill onClick={this.onClickAction} isLoading={executing} data-test-subj="reindexConfirmButton">
+            <EuiSmallButton fill onClick={this.onClickAction} isLoading={executing} data-test-subj="reindexConfirmButton">
               Reindex
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
 

--- a/public/pages/Reindex/container/Reindex/__snapshots__/Reindex.test.tsx.snap
+++ b/public/pages/Reindex/container/Reindex/__snapshots__/Reindex.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`<Reindex /> spec renders the component 1`] = `
     Reindex
   </h1>
   <div
-    class="euiFormRow euiFormRow--fullWidth"
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
     id="some_html_id-row"
   >
     <div
@@ -78,7 +78,7 @@ exports[`<Reindex /> spec renders the component 1`] = `
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -105,18 +105,18 @@ exports[`<Reindex /> spec renders the component 1`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              class="euiComboBox"
+              class="euiComboBox euiComboBox--compressed"
               data-test-subj="sourceSelector"
               role="combobox"
             >
               <div
-                class="euiFormControlLayout"
+                class="euiFormControlLayout euiFormControlLayout--compressed"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <div
-                    class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                    class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                     data-test-subj="comboBoxInput"
                     tabindex="-1"
                   >
@@ -163,7 +163,7 @@ exports[`<Reindex /> spec renders the component 1`] = `
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -173,14 +173,14 @@ exports[`<Reindex /> spec renders the component 1`] = `
             data-test-subj="subsetOption"
           >
             <legend
-              class="euiFormLegend"
+              class="euiFormLegend euiFormLegend--compressed"
             >
               <span>
                 Specify a reindex option
               </span>
             </legend>
             <div
-              class="euiRadio euiRadioGroup__item"
+              class="euiRadio euiRadio--compressed euiRadioGroup__item"
             >
               <input
                 checked=""
@@ -201,7 +201,7 @@ exports[`<Reindex /> spec renders the component 1`] = `
               </label>
             </div>
             <div
-              class="euiRadio euiRadioGroup__item"
+              class="euiRadio euiRadio--compressed euiRadioGroup__item"
             >
               <input
                 class="euiRadio__input"
@@ -272,7 +272,7 @@ exports[`<Reindex /> spec renders the component 1`] = `
           style="max-width: 400px;"
         >
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             id="some_html_id-row"
           >
             <div
@@ -293,18 +293,18 @@ exports[`<Reindex /> spec renders the component 1`] = `
                 <div
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  class="euiComboBox"
+                  class="euiComboBox euiComboBox--compressed"
                   data-test-subj="destinationSelector"
                   role="combobox"
                 >
                   <div
-                    class="euiFormControlLayout"
+                    class="euiFormControlLayout euiFormControlLayout--compressed"
                   >
                     <div
                       class="euiFormControlLayout__childrenWrapper"
                     >
                       <div
-                        class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                        class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                         data-test-subj="comboBoxInput"
                         tabindex="-1"
                       >
@@ -352,7 +352,7 @@ exports[`<Reindex /> spec renders the component 1`] = `
           class="euiFlexItem euiFlexItem--flexGrowZero"
         >
           <button
-            class="euiButton euiButton--primary"
+            class="euiButton euiButton--primary euiButton--small"
             data-test-subj="createIndexButton"
             type="button"
           >
@@ -392,7 +392,7 @@ exports[`<Reindex /> spec renders the component 1`] = `
           >
             <button
               aria-label="drop down icon"
-              class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+              class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small"
               data-test-subj="advanceOptionToggle"
               type="button"
             >
@@ -425,7 +425,7 @@ exports[`<Reindex /> spec renders the component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButtonEmpty euiButtonEmpty--primary"
+        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
         data-test-subj="reindexCancelButton"
         type="button"
       >
@@ -444,7 +444,7 @@ exports[`<Reindex /> spec renders the component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButton euiButton--primary euiButton--fill"
+        class="euiButton euiButton--primary euiButton--small euiButton--fill"
         data-test-subj="reindexConfirmButton"
         type="button"
       >

--- a/public/pages/Repositories/components/CreateRepositoryFlyout/CreateRepositoryFlyout.tsx
+++ b/public/pages/Repositories/components/CreateRepositoryFlyout/CreateRepositoryFlyout.tsx
@@ -7,7 +7,7 @@ import {
   EuiAccordion,
   EuiCallOut,
   EuiCodeEditor,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiCompressedFieldText,
   EuiFlyout,

--- a/public/pages/Repositories/components/CreateRepositoryFlyout/CreateRepositoryFlyout.tsx
+++ b/public/pages/Repositories/components/CreateRepositoryFlyout/CreateRepositoryFlyout.tsx
@@ -16,7 +16,7 @@ import {
   EuiFlyoutHeader,
   EuiCompressedFormRow,
   EuiLink,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiSpacer,
   EuiText,
   EuiTitle,
@@ -292,7 +292,7 @@ export class CreateRepositoryFlyout extends MDSEnabledComponent<CreateRepository
 
           <CustomLabel title="Repository type" helpText={repoTypeHelpText} />
           <EuiCompressedFormRow isInvalid={!!repoTypeError} error={repoTypeError}>
-            <EuiSelect
+            <EuiCompressedSelect
               options={REPO_SELECT_OPTIONS}
               value={selectedRepoTypeOption}
               onChange={(e) => this.setState({ selectedRepoTypeOption: e.target.value })}

--- a/public/pages/Repositories/components/CreateRepositoryFlyout/CreateRepositoryFlyout.tsx
+++ b/public/pages/Repositories/components/CreateRepositoryFlyout/CreateRepositoryFlyout.tsx
@@ -9,7 +9,7 @@ import {
   EuiCodeEditor,
   EuiComboBox,
   EuiComboBoxOptionOption,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutFooter,
@@ -192,7 +192,7 @@ export class CreateRepositoryFlyout extends MDSEnabledComponent<CreateRepository
         <>
           <CustomLabel title="Location" />
           <EuiCompressedFormRow isInvalid={!!locationError} error={locationError}>
-            <EuiFieldText
+            <EuiCompressedFieldText
               disabled={!!editRepo}
               placeholder="e.g., /mnt/snapshots"
               value={location}
@@ -280,7 +280,7 @@ export class CreateRepositoryFlyout extends MDSEnabledComponent<CreateRepository
         <EuiFlyoutBody>
           <CustomLabel title="Repository name" />
           <EuiCompressedFormRow isInvalid={!!repoNameError} error={repoNameError}>
-            <EuiFieldText
+            <EuiCompressedFieldText
               disabled={!!editRepo}
               value={repoName}
               data-test-subj="repoNameInput"

--- a/public/pages/Repositories/components/CreateRepositoryFlyout/CreateRepositoryFlyout.tsx
+++ b/public/pages/Repositories/components/CreateRepositoryFlyout/CreateRepositoryFlyout.tsx
@@ -14,7 +14,7 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiLink,
   EuiSelect,
   EuiSpacer,
@@ -191,14 +191,14 @@ export class CreateRepositoryFlyout extends MDSEnabledComponent<CreateRepository
       configuration = (
         <>
           <CustomLabel title="Location" />
-          <EuiFormRow isInvalid={!!locationError} error={locationError}>
+          <EuiCompressedFormRow isInvalid={!!locationError} error={locationError}>
             <EuiFieldText
               disabled={!!editRepo}
               placeholder="e.g., /mnt/snapshots"
               value={location}
               onChange={(e) => this.setState({ location: e.target.value })}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
 
           <EuiSpacer size="l" />
 
@@ -279,25 +279,25 @@ export class CreateRepositoryFlyout extends MDSEnabledComponent<CreateRepository
 
         <EuiFlyoutBody>
           <CustomLabel title="Repository name" />
-          <EuiFormRow isInvalid={!!repoNameError} error={repoNameError}>
+          <EuiCompressedFormRow isInvalid={!!repoNameError} error={repoNameError}>
             <EuiFieldText
               disabled={!!editRepo}
               value={repoName}
               data-test-subj="repoNameInput"
               onChange={(e) => this.setState({ repoName: e.target.value })}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
 
           <EuiSpacer size="m" />
 
           <CustomLabel title="Repository type" helpText={repoTypeHelpText} />
-          <EuiFormRow isInvalid={!!repoTypeError} error={repoTypeError}>
+          <EuiCompressedFormRow isInvalid={!!repoTypeError} error={repoTypeError}>
             <EuiSelect
               options={REPO_SELECT_OPTIONS}
               value={selectedRepoTypeOption}
               onChange={(e) => this.setState({ selectedRepoTypeOption: e.target.value })}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
 
           <EuiSpacer size="m" />
 

--- a/public/pages/Repositories/components/DeleteModal/DeleteModal.tsx
+++ b/public/pages/Repositories/components/DeleteModal/DeleteModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, Component } from "react";
-import { EuiConfirmModal, EuiFieldText, EuiForm, EuiCompressedFormRow, EuiOverlayMask, EuiSpacer } from "@elastic/eui";
+import { EuiConfirmModal, EuiCompressedFieldText, EuiForm, EuiCompressedFormRow, EuiOverlayMask, EuiSpacer } from "@elastic/eui";
 
 interface DeleteModalProps {
   closeDeleteModal: (event?: any) => void;
@@ -60,7 +60,12 @@ export default class DeleteModal extends Component<DeleteModalProps, DeleteModal
             <EuiSpacer size="s" />
             {!!confirmation && (
               <EuiCompressedFormRow helpText={`To confirm deletion, type "delete".`}>
-                <EuiFieldText value={confirmDeleteText} placeholder="delete" onChange={this.onChange} data-test-subj="deleteTextField" />
+                <EuiCompressedFieldText
+                  value={confirmDeleteText}
+                  placeholder="delete"
+                  onChange={this.onChange}
+                  data-test-subj="deleteTextField"
+                />
               </EuiCompressedFormRow>
             )}
           </EuiForm>

--- a/public/pages/Repositories/components/DeleteModal/DeleteModal.tsx
+++ b/public/pages/Repositories/components/DeleteModal/DeleteModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, Component } from "react";
-import { EuiConfirmModal, EuiFieldText, EuiForm, EuiFormRow, EuiOverlayMask, EuiSpacer } from "@elastic/eui";
+import { EuiConfirmModal, EuiFieldText, EuiForm, EuiCompressedFormRow, EuiOverlayMask, EuiSpacer } from "@elastic/eui";
 
 interface DeleteModalProps {
   closeDeleteModal: (event?: any) => void;
@@ -59,9 +59,9 @@ export default class DeleteModal extends Component<DeleteModalProps, DeleteModal
             </p>
             <EuiSpacer size="s" />
             {!!confirmation && (
-              <EuiFormRow helpText={`To confirm deletion, type "delete".`}>
+              <EuiCompressedFormRow helpText={`To confirm deletion, type "delete".`}>
                 <EuiFieldText value={confirmDeleteText} placeholder="delete" onChange={this.onChange} data-test-subj="deleteTextField" />
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             )}
           </EuiForm>
         </EuiConfirmModal>

--- a/public/pages/Repositories/containers/Repositories/Repositories.tsx
+++ b/public/pages/Repositories/containers/Repositories/Repositories.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiContextMenuItem,
   EuiContextMenuPanel,
   EuiInMemoryTable,
@@ -229,7 +229,7 @@ export class Repositories extends MDSEnabledComponent<RepositoriesProps, Reposit
       </EuiContextMenuItem>,
     ];
     const popoverButton = (
-      <EuiButton
+      <EuiSmallButton
         iconType="arrowDown"
         iconSide="right"
         disabled={!selectedItems.length}
@@ -239,18 +239,18 @@ export class Repositories extends MDSEnabledComponent<RepositoriesProps, Reposit
         data-test-subj="actionButton"
       >
         Actions
-      </EuiButton>
+      </EuiSmallButton>
     );
     const actions = [
-      <EuiButton iconType="refresh" onClick={this.getRepos} data-test-subj="refreshButton">
+      <EuiSmallButton iconType="refresh" onClick={this.getRepos} data-test-subj="refreshButton">
         Refresh
-      </EuiButton>,
-      <EuiButton disabled={!selectedItems.length} onClick={this.showDeleteModal} data-test-subj="deleteButton" color="danger">
+      </EuiSmallButton>,
+      <EuiSmallButton disabled={!selectedItems.length} onClick={this.showDeleteModal} data-test-subj="deleteButton" color="danger">
         Delete
-      </EuiButton>,
-      <EuiButton onClick={this.onClickCreate} fill={true}>
+      </EuiSmallButton>,
+      <EuiSmallButton onClick={this.onClickCreate} fill={true}>
         Create repository
-      </EuiButton>,
+      </EuiSmallButton>,
     ];
 
     const renderToolsRight = () => {

--- a/public/pages/Rollover/containers/Rollover/Rollover.tsx
+++ b/public/pages/Rollover/containers/Rollover/Rollover.tsx
@@ -11,7 +11,7 @@ import { ServicesContext } from "../../../../services";
 import { BrowserServices } from "../../../../models/interfaces";
 import { CoreServicesContext } from "../../../../components/core_services";
 import IndexFormWrapper, { IndexForm } from "../../../../containers/IndexForm";
-import { EuiButton, EuiButtonEmpty, EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle, EuiLink, EuiText } from "@elastic/eui";
+import { EuiSmallButton, EuiButtonEmpty, EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle, EuiLink, EuiText } from "@elastic/eui";
 import CustomFormRow from "../../../../components/CustomFormRow";
 import { ContentPanel } from "../../../../components/ContentPanel";
 import FormGenerator, { AllBuiltInComponents, IFormGeneratorRef } from "../../../../components/FormGenerator";
@@ -189,7 +189,7 @@ export default function Rollover(props: RolloverProps) {
                 </CustomFormRow>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiButton
+                <EuiSmallButton
                   disabled={!writeIndexValue}
                   fill
                   color="primary"
@@ -208,7 +208,7 @@ export default function Rollover(props: RolloverProps) {
                   }}
                 >
                   Assign as write index
-                </EuiButton>
+                </EuiSmallButton>
               </EuiFlexItem>
             </EuiFlexGroup>
           </>
@@ -320,7 +320,7 @@ export default function Rollover(props: RolloverProps) {
             title="Configure new rollover index"
             titleSize="s"
             actions={
-              <EuiButton
+              <EuiSmallButton
                 onClick={() => {
                   indexFormRef.current?.importSettings({
                     index: writingIndex,
@@ -328,7 +328,7 @@ export default function Rollover(props: RolloverProps) {
                 }}
               >
                 Import from old write index
-              </EuiButton>
+              </EuiSmallButton>
             }
           >
             <IndexFormWrapper
@@ -370,7 +370,7 @@ export default function Rollover(props: RolloverProps) {
           </EuiButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             disabled={loading || (sourceType === "alias" && !writingIndex)}
             fill
             onClick={async () => {
@@ -407,7 +407,7 @@ export default function Rollover(props: RolloverProps) {
             data-test-subj="rolloverSubmitButton"
           >
             Roll over
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </div>

--- a/public/pages/Rollover/containers/Rollover/Rollover.tsx
+++ b/public/pages/Rollover/containers/Rollover/Rollover.tsx
@@ -11,7 +11,7 @@ import { ServicesContext } from "../../../../services";
 import { BrowserServices } from "../../../../models/interfaces";
 import { CoreServicesContext } from "../../../../components/core_services";
 import IndexFormWrapper, { IndexForm } from "../../../../containers/IndexForm";
-import { EuiSmallButton, EuiButtonEmpty, EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle, EuiLink, EuiText } from "@elastic/eui";
+import { EuiSmallButton, EuiSmallButtonEmpty, EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle, EuiLink, EuiText } from "@elastic/eui";
 import CustomFormRow from "../../../../components/CustomFormRow";
 import { ContentPanel } from "../../../../components/ContentPanel";
 import FormGenerator, { AllBuiltInComponents, IFormGeneratorRef } from "../../../../components/FormGenerator";
@@ -356,7 +356,7 @@ export default function Rollover(props: RolloverProps) {
       ) : null}
       <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
         <EuiFlexItem grow={false}>
-          <EuiButtonEmpty
+          <EuiSmallButtonEmpty
             onClick={() => {
               if (sourceType === "alias") {
                 props.history.push(ROUTES.ALIASES);
@@ -367,7 +367,7 @@ export default function Rollover(props: RolloverProps) {
             data-test-subj="rolloverCancelButton"
           >
             Cancel
-          </EuiButtonEmpty>
+          </EuiSmallButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiSmallButton

--- a/public/pages/Rollover/containers/Rollover/__snapshots__/Rollover.test.tsx.snap
+++ b/public/pages/Rollover/containers/Rollover/__snapshots__/Rollover.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`container <Rollover /> spec render the component 1`] = `
     Roll over
   </h1>
   <div
-    class="euiFormRow"
+    class="euiFormRow euiFormRow--compressed"
     id="some_html_id-row"
     style="margin-bottom: 20px;"
   >
@@ -59,7 +59,7 @@ exports[`container <Rollover /> spec render the component 1`] = `
         class="euiForm"
       >
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           data-test-subj="form-name-source"
           id="some_html_id-row"
         >
@@ -89,17 +89,17 @@ exports[`container <Rollover /> spec render the component 1`] = `
               <div
                 aria-expanded="false"
                 aria-haspopup="listbox"
-                class="euiComboBox"
+                class="euiComboBox euiComboBox--compressed"
                 role="combobox"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <div
-                      class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                      class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                       data-test-subj="comboBoxInput"
                       tabindex="-1"
                     >
@@ -129,7 +129,7 @@ exports[`container <Rollover /> spec render the component 1`] = `
                     >
                       <button
                         aria-label="Clear input"
-                        class="euiFormControlLayoutClearButton"
+                        class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                         data-test-subj="comboBoxClearButton"
                         type="button"
                       >
@@ -163,7 +163,7 @@ exports[`container <Rollover /> spec render the component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButtonEmpty euiButtonEmpty--primary"
+        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
         data-test-subj="rolloverCancelButton"
         type="button"
       >
@@ -182,7 +182,7 @@ exports[`container <Rollover /> spec render the component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButton euiButton--primary euiButton--fill"
+        class="euiButton euiButton--primary euiButton--small euiButton--fill"
         data-test-subj="rolloverSubmitButton"
         type="button"
       >

--- a/public/pages/RollupDetails/containers/RollupDetails/RollupDetails.tsx
+++ b/public/pages/RollupDetails/containers/RollupDetails/RollupDetails.tsx
@@ -9,7 +9,7 @@ import {
   EuiTitle,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiButton,
+  EuiSmallButton,
   EuiOverlayMask,
   EuiButtonEmpty,
   EuiModalFooter,
@@ -427,22 +427,22 @@ export class RollupDetails extends Component<RollupDetailsProps, RollupDetailsSt
               <EuiFlexItem grow={false}>
                 <EuiFlexGroup alignItems="center" gutterSize="s">
                   <EuiFlexItem grow={false}>
-                    <EuiButton disabled={!enabled} onClick={this.onDisable} data-test-subj="disableButton">
+                    <EuiSmallButton disabled={!enabled} onClick={this.onDisable} data-test-subj="disableButton">
                       Disable
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
-                    <EuiButton disabled={enabled} onClick={this.onEnable} data-test-subj="enableButton">
+                    <EuiSmallButton disabled={enabled} onClick={this.onEnable} data-test-subj="enableButton">
                       Enable
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
-                    <EuiButton onClick={this.showModal}>View JSON</EuiButton>
+                    <EuiSmallButton onClick={this.showModal}>View JSON</EuiSmallButton>
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
-                    <EuiButton onClick={this.showDeleteModal} color="danger" data-test-subj="deleteButton">
+                    <EuiSmallButton onClick={this.showDeleteModal} color="danger" data-test-subj="deleteButton">
                       Delete
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                 </EuiFlexGroup>
               </EuiFlexItem>

--- a/public/pages/RollupDetails/containers/RollupDetails/RollupDetails.tsx
+++ b/public/pages/RollupDetails/containers/RollupDetails/RollupDetails.tsx
@@ -11,7 +11,7 @@ import {
   EuiFlexItem,
   EuiSmallButton,
   EuiOverlayMask,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiModalFooter,
   EuiModal,
   EuiModalHeader,
@@ -492,7 +492,7 @@ export class RollupDetails extends Component<RollupDetailsProps, RollupDetailsSt
               </EuiModalBody>
 
               <EuiModalFooter>
-                <EuiButtonEmpty onClick={this.closeModal}>Close</EuiButtonEmpty>
+                <EuiSmallButtonEmpty onClick={this.closeModal}>Close</EuiSmallButtonEmpty>
               </EuiModalFooter>
             </EuiModal>
           </EuiOverlayMask>

--- a/public/pages/Rollups/components/DeleteModal/DeleteModal.tsx
+++ b/public/pages/Rollups/components/DeleteModal/DeleteModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, Component, Fragment } from "react";
-import { EuiConfirmModal, EuiForm, EuiFormRow, EuiFieldText, EuiOverlayMask, EuiSpacer } from "@elastic/eui";
+import { EuiConfirmModal, EuiForm, EuiCompressedFormRow, EuiFieldText, EuiOverlayMask, EuiSpacer } from "@elastic/eui";
 
 interface DeleteModalProps {
   rollupId: string;
@@ -45,9 +45,9 @@ export default class DeleteModal extends Component<DeleteModalProps, DeleteModal
               will remain as it is.
             </Fragment>
             <EuiSpacer size="s" />
-            <EuiFormRow helpText="To confirm deletion, enter delete in the text field">
+            <EuiCompressedFormRow helpText="To confirm deletion, enter delete in the text field">
               <EuiFieldText value={confirmDeleteText} placeholder="delete" onChange={this.onChange} data-test-subj="deleteTextField" />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiForm>
         </EuiConfirmModal>
       </EuiOverlayMask>

--- a/public/pages/Rollups/components/DeleteModal/DeleteModal.tsx
+++ b/public/pages/Rollups/components/DeleteModal/DeleteModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, Component, Fragment } from "react";
-import { EuiConfirmModal, EuiForm, EuiCompressedFormRow, EuiFieldText, EuiOverlayMask, EuiSpacer } from "@elastic/eui";
+import { EuiConfirmModal, EuiForm, EuiCompressedFormRow, EuiCompressedFieldText, EuiOverlayMask, EuiSpacer } from "@elastic/eui";
 
 interface DeleteModalProps {
   rollupId: string;
@@ -46,7 +46,12 @@ export default class DeleteModal extends Component<DeleteModalProps, DeleteModal
             </Fragment>
             <EuiSpacer size="s" />
             <EuiCompressedFormRow helpText="To confirm deletion, enter delete in the text field">
-              <EuiFieldText value={confirmDeleteText} placeholder="delete" onChange={this.onChange} data-test-subj="deleteTextField" />
+              <EuiCompressedFieldText
+                value={confirmDeleteText}
+                placeholder="delete"
+                onChange={this.onChange}
+                data-test-subj="deleteTextField"
+              />
             </EuiCompressedFormRow>
           </EuiForm>
         </EuiConfirmModal>

--- a/public/pages/Rollups/components/RollupEmptyPrompt/RollupEmptyPrompt.tsx
+++ b/public/pages/Rollups/components/RollupEmptyPrompt/RollupEmptyPrompt.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { EuiButton, EuiEmptyPrompt, EuiText } from "@elastic/eui";
+import { EuiSmallButton, EuiEmptyPrompt, EuiText } from "@elastic/eui";
 import { PLUGIN_NAME, ROUTES } from "../../../../utils/constants";
 
 export const TEXT = {
@@ -26,16 +26,16 @@ const getActions: React.SFC<RollupEmptyPromptProps> = ({ filterIsApplied, loadin
   }
   if (filterIsApplied) {
     return (
-      <EuiButton fill onClick={resetFilters} data-test-subj="rollupEmptyPromptRestFilters">
+      <EuiSmallButton fill onClick={resetFilters} data-test-subj="rollupEmptyPromptRestFilters">
         Reset Filters
-      </EuiButton>
+      </EuiSmallButton>
     );
   }
 
   return (
-    <EuiButton href={`${PLUGIN_NAME}#${ROUTES.CREATE_ROLLUP}`} data-test-subj="emptyPromptCreateRollupButton">
+    <EuiSmallButton href={`${PLUGIN_NAME}#${ROUTES.CREATE_ROLLUP}`} data-test-subj="emptyPromptCreateRollupButton">
       Create rollup
-    </EuiButton>
+    </EuiSmallButton>
   );
 };
 

--- a/public/pages/Rollups/containers/Rollups/Rollups.tsx
+++ b/public/pages/Rollups/containers/Rollups/Rollups.tsx
@@ -22,7 +22,7 @@ import {
   Pagination,
   EuiTableSelectionType,
   EuiFlexItem,
-  EuiFieldSearch,
+  EuiCompressedFieldSearch,
   EuiPagination,
   EuiFlexGroup,
   EuiPanel,
@@ -583,7 +583,7 @@ export class Rollups extends MDSEnabledComponent<RollupsProps, RollupsState> {
         <div style={{ padding: "initial" }}>
           <EuiFlexGroup style={{ padding: "0px 5px" }}>
             <EuiFlexItem>
-              <EuiFieldSearch fullWidth={true} value={search} placeholder="Search" onChange={this.onSearchChange} />
+              <EuiCompressedFieldSearch fullWidth={true} value={search} placeholder="Search" onChange={this.onSearchChange} />
             </EuiFlexItem>
           </EuiFlexGroup>
 

--- a/public/pages/Rollups/containers/Rollups/Rollups.tsx
+++ b/public/pages/Rollups/containers/Rollups/Rollups.tsx
@@ -306,7 +306,6 @@ export class Rollups extends MDSEnabledComponent<RollupsProps, RollupsState> {
         disabled={!selectedItems.length}
         onClick={this.onActionButtonClick}
         data-test-subj="actionButton"
-        size={useNewUX ? "s" : undefined}
       >
         Actions
       </EuiSmallButton>

--- a/public/pages/Rollups/containers/Rollups/Rollups.tsx
+++ b/public/pages/Rollups/containers/Rollups/Rollups.tsx
@@ -23,7 +23,6 @@ import {
   EuiTableSelectionType,
   EuiFlexItem,
   EuiCompressedFieldSearch,
-  EuiPagination,
   EuiFlexGroup,
   EuiPanel,
   EuiTitle,
@@ -34,9 +33,7 @@ import {
   EuiTextColor,
   EuiLink,
   EuiTableFieldDataColumnType,
-  EuiInMemoryTable,
   EuiButtonIcon,
-  EuiCompressedFieldSearch,
 } from "@elastic/eui";
 import { RollupService } from "../../../../services";
 import RollupEmptyPrompt from "../../components/RollupEmptyPrompt";

--- a/public/pages/Rollups/containers/Rollups/Rollups.tsx
+++ b/public/pages/Rollups/containers/Rollups/Rollups.tsx
@@ -27,7 +27,7 @@ import {
   EuiFlexGroup,
   EuiPanel,
   EuiTitle,
-  EuiButton,
+  EuiSmallButton,
   EuiPopover,
   EuiContextMenuItem,
   EuiContextMenuPanel,
@@ -303,7 +303,7 @@ export class Rollups extends MDSEnabledComponent<RollupsProps, RollupsState> {
     };
 
     const actionButton = (
-      <EuiButton
+      <EuiSmallButton
         iconType="arrowDown"
         iconSide="right"
         disabled={!selectedItems.length}
@@ -312,7 +312,7 @@ export class Rollups extends MDSEnabledComponent<RollupsProps, RollupsState> {
         size={useNewUX ? "s" : undefined}
       >
         Actions
-      </EuiButton>
+      </EuiSmallButton>
     );
 
     const selection: EuiTableSelectionType<DocumentRollup> = {
@@ -538,17 +538,17 @@ export class Rollups extends MDSEnabledComponent<RollupsProps, RollupsState> {
           <EuiFlexItem grow={false}>
             <EuiFlexGroup alignItems="center" gutterSize="s">
               <EuiFlexItem grow={false}>
-                <EuiButton iconType="refresh" onClick={this.getRollups} data-test-subj="refreshButton">
+                <EuiSmallButton iconType="refresh" onClick={this.getRollups} data-test-subj="refreshButton">
                   Refresh
-                </EuiButton>
+                </EuiSmallButton>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiButton disabled={!selectedItems.length} onClick={this.onDisable} data-test-subj="disableButton">
+                <EuiSmallButton disabled={!selectedItems.length} onClick={this.onDisable} data-test-subj="disableButton">
                   Disable
-                </EuiButton>
+                </EuiSmallButton>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiButton
+                <EuiSmallButton
                   disabled={!selectedItems.length}
                   onClick={() => {
                     this.onEnable();
@@ -556,7 +556,7 @@ export class Rollups extends MDSEnabledComponent<RollupsProps, RollupsState> {
                   data-test-subj="enableButton"
                 >
                   Enable
-                </EuiButton>
+                </EuiSmallButton>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiPopover
@@ -572,9 +572,9 @@ export class Rollups extends MDSEnabledComponent<RollupsProps, RollupsState> {
                 </EuiPopover>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiButton onClick={this.onClickCreate} fill={true} data-test-subj="createRollupButton">
+                <EuiSmallButton onClick={this.onClickCreate} fill={true} data-test-subj="createRollupButton">
                   Create rollup job
-                </EuiButton>
+                </EuiSmallButton>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>

--- a/public/pages/Rollups/containers/Rollups/__snapshots__/Rollups.test.tsx.snap
+++ b/public/pages/Rollups/containers/Rollups/__snapshots__/Rollups.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`<Rollups /> spec renders the component 1`] = `
             class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <button
-              class="euiButton euiButton--primary"
+              class="euiButton euiButton--primary euiButton--small"
               data-test-subj="refreshButton"
               type="button"
             >
@@ -51,7 +51,7 @@ exports[`<Rollups /> spec renders the component 1`] = `
             class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <button
-              class="euiButton euiButton--primary euiButton-isDisabled"
+              class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
               data-test-subj="disableButton"
               disabled=""
               type="button"
@@ -71,7 +71,7 @@ exports[`<Rollups /> spec renders the component 1`] = `
             class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <button
-              class="euiButton euiButton--primary euiButton-isDisabled"
+              class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
               data-test-subj="enableButton"
               disabled=""
               type="button"
@@ -99,7 +99,7 @@ exports[`<Rollups /> spec renders the component 1`] = `
                 class="euiPopover__anchor"
               >
                 <button
-                  class="euiButton euiButton--primary euiButton-isDisabled"
+                  class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
                   data-test-subj="actionButton"
                   disabled=""
                   type="button"
@@ -122,7 +122,7 @@ exports[`<Rollups /> spec renders the component 1`] = `
             class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <button
-              class="euiButton euiButton--primary euiButton--fill"
+              class="euiButton euiButton--primary euiButton--small euiButton--fill"
               data-test-subj="createRollupButton"
               type="button"
             >
@@ -151,13 +151,13 @@ exports[`<Rollups /> spec renders the component 1`] = `
           class="euiFlexItem"
         >
           <div
-            class="euiFormControlLayout euiFormControlLayout--fullWidth"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <input
-                class="euiFieldSearch euiFieldSearch--fullWidth"
+                class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
                 placeholder="Search"
                 type="search"
                 value=""

--- a/public/pages/ShrinkIndex/container/ShrinkIndex/ShrinkIndex.tsx
+++ b/public/pages/ShrinkIndex/container/ShrinkIndex/ShrinkIndex.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiCallOut,
   EuiFlexGroup,
@@ -375,7 +375,7 @@ export default class ShrinkIndex extends Component<ShrinkIndexProps, ShrinkIndex
             <EuiCallOut title="The source index must block write operations before shrinking." color="danger" iconType="alert">
               <p>In order to shrink an existing index, you must first set the index to block write operations.</p>
               <EuiSpacer />
-              <EuiButton
+              <EuiSmallButton
                 onClick={() => {
                   const indexWriteBlockSettings = {
                     "index.blocks.write": true,
@@ -386,7 +386,7 @@ export default class ShrinkIndex extends Component<ShrinkIndexProps, ShrinkIndex
                 data-test-subj="onSetIndexWriteBlockButton"
               >
                 Block write operations
-              </EuiButton>
+              </EuiSmallButton>
             </EuiCallOut>
             <EuiSpacer />
           </>
@@ -403,7 +403,7 @@ export default class ShrinkIndex extends Component<ShrinkIndexProps, ShrinkIndex
                 to complete. The index will be in red health status while the index is opening.
               </p>
               <EuiSpacer />
-              <EuiButton
+              <EuiSmallButton
                 onClick={() => {
                   this.onOpenIndex();
                 }}
@@ -413,7 +413,7 @@ export default class ShrinkIndex extends Component<ShrinkIndexProps, ShrinkIndex
                 data-test-subj="onOpenIndexButton"
               >
                 Open index
-              </EuiButton>
+              </EuiSmallButton>
             </EuiCallOut>
             <EuiSpacer />
           </>
@@ -669,7 +669,7 @@ export default class ShrinkIndex extends Component<ShrinkIndexProps, ShrinkIndex
             </EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               isLoading={this.state.loading}
               isDisabled={this.state.loading}
               onClick={this.onClickAction}
@@ -678,7 +678,7 @@ export default class ShrinkIndex extends Component<ShrinkIndexProps, ShrinkIndex
               disabled={disableShrinkButton}
             >
               Shrink
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </div>

--- a/public/pages/ShrinkIndex/container/ShrinkIndex/ShrinkIndex.tsx
+++ b/public/pages/ShrinkIndex/container/ShrinkIndex/ShrinkIndex.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
@@ -664,9 +664,9 @@ export default class ShrinkIndex extends Component<ShrinkIndexProps, ShrinkIndex
         <EuiSpacer />
         <EuiFlexGroup justifyContent="flexEnd">
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty onClick={this.onCancel} flush="left" data-test-subj="shrinkIndexCancelButton">
+            <EuiSmallButtonEmpty onClick={this.onCancel} flush="left" data-test-subj="shrinkIndexCancelButton">
               Cancel
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiSmallButton

--- a/public/pages/ShrinkIndex/container/ShrinkIndex/ShrinkIndex.tsx
+++ b/public/pages/ShrinkIndex/container/ShrinkIndex/ShrinkIndex.tsx
@@ -12,7 +12,7 @@ import {
   EuiLink,
   EuiSpacer,
   EuiTitle,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiLoadingSpinner,
 } from "@elastic/eui";
 import React, { Component } from "react";
@@ -626,7 +626,7 @@ export default class ShrinkIndex extends Component<ShrinkIndexProps, ShrinkIndex
     );
 
     const subTitleText = (
-      <EuiFormRow
+      <EuiCompressedFormRow
         fullWidth
         helpText={
           <div>
@@ -638,7 +638,7 @@ export default class ShrinkIndex extends Component<ShrinkIndexProps, ShrinkIndex
         }
       >
         <></>
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     );
 
     return (

--- a/public/pages/ShrinkIndex/container/ShrinkIndex/__snapshots__/ShrinkIndex.test.tsx.snap
+++ b/public/pages/ShrinkIndex/container/ShrinkIndex/__snapshots__/ShrinkIndex.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
       Shrink index
     </h1>
     <div
-      class="euiFormRow euiFormRow--fullWidth"
+      class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
       id="some_html_id-row"
     >
       <div
@@ -199,7 +199,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
           class="euiForm"
         >
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             data-test-subj="form-name-targetIndex"
             id="some_html_id-row"
           >
@@ -221,13 +221,13 @@ exports[`<Shrink index /> spec renders the component 1`] = `
                 class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <input
-                      class="euiFieldText"
+                      class="euiFieldText euiFieldText--compressed"
                       data-test-subj="targetIndexNameInput"
                       placeholder="Specify a name for the new shrunken index."
                       type="text"
@@ -247,7 +247,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
             </div>
           </div>
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             data-test-subj="form-name-index.number_of_shards"
             id="some_html_id-row"
           >
@@ -280,13 +280,13 @@ exports[`<Shrink index /> spec renders the component 1`] = `
                 class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <select
-                      class="euiSelect"
+                      class="euiSelect euiSelect--compressed"
                       data-test-subj="numberOfShardsInput"
                       placeholder="Select primary shard count"
                     >
@@ -316,7 +316,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
             </div>
           </div>
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             data-test-subj="form-name-index.number_of_replicas"
             id="some_html_id-row"
           >
@@ -346,13 +346,13 @@ exports[`<Shrink index /> spec renders the component 1`] = `
                 class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <input
-                      class="euiFieldNumber"
+                      class="euiFieldNumber euiFieldNumber--compressed"
                       data-test-subj="numberOfReplicasInput"
                       min="0"
                       type="number"
@@ -364,7 +364,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
             </div>
           </div>
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             data-test-subj="form-name-aliases"
             id="some_html_id-row"
           >
@@ -397,18 +397,18 @@ exports[`<Shrink index /> spec renders the component 1`] = `
                 <div
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  class="euiComboBox"
+                  class="euiComboBox euiComboBox--compressed"
                   data-test-subj="aliasesInput"
                   role="combobox"
                 >
                   <div
-                    class="euiFormControlLayout"
+                    class="euiFormControlLayout euiFormControlLayout--compressed"
                   >
                     <div
                       class="euiFormControlLayout__childrenWrapper"
                     >
                       <div
-                        class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                        class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                         data-test-subj="comboBoxInput"
                         tabindex="-1"
                       >
@@ -497,7 +497,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
                     class="euiSpacer euiSpacer--s"
                   />
                   <div
-                    class="euiFormRow"
+                    class="euiFormRow euiFormRow--compressed"
                     data-test-subj="formNameAdvancedSettings"
                     id="some_html_id-row"
                   >
@@ -748,7 +748,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
             class="euiSpacer euiSpacer--l"
           />
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             id="some_html_id-row"
           >
             <div
@@ -768,7 +768,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
                 class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
               >
                 <div
-                  class="euiCheckbox"
+                  class="euiCheckbox euiCheckbox--compressed"
                 >
                   <input
                     class="euiCheckbox__input"
@@ -794,7 +794,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
                 class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
               >
                 <div
-                  class="euiCheckbox"
+                  class="euiCheckbox euiCheckbox--compressed"
                 >
                   <input
                     class="euiCheckbox__input"
@@ -833,7 +833,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
         class="euiFlexItem euiFlexItem--flexGrowZero"
       >
         <button
-          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--flushLeft"
+          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiButtonEmpty--flushLeft"
           data-test-subj="shrinkIndexCancelButton"
           type="button"
         >
@@ -852,7 +852,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
         class="euiFlexItem euiFlexItem--flexGrowZero"
       >
         <button
-          class="euiButton euiButton--primary euiButton--fill"
+          class="euiButton euiButton--primary euiButton--small euiButton--fill"
           data-test-subj="shrinkIndexConfirmButton"
           type="button"
         >

--- a/public/pages/SnapshotPolicies/containers/SnapshotPolicies/SnapshotPolicies.tsx
+++ b/public/pages/SnapshotPolicies/containers/SnapshotPolicies/SnapshotPolicies.tsx
@@ -12,7 +12,7 @@ import {
   Criteria,
   Direction,
   EuiBasicTable,
-  EuiButton,
+  EuiSmallButton,
   EuiContextMenuItem,
   EuiContextMenuPanel,
   EuiEmptyPrompt,
@@ -464,15 +464,15 @@ export class SnapshotPolicies extends MDSEnabledComponent<SnapshotPoliciesProps,
       </EuiSmallButton>
     );
     const actions = [
-      <EuiButton iconType="refresh" onClick={this.getPolicies} data-test-subj="refreshButton">
+      <EuiSmallButton iconType="refresh" onClick={this.getPolicies} data-test-subj="refreshButton">
         Refresh
-      </EuiButton>,
-      <EuiButton disabled={!selectedItems.length} onClick={this.onClickStop}>
+      </EuiSmallButton>,
+      <EuiSmallButton disabled={!selectedItems.length} onClick={this.onClickStop}>
         Disable
-      </EuiButton>,
-      <EuiButton disabled={!selectedItems.length} onClick={this.onClickStart}>
+      </EuiSmallButton>,
+      <EuiSmallButton disabled={!selectedItems.length} onClick={this.onClickStart}>
         Enable
-      </EuiButton>,
+      </EuiSmallButton>,
       <EuiPopover
         id="action"
         button={actionsButton}
@@ -484,9 +484,9 @@ export class SnapshotPolicies extends MDSEnabledComponent<SnapshotPoliciesProps,
       >
         <EuiContextMenuPanel items={popoverActionItems} size="s" />
       </EuiPopover>,
-      <EuiButton onClick={this.onClickCreate} fill={true}>
+      <EuiSmallButton onClick={this.onClickCreate} fill={true}>
         Create policy
-      </EuiButton>,
+      </EuiSmallButton>,
     ];
 
     const subTitleText = (
@@ -509,9 +509,9 @@ export class SnapshotPolicies extends MDSEnabledComponent<SnapshotPoliciesProps,
           </EuiText>
         }
         actions={
-          <EuiButton onClick={this.onClickCreate} fill={true}>
+          <EuiSmallButton onClick={this.onClickCreate} fill={true}>
             Create policy
-          </EuiButton>
+          </EuiSmallButton>
         }
       />
     );

--- a/public/pages/SnapshotPolicies/containers/SnapshotPolicies/SnapshotPolicies.tsx
+++ b/public/pages/SnapshotPolicies/containers/SnapshotPolicies/SnapshotPolicies.tsx
@@ -31,7 +31,6 @@ import {
   EuiFlexGroup,
   EuiButtonIcon,
   EuiCompressedFieldSearch,
-  EuiSmallButton,
 } from "@elastic/eui";
 import { BREADCRUMBS, PLUGIN_NAME, ROUTES, SNAPSHOT_MANAGEMENT_DOCUMENTATION_URL } from "../../../../utils/constants";
 import { getMessagePrompt, getSMPoliciesQueryParamsFromURL, renderTimestampMillis } from "../../helpers";

--- a/public/pages/SnapshotPolicyDetails/components/InfoModal/InfoModal.tsx
+++ b/public/pages/SnapshotPolicyDetails/components/InfoModal/InfoModal.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
@@ -34,9 +34,9 @@ const InfoModal = ({ info, onClose }: InfoModalProps) => (
       </EuiModalBody>
 
       <EuiModalFooter>
-        <EuiButton fill onClick={onClose} data-test-subj="infoModalCloseButton">
+        <EuiSmallButton fill onClick={onClose} data-test-subj="infoModalCloseButton">
           Close
-        </EuiButton>
+        </EuiSmallButton>
       </EuiModalFooter>
     </EuiModal>
   </EuiOverlayMask>

--- a/public/pages/SnapshotPolicyDetails/containers/SnapshotPolicyDetails/SnapshotPolicyDetails.tsx
+++ b/public/pages/SnapshotPolicyDetails/containers/SnapshotPolicyDetails/SnapshotPolicyDetails.tsx
@@ -10,7 +10,7 @@ import queryString from "query-string";
 import {
   EuiAccordion,
   EuiBasicTable,
-  EuiButton,
+  EuiSmallButton,
   EuiFlexGrid,
   EuiFlexGroup,
   EuiFlexItem,
@@ -432,12 +432,12 @@ export class SnapshotPolicyDetails extends MDSEnabledComponent<SnapshotPolicyDet
               <EuiFlexItem grow={false}>
                 <EuiFlexGroup alignItems="center" gutterSize="s">
                   <EuiFlexItem grow={false}>
-                    <EuiButton onClick={this.onEdit}>Edit</EuiButton>
+                    <EuiSmallButton onClick={this.onEdit}>Edit</EuiSmallButton>
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
-                    <EuiButton onClick={this.showDeleteModal} color="danger" data-test-subj="deleteButton">
+                    <EuiSmallButton onClick={this.showDeleteModal} color="danger" data-test-subj="deleteButton">
                       Delete
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                 </EuiFlexGroup>
               </EuiFlexItem>
@@ -539,9 +539,9 @@ export class SnapshotPolicyDetails extends MDSEnabledComponent<SnapshotPolicyDet
           title="Last creation/deletion"
           titleSize="s"
           actions={
-            <EuiButton iconType="refresh" onClick={() => this.getPolicy(policyId)} data-test-subj="refreshButton">
+            <EuiSmallButton iconType="refresh" onClick={() => this.getPolicy(policyId)} data-test-subj="refreshButton">
               Refresh
-            </EuiButton>
+            </EuiSmallButton>
           }
         >
           <EuiBasicTable items={latestActivities} itemId="name" columns={this.columns} />

--- a/public/pages/Snapshots/components/AddPrefixInput/AddPrefixInput.tsx
+++ b/public/pages/Snapshots/components/AddPrefixInput/AddPrefixInput.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiCompressedFormRow, EuiFieldText, EuiSpacer } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiCompressedFieldText, EuiSpacer } from "@elastic/eui";
 import React, { useState, ChangeEvent } from "react";
 import CustomLabel from "../../../../components/CustomLabel";
 
@@ -25,7 +25,7 @@ const AddPrefixesInput = ({ getPrefix }: AddPrefixesInputProps) => {
 
       <CustomLabel title="Specify prefix for restored index names" helpText="A prefix will be added to any restored index names." />
       <EuiCompressedFormRow>
-        <EuiFieldText value={prefix} onChange={onPrefixChange} data-test-subj="prefixInput" />
+        <EuiCompressedFieldText value={prefix} onChange={onPrefixChange} data-test-subj="prefixInput" />
       </EuiCompressedFormRow>
 
       <EuiSpacer size="m" />

--- a/public/pages/Snapshots/components/AddPrefixInput/AddPrefixInput.tsx
+++ b/public/pages/Snapshots/components/AddPrefixInput/AddPrefixInput.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiFormRow, EuiFieldText, EuiSpacer } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiFieldText, EuiSpacer } from "@elastic/eui";
 import React, { useState, ChangeEvent } from "react";
 import CustomLabel from "../../../../components/CustomLabel";
 
@@ -24,9 +24,9 @@ const AddPrefixesInput = ({ getPrefix }: AddPrefixesInputProps) => {
       <EuiSpacer size="l" />
 
       <CustomLabel title="Specify prefix for restored index names" helpText="A prefix will be added to any restored index names." />
-      <EuiFormRow>
+      <EuiCompressedFormRow>
         <EuiFieldText value={prefix} onChange={onPrefixChange} data-test-subj="prefixInput" />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
 
       <EuiSpacer size="m" />
     </>

--- a/public/pages/Snapshots/components/AddPrefixInput/__snapshots__/AddPrefixInput.test.tsx.snap
+++ b/public/pages/Snapshots/components/AddPrefixInput/__snapshots__/AddPrefixInput.test.tsx.snap
@@ -29,20 +29,20 @@ exports[`AddPrefixInput component renders without error 1`] = `
     class="euiSpacer euiSpacer--s"
   />
   <div
-    class="euiFormRow"
+    class="euiFormRow euiFormRow--compressed"
     id="some_html_id-row"
   >
     <div
       class="euiFormRow__fieldWrapper"
     >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout euiFormControlLayout--compressed"
       >
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
           <input
-            class="euiFieldText"
+            class="euiFieldText euiFieldText--compressed"
             data-test-subj="prefixInput"
             id="some_html_id"
             type="text"

--- a/public/pages/Snapshots/components/CreateSnapshotFlyout/CreateSnapshotFlyout.tsx
+++ b/public/pages/Snapshots/components/CreateSnapshotFlyout/CreateSnapshotFlyout.tsx
@@ -6,7 +6,7 @@
 import {
   EuiAccordion,
   EuiComboBoxOptionOption,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutFooter,
@@ -227,7 +227,7 @@ export class CreateSnapshotFlyout extends MDSEnabledComponent<CreateSnapshotProp
         <EuiFlyoutBody>
           <CustomLabel title="Snapshot name" />
           <EuiCompressedFormRow isInvalid={!!snapshotIdError} error={snapshotIdError}>
-            <EuiFieldText
+            <EuiCompressedFieldText
               value={snapshotId}
               onChange={(e) => {
                 this.setState({ snapshotId: e.target.value });

--- a/public/pages/Snapshots/components/CreateSnapshotFlyout/CreateSnapshotFlyout.tsx
+++ b/public/pages/Snapshots/components/CreateSnapshotFlyout/CreateSnapshotFlyout.tsx
@@ -11,7 +11,7 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSpacer,
   EuiTitle,
   EuiText,
@@ -226,7 +226,7 @@ export class CreateSnapshotFlyout extends MDSEnabledComponent<CreateSnapshotProp
 
         <EuiFlyoutBody>
           <CustomLabel title="Snapshot name" />
-          <EuiFormRow isInvalid={!!snapshotIdError} error={snapshotIdError}>
+          <EuiCompressedFormRow isInvalid={!!snapshotIdError} error={snapshotIdError}>
             <EuiFieldText
               value={snapshotId}
               onChange={(e) => {
@@ -235,7 +235,7 @@ export class CreateSnapshotFlyout extends MDSEnabledComponent<CreateSnapshotProp
               data-test-subj="snapshotNameInput"
               placeholder="Enter snapshot name"
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
           <EuiFormHelpText>A valid snapshot name can not contain upper case characters. </EuiFormHelpText>
 
           <EuiSpacer size="m" />

--- a/public/pages/Snapshots/components/ErrorModal/ErrorModal.tsx
+++ b/public/pages/Snapshots/components/ErrorModal/ErrorModal.tsx
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiModal, EuiText, EuiButton, EuiModalHeader, EuiModalFooter, EuiModalBody, EuiModalHeaderTitle } from "@elastic/eui";
+import { EuiModal, EuiText, EuiSmallButton, EuiModalHeader, EuiModalFooter, EuiModalBody, EuiModalHeaderTitle } from "@elastic/eui";
 import React from "react";
-import { RestoreError } from "../../../../models/interfaces"
-
+import { RestoreError } from "../../../../models/interfaces";
 
 interface ErrorModalProps {
   error: RestoreError;
@@ -16,20 +15,25 @@ interface ErrorModalProps {
 }
 
 const ErrorModal = ({ onClick, error, snapshotId }: ErrorModalProps) => {
-
   return (
     <>
       <EuiModal onClose={onClick}>
         <EuiModalHeader color="danger" style={{ flexDirection: "column", alignItems: "flex-start" }}>
-          <EuiModalHeaderTitle><h1>{`Failed to restore snapshot ${snapshotId}`}</h1></EuiModalHeaderTitle>
+          <EuiModalHeaderTitle>
+            <h1>{`Failed to restore snapshot ${snapshotId}`}</h1>
+          </EuiModalHeaderTitle>
         </EuiModalHeader>
 
         <EuiModalBody>
-          <EuiText size="m" color="danger">{error.reason ?? error}.</EuiText>
+          <EuiText size="m" color="danger">
+            {error.reason ?? error}.
+          </EuiText>
         </EuiModalBody>
 
         <EuiModalFooter>
-          <EuiButton onClick={onClick} fill>Close</EuiButton>
+          <EuiSmallButton onClick={onClick} fill>
+            Close
+          </EuiSmallButton>
         </EuiModalFooter>
       </EuiModal>
     </>

--- a/public/pages/Snapshots/components/IndexSettingsInput/IndexSettingsInput.tsx
+++ b/public/pages/Snapshots/components/IndexSettingsInput/IndexSettingsInput.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiCompressedFormRow, EuiText, EuiTextArea, EuiSpacer, EuiLink } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiText, EuiCompressedTextArea, EuiSpacer, EuiLink } from "@elastic/eui";
 import React, { useState, ChangeEvent } from "react";
 import { INDEX_SETTINGS_URL } from "../../../../utils/constants";
 
@@ -56,7 +56,7 @@ const IndexSettingsInput = ({ getIndexSettings, ignore, showError, inputError }:
         label={indexSettingsLabel}
         id={ignore ? "ignore_index_settings" : "customize_index_settings"}
       >
-        <EuiTextArea value={indexSettings} onChange={onSettingsChange} placeholder={placeholderText} isInvalid={showError} />
+        <EuiCompressedTextArea value={indexSettings} onChange={onSettingsChange} placeholder={placeholderText} isInvalid={showError} />
       </EuiCompressedFormRow>
 
       <EuiSpacer size="m" />

--- a/public/pages/Snapshots/components/IndexSettingsInput/IndexSettingsInput.tsx
+++ b/public/pages/Snapshots/components/IndexSettingsInput/IndexSettingsInput.tsx
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiFormRow, EuiText, EuiTextArea, EuiSpacer, EuiLink } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiText, EuiTextArea, EuiSpacer, EuiLink } from "@elastic/eui";
 import React, { useState, ChangeEvent } from "react";
-import { INDEX_SETTINGS_URL } from "../../../../utils/constants"
+import { INDEX_SETTINGS_URL } from "../../../../utils/constants";
 
 interface IndexSettingsInputProps {
   getIndexSettings: (indexSettings: string, ignore: boolean) => void;
@@ -50,9 +50,14 @@ const IndexSettingsInput = ({ getIndexSettings, ignore, showError, inputError }:
     <>
       <EuiSpacer size="m" />
 
-      <EuiFormRow isInvalid={showError} error={inputError} label={indexSettingsLabel} id={ignore ? "ignore_index_settings" : "customize_index_settings"}>
+      <EuiCompressedFormRow
+        isInvalid={showError}
+        error={inputError}
+        label={indexSettingsLabel}
+        id={ignore ? "ignore_index_settings" : "customize_index_settings"}
+      >
         <EuiTextArea value={indexSettings} onChange={onSettingsChange} placeholder={placeholderText} isInvalid={showError} />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
 
       <EuiSpacer size="m" />
     </>

--- a/public/pages/Snapshots/components/RenameInput/RenameInput.tsx
+++ b/public/pages/Snapshots/components/RenameInput/RenameInput.tsx
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiFormRow, EuiFieldText, EuiSpacer, EuiText, EuiLink } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiFieldText, EuiSpacer, EuiText, EuiLink } from "@elastic/eui";
 import React, { useState, ChangeEvent } from "react";
-import { RESTORE_SNAPSHOT_DOCUMENTATION_URL } from "../../../../utils/constants"
-import { BAD_RENAME_PATTERN_TEXT, BAD_RENAME_REPLACEMENT_TEXT, RENAME_HELP_TEXT, PATTERN_HELP_TEXT } from "../../constants"
+import { RESTORE_SNAPSHOT_DOCUMENTATION_URL } from "../../../../utils/constants";
+import { BAD_RENAME_PATTERN_TEXT, BAD_RENAME_REPLACEMENT_TEXT, RENAME_HELP_TEXT, PATTERN_HELP_TEXT } from "../../constants";
 interface RenameInputProps {
   getRenamePattern: (prefix: string) => void;
   getRenameReplacement: (prefix: string) => void;
   showPatternError: boolean;
-  showRenameError: boolean
+  showRenameError: boolean;
 }
 
 const RenameInput = ({ getRenamePattern, getRenameReplacement, showPatternError, showRenameError }: RenameInputProps) => {
@@ -59,15 +59,20 @@ const RenameInput = ({ getRenamePattern, getRenameReplacement, showPatternError,
   return (
     <>
       <EuiSpacer size="l" />
-      <EuiFormRow error={BAD_RENAME_PATTERN_TEXT} isInvalid={showPatternError} label={patternLabel} id="rename_pattern">
+      <EuiCompressedFormRow error={BAD_RENAME_PATTERN_TEXT} isInvalid={showPatternError} label={patternLabel} id="rename_pattern">
         <EuiFieldText value={renamePattern} onChange={onPatternChange} isInvalid={showPatternError} data-test-subj="renamePatternInput" />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
 
       <EuiSpacer size="m" />
 
-      <EuiFormRow error={BAD_RENAME_REPLACEMENT_TEXT} isInvalid={showRenameError} label={renameLabel} id="rename_replacement">
-        <EuiFieldText value={renameReplacement} onChange={onReplacementChange} isInvalid={showRenameError} data-test-subj="renameReplacementInput" />
-      </EuiFormRow>
+      <EuiCompressedFormRow error={BAD_RENAME_REPLACEMENT_TEXT} isInvalid={showRenameError} label={renameLabel} id="rename_replacement">
+        <EuiFieldText
+          value={renameReplacement}
+          onChange={onReplacementChange}
+          isInvalid={showRenameError}
+          data-test-subj="renameReplacementInput"
+        />
+      </EuiCompressedFormRow>
     </>
   );
 };

--- a/public/pages/Snapshots/components/RenameInput/RenameInput.tsx
+++ b/public/pages/Snapshots/components/RenameInput/RenameInput.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiCompressedFormRow, EuiFieldText, EuiSpacer, EuiText, EuiLink } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiCompressedFieldText, EuiSpacer, EuiText, EuiLink } from "@elastic/eui";
 import React, { useState, ChangeEvent } from "react";
 import { RESTORE_SNAPSHOT_DOCUMENTATION_URL } from "../../../../utils/constants";
 import { BAD_RENAME_PATTERN_TEXT, BAD_RENAME_REPLACEMENT_TEXT, RENAME_HELP_TEXT, PATTERN_HELP_TEXT } from "../../constants";
@@ -60,13 +60,18 @@ const RenameInput = ({ getRenamePattern, getRenameReplacement, showPatternError,
     <>
       <EuiSpacer size="l" />
       <EuiCompressedFormRow error={BAD_RENAME_PATTERN_TEXT} isInvalid={showPatternError} label={patternLabel} id="rename_pattern">
-        <EuiFieldText value={renamePattern} onChange={onPatternChange} isInvalid={showPatternError} data-test-subj="renamePatternInput" />
+        <EuiCompressedFieldText
+          value={renamePattern}
+          onChange={onPatternChange}
+          isInvalid={showPatternError}
+          data-test-subj="renamePatternInput"
+        />
       </EuiCompressedFormRow>
 
       <EuiSpacer size="m" />
 
       <EuiCompressedFormRow error={BAD_RENAME_REPLACEMENT_TEXT} isInvalid={showRenameError} label={renameLabel} id="rename_replacement">
-        <EuiFieldText
+        <EuiCompressedFieldText
           value={renameReplacement}
           onChange={onReplacementChange}
           isInvalid={showRenameError}

--- a/public/pages/Snapshots/components/RenameInput/__snapshots__/RenameInput.test.tsx.snap
+++ b/public/pages/Snapshots/components/RenameInput/__snapshots__/RenameInput.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`RenameInput component renders without error 1`] = `
     class="euiSpacer euiSpacer--l"
   />
   <div
-    class="euiFormRow"
+    class="euiFormRow euiFormRow--compressed"
     id="rename_pattern-row"
   >
     <div
@@ -53,13 +53,13 @@ exports[`RenameInput component renders without error 1`] = `
       class="euiFormRow__fieldWrapper"
     >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout euiFormControlLayout--compressed"
       >
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
           <input
-            class="euiFieldText"
+            class="euiFieldText euiFieldText--compressed"
             data-test-subj="renamePatternInput"
             id="rename_pattern"
             type="text"
@@ -73,7 +73,7 @@ exports[`RenameInput component renders without error 1`] = `
     class="euiSpacer euiSpacer--m"
   />
   <div
-    class="euiFormRow"
+    class="euiFormRow euiFormRow--compressed"
     id="rename_replacement-row"
   >
     <div
@@ -120,13 +120,13 @@ exports[`RenameInput component renders without error 1`] = `
       class="euiFormRow__fieldWrapper"
     >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout euiFormControlLayout--compressed"
       >
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
           <input
-            class="euiFieldText"
+            class="euiFieldText euiFieldText--compressed"
             data-test-subj="renameReplacementInput"
             id="rename_replacement"
             type="text"

--- a/public/pages/Snapshots/components/RestoreActivitiesPanel/RestoreActivitiesPanel.tsx
+++ b/public/pages/Snapshots/components/RestoreActivitiesPanel/RestoreActivitiesPanel.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiInMemoryTable, EuiSpacer, EuiLink, EuiFlyout, EuiButton, EuiButtonIcon, EuiEmptyPrompt, EuiHealth } from "@elastic/eui";
+import { EuiInMemoryTable, EuiSpacer, EuiLink, EuiFlyout, EuiSmallButton, EuiButtonIcon, EuiEmptyPrompt, EuiHealth } from "@elastic/eui";
 import _ from "lodash";
 import React, { useEffect, useContext, useState, useMemo } from "react";
 import { SnapshotManagementService } from "../../../../services";
@@ -191,14 +191,14 @@ export const RestoreActivitiesPanel = ({
 
   const actions = useMemo(
     () => [
-      <EuiButton
+      <EuiSmallButton
         iconType="refresh"
         onClick={getRestoreStatus}
         data-test-subj="refreshStatusButton"
         isDisabled={restoreStartRef ? false : true}
       >
         Refresh
-      </EuiButton>,
+      </EuiSmallButton>,
     ],
     []
   );

--- a/public/pages/Snapshots/components/RestoreSnapshotFlyout/RestoreSnapshotFlyout.tsx
+++ b/public/pages/Snapshots/components/RestoreSnapshotFlyout/RestoreSnapshotFlyout.tsx
@@ -15,7 +15,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiAccordion,
-  EuiCheckbox,
+  EuiCompressedCheckbox,
   EuiCallOut,
   EuiText,
 } from "@elastic/eui";
@@ -493,7 +493,7 @@ export class RestoreSnapshotFlyout extends MDSEnabledComponent<RestoreSnapshotPr
                     snapshot. Do you want to continue?
                   </p>
                   <EuiSpacer size="s" />
-                  <EuiCheckbox
+                  <EuiCompressedCheckbox
                     id={partial}
                     label={<EuiText size="s">Allow restore partial snapshots</EuiText>}
                     checked={String(_.get(snapshot, partial, false)) == "true"}

--- a/public/pages/Snapshots/components/SnapshotFlyout/SnapshotFlyout.tsx
+++ b/public/pages/Snapshots/components/SnapshotFlyout/SnapshotFlyout.tsx
@@ -5,7 +5,7 @@
 
 import React, { Component, useContext } from "react";
 import {
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFlexGrid,
   EuiFlexItem,
   EuiFlyout,
@@ -157,7 +157,7 @@ export class SnapshotFlyout extends MDSEnabledComponent<SnapshotFlyoutProps, Sna
         </EuiFlyoutBody>
 
         <EuiFlyoutFooter>
-          <EuiButtonEmpty onClick={onCloseFlyout}>Close</EuiButtonEmpty>
+          <EuiSmallButtonEmpty onClick={onCloseFlyout}>Close</EuiSmallButtonEmpty>
         </EuiFlyoutFooter>
       </EuiFlyout>
     );

--- a/public/pages/Snapshots/components/SnapshotIndicesInput/SnapshotIndicesInput.tsx
+++ b/public/pages/Snapshots/components/SnapshotIndicesInput/SnapshotIndicesInput.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiComboBox, EuiComboBoxOptionOption, EuiSpacer, EuiFormRow } from "@elastic/eui";
+import { EuiComboBox, EuiComboBoxOptionOption, EuiSpacer, EuiCompressedFormRow } from "@elastic/eui";
 import React from "react";
 import { IndexItem } from "../../../../../models/interfaces";
 
@@ -24,13 +24,13 @@ const SnapshotIndicesInput = ({
   onIndicesSelectionChange,
   getIndexOptions,
   onCreateOption,
-  showError
+  showError,
 }: SnapshotIndicesInputProps) => {
   const selectionError = "You must select at least one index to restore.";
 
   return (
     <>
-      <EuiFormRow label="Select indices or input index patterns you want to restore" error={selectionError} isInvalid={showError}>
+      <EuiCompressedFormRow label="Select indices or input index patterns you want to restore" error={selectionError} isInvalid={showError}>
         <EuiComboBox
           isInvalid={showError}
           placeholder="Select indices or input index patterns."
@@ -41,7 +41,7 @@ const SnapshotIndicesInput = ({
           onCreateOption={onCreateOption}
           isClearable={true}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
 
       <EuiSpacer size="m" />
     </>

--- a/public/pages/Snapshots/components/SnapshotIndicesInput/SnapshotIndicesInput.tsx
+++ b/public/pages/Snapshots/components/SnapshotIndicesInput/SnapshotIndicesInput.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiComboBox, EuiComboBoxOptionOption, EuiSpacer, EuiCompressedFormRow } from "@elastic/eui";
+import { EuiCompressedComboBox, EuiComboBoxOptionOption, EuiSpacer, EuiCompressedFormRow } from "@elastic/eui";
 import React from "react";
 import { IndexItem } from "../../../../../models/interfaces";
 
@@ -31,7 +31,7 @@ const SnapshotIndicesInput = ({
   return (
     <>
       <EuiCompressedFormRow label="Select indices or input index patterns you want to restore" error={selectionError} isInvalid={showError}>
-        <EuiComboBox
+        <EuiCompressedComboBox
           isInvalid={showError}
           placeholder="Select indices or input index patterns."
           options={indexOptions}

--- a/public/pages/Snapshots/components/SnapshotIndicesInput/__snapshots__/SnapshotIndicesInput.test.tsx.snap
+++ b/public/pages/Snapshots/components/SnapshotIndicesInput/__snapshots__/SnapshotIndicesInput.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`SnapshotIndicesInput component renders without error 1`] = `
 <div>
   <div
-    class="euiFormRow"
+    class="euiFormRow euiFormRow--compressed"
     id="some_html_id-row"
   >
     <div
@@ -22,17 +22,17 @@ exports[`SnapshotIndicesInput component renders without error 1`] = `
       <div
         aria-expanded="false"
         aria-haspopup="listbox"
-        class="euiComboBox"
+        class="euiComboBox euiComboBox--compressed"
         role="combobox"
       >
         <div
-          class="euiFormControlLayout"
+          class="euiFormControlLayout euiFormControlLayout--compressed"
         >
           <div
             class="euiFormControlLayout__childrenWrapper"
           >
             <div
-              class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+              class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
               data-test-subj="comboBoxInput"
               tabindex="-1"
             >

--- a/public/pages/Snapshots/components/SnapshotRenameOptions/SnapshotRenameOptions.tsx
+++ b/public/pages/Snapshots/components/SnapshotRenameOptions/SnapshotRenameOptions.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiRadio, EuiSpacer } from "@elastic/eui";
+import { EuiCompressedRadio, EuiSpacer } from "@elastic/eui";
 import CustomLabel from "../../../../components/CustomLabel";
 import { RESTORE_OPTIONS } from "../../../../models/interfaces";
 interface SnapshotRenameOptionsProps {
@@ -34,7 +34,7 @@ const SnapshotRenameOptions = ({
 
       <EuiSpacer size="m" />
 
-      <EuiRadio
+      <EuiCompressedRadio
         id={do_not_rename}
         name="rename_option"
         label="Do not rename"
@@ -44,7 +44,7 @@ const SnapshotRenameOptions = ({
 
       <EuiSpacer size="s" />
 
-      <EuiRadio
+      <EuiCompressedRadio
         id={add_prefix}
         name="rename_option"
         label="Add prefix to restored index names"
@@ -54,7 +54,7 @@ const SnapshotRenameOptions = ({
 
       <EuiSpacer size="s" />
 
-      <EuiRadio
+      <EuiCompressedRadio
         id={rename_indices}
         name="rename_option"
         label="Rename using regular expression (Advanced)"

--- a/public/pages/Snapshots/components/SnapshotRenameOptions/__snapshots__/SnapshotRenameOptions.test.tsx.snap
+++ b/public/pages/Snapshots/components/SnapshotRenameOptions/__snapshots__/SnapshotRenameOptions.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`SnapshotRenameOptions component renders without error 1`] = `
       class="euiSpacer euiSpacer--m"
     />
     <div
-      class="euiRadio"
+      class="euiRadio euiRadio--compressed"
     >
       <input
         checked=""
@@ -34,7 +34,7 @@ exports[`SnapshotRenameOptions component renders without error 1`] = `
       class="euiSpacer euiSpacer--s"
     />
     <div
-      class="euiRadio"
+      class="euiRadio euiRadio--compressed"
     >
       <input
         class="euiRadio__input"
@@ -57,7 +57,7 @@ exports[`SnapshotRenameOptions component renders without error 1`] = `
       class="euiSpacer euiSpacer--s"
     />
     <div
-      class="euiRadio"
+      class="euiRadio euiRadio--compressed"
     >
       <input
         class="euiRadio__input"

--- a/public/pages/Snapshots/components/SnapshotRestoreAdvancedOptions/SnapshotRestoreAdvancedOptions.tsx
+++ b/public/pages/Snapshots/components/SnapshotRestoreAdvancedOptions/SnapshotRestoreAdvancedOptions.tsx
@@ -4,8 +4,8 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiCheckbox, EuiSpacer, EuiText } from "@elastic/eui";
-import { CheckBoxLabel } from "../../helper"
+import { EuiCompressedCheckbox, EuiSpacer, EuiText } from "@elastic/eui";
+import { CheckBoxLabel } from "../../helper";
 import IndexSettingsInput from "../../components/IndexSettingsInput";
 import { RESTORE_OPTIONS } from "../../../../models/interfaces";
 
@@ -40,21 +40,15 @@ const SnapshotRestoreAdvancedOptions = ({
   onIgnoreIndexSettingsToggle,
   width,
   badJSONInput,
-  badIgnoreInput
+  badIgnoreInput,
 }: SnapshotAdvancedOptionsProps) => {
-  const {
-    restore_aliases,
-    include_global_state,
-    ignore_unavailable,
-    customize_index_settings,
-    ignore_index_settings,
-  } = RESTORE_OPTIONS;
-  const JSONerror = "Please enter valid JSON between curly brackets."
-  const ignoreListError = "Please enter a comma separated list of valid settings to ignore."
+  const { restore_aliases, include_global_state, ignore_unavailable, customize_index_settings, ignore_index_settings } = RESTORE_OPTIONS;
+  const JSONerror = "Please enter valid JSON between curly brackets.";
+  const ignoreListError = "Please enter a comma separated list of valid settings to ignore.";
 
   return (
     <div style={{ padding: "10px 10px", width: width }}>
-      <EuiCheckbox
+      <EuiCompressedCheckbox
         id={restore_aliases}
         label={<CheckBoxLabel title="Restore aliases" helpText="Restore index aliases alongside their associated indices." />}
         checked={restoreAliases}
@@ -63,7 +57,7 @@ const SnapshotRestoreAdvancedOptions = ({
 
       <EuiSpacer size="s" />
 
-      <EuiCheckbox
+      <EuiCompressedCheckbox
         id={include_global_state}
         label={<EuiText size="s">Restore cluster state from snapshots</EuiText>}
         checked={restoreClusterState}
@@ -72,7 +66,7 @@ const SnapshotRestoreAdvancedOptions = ({
 
       <EuiSpacer size="m" />
 
-      <EuiCheckbox
+      <EuiCompressedCheckbox
         id={ignore_unavailable}
         label={
           <CheckBoxLabel
@@ -97,30 +91,31 @@ const SnapshotRestoreAdvancedOptions = ({
 
       <EuiSpacer size="m" />
 
-      <EuiCheckbox
+      <EuiCompressedCheckbox
         id={customize_index_settings}
         label={<CheckBoxLabel title="Customize index settings" helpText="Overrides index settings on all restored indices." />}
         checked={customizeIndexSettings}
         onChange={onCustomizeIndexSettingsToggle}
       />
 
-      {customizeIndexSettings && <IndexSettingsInput getIndexSettings={getIndexSettings} ignore={false} showError={badJSONInput} inputError={JSONerror} />}
+      {customizeIndexSettings && (
+        <IndexSettingsInput getIndexSettings={getIndexSettings} ignore={false} showError={badJSONInput} inputError={JSONerror} />
+      )}
 
       <EuiSpacer size="s" />
 
-      <EuiCheckbox
+      <EuiCompressedCheckbox
         id={ignore_index_settings}
         label={
-          <CheckBoxLabel
-            title="Ignore index settings"
-            helpText="Exclude index settings that you don't want to restore from a snapshot."
-          />
+          <CheckBoxLabel title="Ignore index settings" helpText="Exclude index settings that you don't want to restore from a snapshot." />
         }
         checked={ignoreIndexSettings}
         onChange={onIgnoreIndexSettingsToggle}
       />
 
-      {ignoreIndexSettings && <IndexSettingsInput getIndexSettings={getIndexSettings} ignore={true} showError={badIgnoreInput} inputError={ignoreListError} />}
+      {ignoreIndexSettings && (
+        <IndexSettingsInput getIndexSettings={getIndexSettings} ignore={true} showError={badIgnoreInput} inputError={ignoreListError} />
+      )}
     </div>
   );
 };

--- a/public/pages/Snapshots/components/SnapshotRestoreOption/SnapshotRestoreOption.tsx
+++ b/public/pages/Snapshots/components/SnapshotRestoreOption/SnapshotRestoreOption.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiRadio, EuiSpacer } from "@elastic/eui";
+import { EuiCompressedRadio, EuiSpacer } from "@elastic/eui";
 import CustomLabel from "../../../../components/CustomLabel";
 import { RESTORE_OPTIONS } from "../../../../models/interfaces";
 
@@ -31,7 +31,7 @@ const SnapshotRestoreOption = ({
 
       <EuiSpacer size="m" />
 
-      <EuiRadio
+      <EuiCompressedRadio
         id={restore_all_indices}
         name="restore_option"
         label="Restore all indices in snapshot"
@@ -41,7 +41,7 @@ const SnapshotRestoreOption = ({
 
       <EuiSpacer size="s" />
 
-      <EuiRadio
+      <EuiCompressedRadio
         id={restore_specific_indices}
         name="restore_option"
         label="Restore specific indices"

--- a/public/pages/Snapshots/components/SnapshotRestoreOption/__snapshots__/SnapshotRestoreOption.test.tsx.snap
+++ b/public/pages/Snapshots/components/SnapshotRestoreOption/__snapshots__/SnapshotRestoreOption.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`SnapshotRestoreOption component renders without error 1`] = `
       class="euiSpacer euiSpacer--m"
     />
     <div
-      class="euiRadio"
+      class="euiRadio euiRadio--compressed"
     >
       <input
         checked=""
@@ -34,7 +34,7 @@ exports[`SnapshotRestoreOption component renders without error 1`] = `
       class="euiSpacer euiSpacer--s"
     />
     <div
-      class="euiRadio"
+      class="euiRadio euiRadio--compressed"
     >
       <input
         class="euiRadio__input"

--- a/public/pages/Snapshots/containers/Snapshots/Snapshots.tsx
+++ b/public/pages/Snapshots/containers/Snapshots/Snapshots.tsx
@@ -7,6 +7,7 @@ import React, { Component, useContext } from "react";
 import _ from "lodash";
 import { RouteComponentProps } from "react-router-dom";
 import {
+  EuiSmallButton,
   EuiInMemoryTable,
   EuiLink,
   EuiTableFieldDataColumnType,
@@ -524,18 +525,18 @@ export class Snapshots extends MDSEnabledComponent<SnapshotsProps, SnapshotsStat
     };
 
     const actions = [
-      <EuiButton iconType="refresh" onClick={this.getSnapshots} data-test-subj="refreshButton">
+      <EuiSmallButton iconType="refresh" onClick={this.getSnapshots} data-test-subj="refreshButton">
         Refresh
-      </EuiButton>,
-      <EuiButton disabled={!selectedItems.length} onClick={this.showDeleteModal} data-test-subj="deleteButton" color="danger">
+      </EuiSmallButton>,
+      <EuiSmallButton disabled={!selectedItems.length} onClick={this.showDeleteModal} data-test-subj="deleteButton" color="danger">
         Delete
-      </EuiButton>,
-      <EuiButton disabled={selectedItems.length !== 1} onClick={this.onClickRestore} color="primary" data-test-subj="restoreButton">
+      </EuiSmallButton>,
+      <EuiSmallButton disabled={selectedItems.length !== 1} onClick={this.onClickRestore} color="primary" data-test-subj="restoreButton">
         Restore
-      </EuiButton>,
-      <EuiButton onClick={this.onClickCreate} fill={true} data-test-subj="takeSnapshotButton">
+      </EuiSmallButton>,
+      <EuiSmallButton onClick={this.onClickCreate} fill={true} data-test-subj="takeSnapshotButton">
         Take snapshot
-      </EuiButton>,
+      </EuiSmallButton>,
     ];
 
     const subTitleText = (

--- a/public/pages/Snapshots/containers/Snapshots/Snapshots.tsx
+++ b/public/pages/Snapshots/containers/Snapshots/Snapshots.tsx
@@ -479,16 +479,15 @@ export class Snapshots extends MDSEnabledComponent<SnapshotsProps, SnapshotsStat
     };
 
     const actionsButton = (
-      <EuiButton
+      <EuiSmallButton
         iconType="arrowDown"
         iconSide="right"
         disabled={!selectedItems.length}
         onClick={this.onActionButtonClick}
         data-test-subj="actionButton"
-        size="s"
       >
         Actions
-      </EuiButton>
+      </EuiSmallButton>
     );
 
     const search = {

--- a/public/pages/Snapshots/helper.tsx
+++ b/public/pages/Snapshots/helper.tsx
@@ -5,8 +5,8 @@
 
 import React from "react";
 import _ from "lodash";
-import { Toast } from "../../models/interfaces"
-import { EuiHealth, EuiButton, EuiFlexGroup, EuiSpacer, EuiText } from "@elastic/eui";
+import { Toast } from "../../models/interfaces";
+import { EuiHealth, EuiSmallButton, EuiFlexGroup, EuiSpacer, EuiText } from "@elastic/eui";
 
 export function truncateLongText(text: string, truncateLen: number = 20): string {
   if (text.length > truncateLen) {
@@ -30,7 +30,6 @@ export function snapshotStatusRender(value: string): React.ReactElement {
   return <EuiHealth color={color}>{capital}</EuiHealth>;
 }
 
-
 export const getToasts = (id: string, message: string | undefined, snapshotId: string, onClick: (e: React.MouseEvent) => void): Toast[] => {
   const toasts = [
     {
@@ -42,10 +41,10 @@ export const getToasts = (id: string, message: string | undefined, snapshotId: s
         <>
           <EuiSpacer size="xl" />
           <EuiFlexGroup justifyContent="flexEnd" style={{ paddingRight: "1rem" }}>
-            <EuiButton onClick={onClick}>View restore activities</EuiButton>
+            <EuiSmallButton onClick={onClick}>View restore activities</EuiSmallButton>
           </EuiFlexGroup>
         </>
-      )
+      ),
     },
     {
       id: "error_restore_toast",
@@ -53,20 +52,22 @@ export const getToasts = (id: string, message: string | undefined, snapshotId: s
       color: "danger",
       text: (
         <>
-          <EuiText size="s" >{message}</EuiText>
+          <EuiText size="s">{message}</EuiText>
           <EuiSpacer size="xl" />
           <EuiFlexGroup justifyContent="flexEnd" style={{ paddingRight: "1rem" }}>
-            <EuiButton onClick={onClick} color="danger">View full error</EuiButton>
+            <EuiSmallButton onClick={onClick} color="danger">
+              View full error
+            </EuiSmallButton>
           </EuiFlexGroup>
         </>
-      )
-    }
-  ]
+      ),
+    },
+  ];
   if (id === "success_restore_toast") {
-    return [toasts[0]]
+    return [toasts[0]];
   }
   return [toasts[1]];
-}
+};
 
 interface CheckboxLabelProps {
   title: string;
@@ -76,9 +77,7 @@ interface CheckboxLabelProps {
 export const CheckBoxLabel = ({ title, helpText }: CheckboxLabelProps) => (
   <>
     <EuiText size="s">{title}</EuiText>
-    <EuiText
-      size="xs"
-      style={{ fontWeight: "200" }}>
+    <EuiText size="xs" style={{ fontWeight: "200" }}>
       {helpText}
     </EuiText>
   </>
@@ -91,7 +90,7 @@ export const checkBadJSON = (testString: string) => {
   } catch (err) {
     return true;
   }
-}
+};
 
 export const checkNoSelectedIndices = (indices: string, restoreSpecific: boolean): boolean => {
   let notSelected = false;
@@ -101,7 +100,7 @@ export const checkNoSelectedIndices = (indices: string, restoreSpecific: boolean
   }
 
   return notSelected;
-}
+};
 
 export const checkBadRegex = (regex: string): boolean => {
   try {
@@ -109,10 +108,9 @@ export const checkBadRegex = (regex: string): boolean => {
 
     return false;
   } catch (err) {
-
     return true;
   }
-}
+};
 
 export const checkBadReplacement = (regexString: string): boolean => {
   const isNotValid = regexString.indexOf("$") >= 0;
@@ -120,7 +118,7 @@ export const checkBadReplacement = (regexString: string): boolean => {
   if (isNotValid) return false;
 
   return true;
-}
+};
 
 export const checkCustomIgnoreConflict = (customIndexSettings?: string, ignoreIndexSettings?: string) => {
   if (customIndexSettings && customIndexSettings.length > 0) {
@@ -139,4 +137,4 @@ export const checkCustomIgnoreConflict = (customIndexSettings?: string, ignoreIn
     }
   }
   return false;
-}
+};

--- a/public/pages/SplitIndex/components/SplitIndexForm/SplitIndexForm.tsx
+++ b/public/pages/SplitIndex/components/SplitIndexForm/SplitIndexForm.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React, { Component } from "react";
-import { EuiSpacer, EuiLink, EuiFlexItem, EuiFlexGroup, EuiSmallButton, EuiButtonEmpty } from "@elastic/eui";
+import { EuiSpacer, EuiLink, EuiFlexItem, EuiFlexGroup, EuiSmallButton, EuiSmallButtonEmpty } from "@elastic/eui";
 import FormGenerator, { IField, IFormGeneratorRef, IFieldComponentProps } from "../../../../components/FormGenerator";
 import { IndexItem } from "../../../../../models/interfaces";
 import IndexDetail from "../../../../containers/IndexDetail";
@@ -240,9 +240,9 @@ export default class SplitIndexForm extends Component<SplitIndexComponentProps> 
         <EuiSpacer />
         <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty onClick={this.props.onCancel} data-test-subj="splitCancelButton">
+            <EuiSmallButtonEmpty onClick={this.props.onCancel} data-test-subj="splitCancelButton">
               Cancel
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiSmallButton

--- a/public/pages/SplitIndex/components/SplitIndexForm/SplitIndexForm.tsx
+++ b/public/pages/SplitIndex/components/SplitIndexForm/SplitIndexForm.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React, { Component } from "react";
-import { EuiSpacer, EuiLink, EuiFlexItem, EuiFlexGroup, EuiButton, EuiButtonEmpty } from "@elastic/eui";
+import { EuiSpacer, EuiLink, EuiFlexItem, EuiFlexGroup, EuiSmallButton, EuiButtonEmpty } from "@elastic/eui";
 import FormGenerator, { IField, IFormGeneratorRef, IFieldComponentProps } from "../../../../components/FormGenerator";
 import { IndexItem } from "../../../../../models/interfaces";
 import IndexDetail from "../../../../containers/IndexDetail";
@@ -245,7 +245,7 @@ export default class SplitIndexForm extends Component<SplitIndexComponentProps> 
             </EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               fill
               onClick={this.onSubmit}
               isLoading={this.props.loading}
@@ -254,7 +254,7 @@ export default class SplitIndexForm extends Component<SplitIndexComponentProps> 
               isDisabled={!readyForSplit}
             >
               Split
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </div>

--- a/public/pages/SplitIndex/container/SplitIndex/SplitIndex.tsx
+++ b/public/pages/SplitIndex/container/SplitIndex/SplitIndex.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React, { Component, useContext } from "react";
-import { EuiCallOut, EuiSpacer, EuiTitle, EuiSmallButton, EuiLink, EuiFormRow } from "@elastic/eui";
+import { EuiCallOut, EuiSpacer, EuiTitle, EuiSmallButton, EuiLink, EuiCompressedFormRow } from "@elastic/eui";
 import { get } from "lodash";
 
 import { CatIndex } from "../../../../../server/models/interfaces";
@@ -225,7 +225,7 @@ export class SplitIndex extends Component<SplitIndexProps> {
           <h1>Split index</h1>
         </EuiTitle>
 
-        <EuiFormRow
+        <EuiCompressedFormRow
           fullWidth
           helpText={
             <div>
@@ -241,7 +241,7 @@ export class SplitIndex extends Component<SplitIndexProps> {
           }
         >
           <></>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
 
         <EuiSpacer />
 

--- a/public/pages/SplitIndex/container/SplitIndex/SplitIndex.tsx
+++ b/public/pages/SplitIndex/container/SplitIndex/SplitIndex.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React, { Component, useContext } from "react";
-import { EuiCallOut, EuiSpacer, EuiTitle, EuiButton, EuiLink, EuiFormRow } from "@elastic/eui";
+import { EuiCallOut, EuiSpacer, EuiTitle, EuiSmallButton, EuiLink, EuiFormRow } from "@elastic/eui";
 import { get } from "lodash";
 
 import { CatIndex } from "../../../../../server/models/interfaces";
@@ -124,7 +124,7 @@ export class SplitIndex extends Component<SplitIndexProps> {
               complete. The index will be in the Red state while the index is opening.
             </p>
             <p>
-              <EuiButton
+              <EuiSmallButton
                 fill
                 isLoading={this.state.loading}
                 isDisabled={this.state.loading}
@@ -144,7 +144,7 @@ export class SplitIndex extends Component<SplitIndexProps> {
                 data-test-subj={"open-index-button"}
               >
                 Open index
-              </EuiButton>
+              </EuiSmallButton>
             </p>
           </EuiCallOut>
           <EuiSpacer />
@@ -159,7 +159,7 @@ export class SplitIndex extends Component<SplitIndexProps> {
         <>
           <EuiCallOut color="danger" iconType="alert" title="The source index must block write operations before splitting.">
             <p>In order to split an existing index, you must first set the index to block write operations.</p>
-            <EuiButton
+            <EuiSmallButton
               fill
               onClick={async () => {
                 try {
@@ -178,7 +178,7 @@ export class SplitIndex extends Component<SplitIndexProps> {
               data-test-subj={"set-indexsetting-button"}
             >
               Block write operations
-            </EuiButton>
+            </EuiSmallButton>
           </EuiCallOut>
           <EuiSpacer />
         </>

--- a/public/pages/SplitIndex/container/SplitIndex/__snapshots__/SplitIndex.test.tsx.snap
+++ b/public/pages/SplitIndex/container/SplitIndex/__snapshots__/SplitIndex.test.tsx.snap
@@ -12,7 +12,7 @@ HTMLCollection [
         Split index
       </h1>
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div

--- a/public/pages/Templates/components/DeleteTemplate/index.tsx
+++ b/public/pages/Templates/components/DeleteTemplate/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React, { useState } from "react";
-import { EuiButtonIcon, EuiToolTip } from "@elastic/eui";
+import { EuiSmallButtonIcon, EuiToolTip } from "@elastic/eui";
 import DeleteIndexModal from "../../containers/DeleteTemplatesModal";
 import { ITemplate } from "../../interface";
 
@@ -23,7 +23,7 @@ export default function DeleteTemplate(props: DeleteTemplateProps) {
   return (
     <>
       <EuiToolTip content="Delete template">
-        <EuiButtonIcon
+        <EuiSmallButtonIcon
           aria-label="Delete template"
           color="danger"
           iconType="trash"

--- a/public/pages/Templates/components/IndexControls/IndexControls.tsx
+++ b/public/pages/Templates/components/IndexControls/IndexControls.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useEffect, useState } from "react";
-import { EuiFieldSearch, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiCompressedFieldSearch, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import { getUISettings } from "../../../../services/Services";
 import TemplatesActions from "../../containers/TemplatesActions";
 import { ITemplate } from "../../interface";
@@ -40,8 +40,7 @@ export default function SearchControls(props: SearchControlsProps) {
   return useUpdatedUX ? (
     <EuiFlexGroup style={{ padding: "0px 5px 16px 5px" }} alignItems="center">
       <EuiFlexItem>
-        <EuiFieldSearch
-          compressed
+        <EuiCompressedFieldSearch
           fullWidth
           placeholder="Search"
           value={state.search}
@@ -55,7 +54,12 @@ export default function SearchControls(props: SearchControlsProps) {
   ) : (
     <EuiFlexGroup style={{ padding: "0px 5px" }} alignItems="center">
       <EuiFlexItem>
-        <EuiFieldSearch fullWidth placeholder="Search..." value={state.search} onChange={(e) => onChange("search", e.target.value)} />
+        <EuiCompressedFieldSearch
+          fullWidth
+          placeholder="Search..."
+          value={state.search}
+          onChange={(e) => onChange("search", e.target.value)}
+        />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/pages/Templates/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
+++ b/public/pages/Templates/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
@@ -9,13 +9,13 @@ exports[`<IndexControls /> spec renders the component 1`] = `
     class="euiFlexItem"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <input
-          class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
+          class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch-isClearable"
           placeholder="Search..."
           type="search"
           value="testing"
@@ -34,7 +34,7 @@ exports[`<IndexControls /> spec renders the component 1`] = `
         >
           <button
             aria-label="Clear input"
-            class="euiFormControlLayoutClearButton"
+            class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
             type="button"
           >
             EuiIconMock

--- a/public/pages/Templates/containers/AssociatedComponentsModal/AssociatedComponentsModal.tsx
+++ b/public/pages/Templates/containers/AssociatedComponentsModal/AssociatedComponentsModal.tsx
@@ -7,7 +7,16 @@ import React, { Dispatch, SetStateAction, useContext, useState } from "react";
 import { CoreStart } from "opensearch-dashboards/public";
 import { ServicesContext } from "../../../../services";
 import { CoreServicesContext } from "../../../../components/core_services";
-import { EuiButtonIcon, EuiFlyout, EuiFlyoutBody, EuiFlyoutHeader, EuiInMemoryTable, EuiLink, EuiTitle, EuiToolTip } from "@elastic/eui";
+import {
+  EuiSmallButtonIcon,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutHeader,
+  EuiInMemoryTable,
+  EuiLink,
+  EuiTitle,
+  EuiToolTip,
+} from "@elastic/eui";
 import { ROUTES } from "../../../../utils/constants";
 import { ReactChild } from "react";
 import { Modal } from "../../../../components/Modal";
@@ -62,7 +71,7 @@ export default function AssociatedComponentsModal(props: AssociatedComponentsMod
                   render: (value: string, record) => {
                     return (
                       <EuiToolTip content="Unlink">
-                        <EuiButtonIcon
+                        <EuiSmallButtonIcon
                           aria-label={`Unlink ${record.name}?`}
                           iconType="unlink"
                           onClick={() => {

--- a/public/pages/Templates/containers/AssociatedComponentsModal/__snapshots__/AssociatedComponentsModal.test.tsx.snap
+++ b/public/pages/Templates/containers/AssociatedComponentsModal/__snapshots__/AssociatedComponentsModal.test.tsx.snap
@@ -169,7 +169,7 @@ HTMLCollection [
                             >
                               <button
                                 aria-label="Unlink test_component_template?"
-                                class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
+                                class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
                                 type="button"
                               >
                                 EuiIconMock

--- a/public/pages/Templates/containers/DeleteTemplatesModal/__snapshots__/DeleteTemplateModal.test.tsx.snap
+++ b/public/pages/Templates/containers/DeleteTemplatesModal/__snapshots__/DeleteTemplateModal.test.tsx.snap
@@ -76,13 +76,13 @@ HTMLCollection [
                   </div>
                 </div>
                 <div
-                  class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                  class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <input
-                      class="euiFieldText euiFieldText--fullWidth"
+                      class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
                       data-test-subj="deleteInput"
                       placeholder="delete"
                       type="text"
@@ -97,7 +97,7 @@ HTMLCollection [
             class="euiModalFooter"
           >
             <button
-              class="euiButtonEmpty euiButtonEmpty--primary"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
               data-test-subj="deletaCancelButton"
               type="button"
             >
@@ -112,7 +112,7 @@ HTMLCollection [
               </span>
             </button>
             <button
-              class="euiButton euiButton--danger euiButton--fill euiButton-isDisabled"
+              class="euiButton euiButton--danger euiButton--small euiButton--fill euiButton-isDisabled"
               data-test-subj="deleteConfirmButton"
               disabled=""
               type="button"

--- a/public/pages/Templates/containers/Templates/Templates.tsx
+++ b/public/pages/Templates/containers/Templates/Templates.tsx
@@ -18,7 +18,7 @@ import {
   EuiSmallButton,
   EuiLink,
   EuiTitle,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiEmptyPrompt,
   EuiText,
   EuiToolTip,
@@ -382,7 +382,7 @@ class Templates extends MDSEnabledComponent<TemplatesProps, TemplatesState> {
     const description = [
       {
         renderComponent: (
-          <EuiFormRow
+          <EuiCompressedFormRow
             fullWidth
             helpText={
               <div>
@@ -394,7 +394,7 @@ class Templates extends MDSEnabledComponent<TemplatesProps, TemplatesState> {
             }
           >
             <></>
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         ),
       },
     ];

--- a/public/pages/Templates/containers/Templates/Templates.tsx
+++ b/public/pages/Templates/containers/Templates/Templates.tsx
@@ -22,7 +22,7 @@ import {
   EuiEmptyPrompt,
   EuiText,
   EuiToolTip,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
 } from "@elastic/eui";
 import { ContentPanel, ContentPanelActions } from "../../../../components/ContentPanel";
 import { DEFAULT_PAGE_SIZE_OPTIONS, DEFAULT_QUERY_PARAMS } from "../../utils/constants";
@@ -301,7 +301,7 @@ class Templates extends MDSEnabledComponent<TemplatesProps, TemplatesState> {
                       onUnlink={() => this.getTemplates()}
                       renderProps={({ setVisible }) => (
                         <EuiToolTip content="View associated index templates">
-                          <EuiButtonIcon
+                          <EuiSmallButtonIcon
                             aria-label="View associated index templates"
                             iconType="kqlSelector"
                             onClick={() => setVisible(true)}

--- a/public/pages/Templates/containers/Templates/Templates.tsx
+++ b/public/pages/Templates/containers/Templates/Templates.tsx
@@ -15,7 +15,7 @@ import {
   Direction,
   Pagination,
   EuiTableSelectionType,
-  EuiButton,
+  EuiSmallButton,
   EuiLink,
   EuiTitle,
   EuiFormRow,
@@ -339,14 +339,14 @@ class Templates extends MDSEnabledComponent<TemplatesProps, TemplatesState> {
                   </EuiText>
                 }
                 actions={[
-                  <EuiButton
+                  <EuiSmallButton
                     fill
                     onClick={() => {
                       this.props.history.push(ROUTES.CREATE_TEMPLATE);
                     }}
                   >
                     Create template
-                  </EuiButton>,
+                  </EuiSmallButton>,
                 ]}
               />
             ) : (
@@ -357,7 +357,7 @@ class Templates extends MDSEnabledComponent<TemplatesProps, TemplatesState> {
                   </EuiText>
                 }
                 actions={[
-                  <EuiButton
+                  <EuiSmallButton
                     fill
                     onClick={() => {
                       this.setState(defaultFilter, () => {
@@ -366,7 +366,7 @@ class Templates extends MDSEnabledComponent<TemplatesProps, TemplatesState> {
                     }}
                   >
                     Reset filters
-                  </EuiButton>,
+                  </EuiSmallButton>,
                 ]}
               />
             )

--- a/public/pages/Templates/containers/Templates/Templates.tsx
+++ b/public/pages/Templates/containers/Templates/Templates.tsx
@@ -460,7 +460,7 @@ class Templates extends MDSEnabledComponent<TemplatesProps, TemplatesState> {
             <EuiTitle>
               <span>Templates</span>
             </EuiTitle>
-            <EuiFormRow
+            <EuiCompressedFormRow
               fullWidth
               helpText={
                 <div>
@@ -472,7 +472,7 @@ class Templates extends MDSEnabledComponent<TemplatesProps, TemplatesState> {
               }
             >
               <></>
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </>
         }
       >

--- a/public/pages/Templates/containers/Templates/__snapshots__/Templates.test.tsx.snap
+++ b/public/pages/Templates/containers/Templates/__snapshots__/Templates.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`<Templates /> spec renders the component 1`] = `
         Templates
       </span>
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -73,7 +73,7 @@ exports[`<Templates /> spec renders the component 1`] = `
                   class="euiPopover__anchor"
                 >
                   <button
-                    class="euiButton euiButton--primary"
+                    class="euiButton euiButton--primary euiButton--small"
                     type="button"
                   >
                     <span
@@ -94,7 +94,7 @@ exports[`<Templates /> spec renders the component 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButton euiButton--primary euiButton--fill"
+                class="euiButton euiButton--primary euiButton--small euiButton--fill"
                 data-test-subj="Create templateButton"
                 type="button"
               >
@@ -128,13 +128,13 @@ exports[`<Templates /> spec renders the component 1`] = `
         class="euiFlexItem"
       >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+          class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
         >
           <div
             class="euiFormControlLayout__childrenWrapper"
           >
             <input
-              class="euiFieldSearch euiFieldSearch--fullWidth"
+              class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
               placeholder="Search..."
               type="search"
               value=""
@@ -427,7 +427,7 @@ exports[`<Templates /> spec renders the component 1`] = `
                           class="euiFlexItem euiFlexItem--flexGrowZero"
                         >
                           <button
-                            class="euiButton euiButton--primary euiButton--fill"
+                            class="euiButton euiButton--primary euiButton--small euiButton--fill"
                             type="button"
                           >
                             <span

--- a/public/pages/Templates/containers/TemplatesActions/__snapshots__/TemplatesActions.test.tsx.snap
+++ b/public/pages/Templates/containers/TemplatesActions/__snapshots__/TemplatesActions.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`<TemplatesActions /> spec delete templates by calling commonService 1`]
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -36,7 +36,7 @@ exports[`<TemplatesActions /> spec renders the component and all the actions sho
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span

--- a/public/pages/Templates/containers/TemplatesActions/index.tsx
+++ b/public/pages/Templates/containers/TemplatesActions/index.tsx
@@ -4,7 +4,7 @@
  */
 import React, { useMemo, useState } from "react";
 import { RouteComponentProps } from "react-router-dom";
-import { EuiButton, EuiContextMenu } from "@elastic/eui";
+import { EuiSmallButton, EuiContextMenu } from "@elastic/eui";
 import SimplePopover from "../../../../components/SimplePopover";
 import DeleteIndexModal from "../DeleteTemplatesModal";
 import { ITemplate } from "../../interface";
@@ -38,9 +38,9 @@ export default function TemplatesActions(props: TemplatesActionsProps) {
         data-test-subj="moreAction"
         panelPaddingSize="none"
         button={
-          <EuiButton iconType="arrowDown" iconSide="right" size={size}>
+          <EuiSmallButton iconType="arrowDown" iconSide="right">
             Actions
-          </EuiButton>
+          </EuiSmallButton>
         }
       >
         <EuiContextMenu

--- a/public/pages/Transforms/components/ConfigureTransform/Configure.tsx
+++ b/public/pages/Transforms/components/ConfigureTransform/Configure.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiSpacer, EuiCompressedFormRow, EuiFieldText, EuiTextArea, EuiText, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiSpacer, EuiCompressedFormRow, EuiCompressedFieldText, EuiTextArea, EuiText, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
 
 interface ConfigureTransformProps {
@@ -30,7 +30,13 @@ const ConfigureTransform = ({
     <div style={{ paddingLeft: "10px" }}>
       <EuiSpacer size="s" />
       <EuiCompressedFormRow label="Name" helpText="Specify a unique, descriptive name." isInvalid={!!error} error={error}>
-        <EuiFieldText isInvalid={!!error} placeholder="transform-id" value={transformId} onChange={onChangeName} disabled={inEdit} />
+        <EuiCompressedFieldText
+          isInvalid={!!error}
+          placeholder="transform-id"
+          value={transformId}
+          onChange={onChangeName}
+          disabled={inEdit}
+        />
       </EuiCompressedFormRow>
       <EuiSpacer />
       <EuiFlexGroup gutterSize="xs">

--- a/public/pages/Transforms/components/ConfigureTransform/Configure.tsx
+++ b/public/pages/Transforms/components/ConfigureTransform/Configure.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiSpacer, EuiFormRow, EuiFieldText, EuiTextArea, EuiText, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiSpacer, EuiCompressedFormRow, EuiFieldText, EuiTextArea, EuiText, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
 
 interface ConfigureTransformProps {
@@ -29,9 +29,9 @@ const ConfigureTransform = ({
   <ContentPanel bodyStyles={{ padding: "initial" }} title="Job name and description" titleSize={size}>
     <div style={{ paddingLeft: "10px" }}>
       <EuiSpacer size="s" />
-      <EuiFormRow label="Name" helpText="Specify a unique, descriptive name." isInvalid={!!error} error={error}>
+      <EuiCompressedFormRow label="Name" helpText="Specify a unique, descriptive name." isInvalid={!!error} error={error}>
         <EuiFieldText isInvalid={!!error} placeholder="transform-id" value={transformId} onChange={onChangeName} disabled={inEdit} />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
       <EuiSpacer />
       <EuiFlexGroup gutterSize="xs">
         <EuiFlexItem grow={false}>
@@ -46,9 +46,9 @@ const ConfigureTransform = ({
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="xs" />
-      <EuiFormRow>
+      <EuiCompressedFormRow>
         <EuiTextArea compressed={true} value={description} onChange={onChangeDescription} data-test-subj="description" />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </div>
   </ContentPanel>
 );

--- a/public/pages/Transforms/components/DeleteModal/DeleteModal.tsx
+++ b/public/pages/Transforms/components/DeleteModal/DeleteModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, Component, Fragment } from "react";
-import { EuiConfirmModal, EuiForm, EuiCompressedFormRow, EuiFieldText, EuiOverlayMask, EuiSpacer } from "@elastic/eui";
+import { EuiConfirmModal, EuiForm, EuiCompressedFormRow, EuiCompressedFieldText, EuiOverlayMask, EuiSpacer } from "@elastic/eui";
 
 // TODO: Merge with Rollup to create generic component
 interface DeleteModalProps {
@@ -47,7 +47,12 @@ export default class DeleteModal extends Component<DeleteModalProps, DeleteModal
             </Fragment>
             <EuiSpacer size="s" />
             <EuiCompressedFormRow helpText="To confirm deletion, enter delete in the text field">
-              <EuiFieldText value={confirmDeleteText} placeholder="delete" onChange={this.onChange} data-test-subj="deleteTextField" />
+              <EuiCompressedFieldText
+                value={confirmDeleteText}
+                placeholder="delete"
+                onChange={this.onChange}
+                data-test-subj="deleteTextField"
+              />
             </EuiCompressedFormRow>
           </EuiForm>
         </EuiConfirmModal>

--- a/public/pages/Transforms/components/DeleteModal/DeleteModal.tsx
+++ b/public/pages/Transforms/components/DeleteModal/DeleteModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, Component, Fragment } from "react";
-import { EuiConfirmModal, EuiForm, EuiFormRow, EuiFieldText, EuiOverlayMask, EuiSpacer } from "@elastic/eui";
+import { EuiConfirmModal, EuiForm, EuiCompressedFormRow, EuiFieldText, EuiOverlayMask, EuiSpacer } from "@elastic/eui";
 
 // TODO: Merge with Rollup to create generic component
 interface DeleteModalProps {
@@ -46,9 +46,9 @@ export default class DeleteModal extends Component<DeleteModalProps, DeleteModal
               it will remain intact.
             </Fragment>
             <EuiSpacer size="s" />
-            <EuiFormRow helpText="To confirm deletion, enter delete in the text field">
+            <EuiCompressedFormRow helpText="To confirm deletion, enter delete in the text field">
               <EuiFieldText value={confirmDeleteText} placeholder="delete" onChange={this.onChange} data-test-subj="deleteTextField" />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiForm>
         </EuiConfirmModal>
       </EuiOverlayMask>

--- a/public/pages/Transforms/components/ErrorModal/ErrorModal.tsx
+++ b/public/pages/Transforms/components/ErrorModal/ErrorModal.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
@@ -37,9 +37,9 @@ const ErrorModal = ({ metadata, onClose }: ErrorModalProps) => (
       </EuiModalBody>
 
       <EuiModalFooter>
-        <EuiButton fill onClick={onClose} data-test-subj="errorModalCloseButton">
+        <EuiSmallButton fill onClick={onClose} data-test-subj="errorModalCloseButton">
           Close
-        </EuiButton>
+        </EuiSmallButton>
       </EuiModalFooter>
     </EuiModal>
   </EuiOverlayMask>

--- a/public/pages/Transforms/components/Schedule/Schedule.tsx
+++ b/public/pages/Transforms/components/Schedule/Schedule.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, Component } from "react";
-import { EuiSpacer, EuiCheckbox, EuiAccordion, EuiCompressedFormRow, EuiCompressedFieldNumber } from "@elastic/eui";
+import { EuiSpacer, EuiCompressedCheckbox, EuiAccordion, EuiCompressedFormRow, EuiCompressedFieldNumber } from "@elastic/eui";
 // @ts-ignore
 import { htmlIdGenerator } from "@elastic/eui/lib/services";
 import { ContentPanel } from "../../../../components/ContentPanel";
@@ -52,7 +52,7 @@ export default class Schedule extends Component<ScheduleProps> {
     return (
       <ContentPanel bodyStyles={{ padding: "initial" }} title="Schedule" titleSize={size}>
         <div style={{ paddingLeft: "10px" }}>
-          <EuiCheckbox
+          <EuiCompressedCheckbox
             id="jobEnabled"
             label="Job enabled by default"
             checked={enabled}

--- a/public/pages/Transforms/components/Schedule/Schedule.tsx
+++ b/public/pages/Transforms/components/Schedule/Schedule.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, Component } from "react";
-import { EuiSpacer, EuiCheckbox, EuiAccordion, EuiFormRow, EuiFieldNumber } from "@elastic/eui";
+import { EuiSpacer, EuiCheckbox, EuiAccordion, EuiCompressedFormRow, EuiFieldNumber } from "@elastic/eui";
 // @ts-ignore
 import { htmlIdGenerator } from "@elastic/eui/lib/services";
 import { ContentPanel } from "../../../../components/ContentPanel";
@@ -71,14 +71,14 @@ export default class Schedule extends Component<ScheduleProps> {
 
           <EuiAccordion id={htmlIdGenerator()()} buttonContent="Advanced">
             <EuiSpacer size="m" />
-            <EuiFormRow
+            <EuiCompressedFormRow
               label={"Pages per execution"}
               helpText={
                 "Determines the number of transformed buckets that are computed and indexed at a time. A larger number means faster execution, but costs more memory. An exception occurs when memory limits are exceeded. We recommend you to start with default value and adjust based on your use case."
               }
             >
               <EuiFieldNumber min={1} placeholder="1000" value={pageSize} onChange={onPageChange} />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiAccordion>
         </div>
       </ContentPanel>

--- a/public/pages/Transforms/components/Schedule/Schedule.tsx
+++ b/public/pages/Transforms/components/Schedule/Schedule.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, Component } from "react";
-import { EuiSpacer, EuiCheckbox, EuiAccordion, EuiCompressedFormRow, EuiFieldNumber } from "@elastic/eui";
+import { EuiSpacer, EuiCheckbox, EuiAccordion, EuiCompressedFormRow, EuiCompressedFieldNumber } from "@elastic/eui";
 // @ts-ignore
 import { htmlIdGenerator } from "@elastic/eui/lib/services";
 import { ContentPanel } from "../../../../components/ContentPanel";
@@ -77,7 +77,7 @@ export default class Schedule extends Component<ScheduleProps> {
                 "Determines the number of transformed buckets that are computed and indexed at a time. A larger number means faster execution, but costs more memory. An exception occurs when memory limits are exceeded. We recommend you to start with default value and adjust based on your use case."
               }
             >
-              <EuiFieldNumber min={1} placeholder="1000" value={pageSize} onChange={onPageChange} />
+              <EuiCompressedFieldNumber min={1} placeholder="1000" value={pageSize} onChange={onPageChange} />
             </EuiCompressedFormRow>
           </EuiAccordion>
         </div>

--- a/public/pages/Transforms/components/TransformEmptyPrompt/TransformEmptyPrompt.tsx
+++ b/public/pages/Transforms/components/TransformEmptyPrompt/TransformEmptyPrompt.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { EuiButton, EuiEmptyPrompt, EuiText } from "@elastic/eui";
+import { EuiSmallButton, EuiEmptyPrompt, EuiText } from "@elastic/eui";
 import { PLUGIN_NAME, ROUTES } from "../../../../utils/constants";
 import { getUISettings } from "../../../../services/Services";
 
@@ -36,20 +36,16 @@ const getActions: React.SFC<TransformEmptyPromptProps> = ({ filterIsApplied, loa
 
   if (filterIsApplied) {
     return (
-      <EuiButton size={useUpdatedUX ? "s" : undefined} fill onClick={resetFilters} data-test-subj="transformEmptyPromptRestFilters">
+      <EuiSmallButton fill onClick={resetFilters} data-test-subj="transformEmptyPromptRestFilters">
         Reset Filters
-      </EuiButton>
+      </EuiSmallButton>
     );
   }
 
   return (
-    <EuiButton
-      size={useUpdatedUX ? "s" : undefined}
-      href={`${PLUGIN_NAME}#${ROUTES.CREATE_TRANSFORM}`}
-      data-test-subj="emptyPromptCreateTransformButton"
-    >
+    <EuiSmallButton href={`${PLUGIN_NAME}#${ROUTES.CREATE_TRANSFORM}`} data-test-subj="emptyPromptCreateTransformButton">
       Create transform
-    </EuiButton>
+    </EuiSmallButton>
   );
 };
 

--- a/public/pages/Transforms/containers/Transforms/EditTransform.tsx
+++ b/public/pages/Transforms/containers/Transforms/EditTransform.tsx
@@ -11,7 +11,7 @@ import { EMPTY_TRANSFORM } from "../../utils/constants";
 import queryString from "query-string";
 import { BREADCRUMBS, ROUTES } from "../../../../utils/constants";
 import { getErrorMessage } from "../../../../utils/helpers";
-import { EuiFlexItem, EuiFlexGroup, EuiButton, EuiTitle, EuiSpacer, EuiButtonEmpty } from "@elastic/eui";
+import { EuiFlexItem, EuiFlexGroup, EuiSmallButton, EuiTitle, EuiSpacer, EuiButtonEmpty } from "@elastic/eui";
 import ConfigureTransform from "../../components/ConfigureTransform";
 import Schedule from "../../components/Schedule";
 import Indices from "../../components/Indices";
@@ -197,15 +197,14 @@ export class EditTransform extends Component<EditTransformProps, EditTransformSt
               </EuiButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
-                size={this.state.useUpdatedUX ? "s" : undefined}
+              <EuiSmallButton
                 fill
                 onClick={this.onSubmit}
                 isLoading={isSubmitting}
                 data-test-subj="editTransformSaveButton"
               >
                 Save changes
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
         </>

--- a/public/pages/Transforms/containers/Transforms/EditTransform.tsx
+++ b/public/pages/Transforms/containers/Transforms/EditTransform.tsx
@@ -11,7 +11,7 @@ import { EMPTY_TRANSFORM } from "../../utils/constants";
 import queryString from "query-string";
 import { BREADCRUMBS, ROUTES } from "../../../../utils/constants";
 import { getErrorMessage } from "../../../../utils/helpers";
-import { EuiFlexItem, EuiFlexGroup, EuiSmallButton, EuiTitle, EuiSpacer, EuiButtonEmpty } from "@elastic/eui";
+import { EuiFlexItem, EuiFlexGroup, EuiSmallButton, EuiTitle, EuiSpacer, EuiSmallButtonEmpty } from "@elastic/eui";
 import ConfigureTransform from "../../components/ConfigureTransform";
 import Schedule from "../../components/Schedule";
 import Indices from "../../components/Indices";
@@ -188,13 +188,9 @@ export class EditTransform extends Component<EditTransformProps, EditTransformSt
 
           <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty
-                size={this.state.useUpdatedUX ? "s" : undefined}
-                onClick={this.onCancel}
-                data-test-subj="editTransformCancelButton"
-              >
+              <EuiSmallButtonEmpty onClick={this.onCancel} data-test-subj="editTransformCancelButton">
                 Cancel
-              </EuiButtonEmpty>
+              </EuiSmallButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiSmallButton

--- a/public/pages/Transforms/containers/Transforms/TransformDetails.tsx
+++ b/public/pages/Transforms/containers/Transforms/TransformDetails.tsx
@@ -333,22 +333,21 @@ export class TransformDetails extends Component<TransformDetailsProps, Transform
       },
       {
         renderComponent: (
-          <EuiButton size="s" onClick={() => (!this.state.enabled ? onClickEnable() : onClickDisable())}>
+          <EuiSmallButton onClick={() => (!this.state.enabled ? onClickEnable() : onClickDisable())}>
             {this.state.enabled ? "Disable" : "Enable"}
-          </EuiButton>
+          </EuiSmallButton>
         ),
       },
       {
         renderComponent: (
-          <EuiButton
-            size="s"
+          <EuiSmallButton
             onClick={() => {
               this.closePopover();
               this.showJsonModal();
             }}
           >
             View JSON
-          </EuiButton>
+          </EuiSmallButton>
         ),
       },
       {

--- a/public/pages/Transforms/containers/Transforms/TransformDetails.tsx
+++ b/public/pages/Transforms/containers/Transforms/TransformDetails.tsx
@@ -10,7 +10,7 @@ import {
   EuiFlexItem,
   EuiSmallButton,
   EuiOverlayMask,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiModalFooter,
   EuiModal,
   EuiModalHeader,
@@ -456,7 +456,7 @@ export class TransformDetails extends Component<TransformDetailsProps, Transform
               </EuiModalBody>
 
               <EuiModalFooter>
-                <EuiButtonEmpty onClick={this.closeModal}>Close</EuiButtonEmpty>
+                <EuiSmallButtonEmpty onClick={this.closeModal}>Close</EuiSmallButtonEmpty>
               </EuiModalFooter>
             </EuiModal>
           </EuiOverlayMask>

--- a/public/pages/Transforms/containers/Transforms/TransformDetails.tsx
+++ b/public/pages/Transforms/containers/Transforms/TransformDetails.tsx
@@ -8,7 +8,7 @@ import {
   EuiTitle,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiButton,
+  EuiSmallButton,
   EuiOverlayMask,
   EuiButtonEmpty,
   EuiModalFooter,
@@ -238,9 +238,15 @@ export class TransformDetails extends Component<TransformDetailsProps, Transform
       scheduleText = buildIntervalScheduleText(transformJson.transform.continuous, interval, intervalTimeUnit);
     }
     const actionButton = (
-      <EuiButton iconType="arrowDown" iconSide="right" disabled={false} onClick={this.onActionButtonClick} data-test-subj="actionButton">
+      <EuiSmallButton
+        iconType="arrowDown"
+        iconSide="right"
+        disabled={false}
+        onClick={this.onActionButtonClick}
+        data-test-subj="actionButton"
+      >
         Actions
-      </EuiButton>
+      </EuiSmallButton>
     );
 
     const actionItems = [

--- a/public/pages/Transforms/containers/Transforms/Transforms.tsx
+++ b/public/pages/Transforms/containers/Transforms/Transforms.tsx
@@ -11,7 +11,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiTitle,
-  EuiButton,
+  EuiSmallButton,
   EuiBasicTable,
   EuiPopover,
   EuiContextMenuPanel,
@@ -200,7 +200,7 @@ export class Transforms extends MDSEnabledComponent<TransformProps, TransformSta
     const Actionsize = this.state.useUpdatedUX ? "s" : "m";
 
     const actionButton = (
-      <EuiButton
+      <EuiSmallButton
         iconType="arrowDown"
         iconSide="right"
         disabled={!selectedItems.length}
@@ -209,7 +209,7 @@ export class Transforms extends MDSEnabledComponent<TransformProps, TransformSta
         size={Actionsize}
       >
         Actions
-      </EuiButton>
+      </EuiSmallButton>
     );
 
     const actionItems = [
@@ -336,17 +336,17 @@ export class Transforms extends MDSEnabledComponent<TransformProps, TransformSta
           <EuiFlexItem grow={false}>
             <EuiFlexGroup alignItems="center" gutterSize="s">
               <EuiFlexItem grow={false}>
-                <EuiButton iconType="refresh" onClick={this.getTransforms} data-test-subj="refreshButton">
+                <EuiSmallButton iconType="refresh" onClick={this.getTransforms} data-test-subj="refreshButton">
                   Refresh
-                </EuiButton>
+                </EuiSmallButton>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiButton disabled={!selectedItems.length} onClick={this.onDisable} data-test-subj="disableButton">
+                <EuiSmallButton disabled={!selectedItems.length} onClick={this.onDisable} data-test-subj="disableButton">
                   Disable
-                </EuiButton>
+                </EuiSmallButton>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiButton
+                <EuiSmallButton
                   disabled={!selectedItems.length}
                   onClick={() => {
                     this.onEnable();
@@ -354,7 +354,7 @@ export class Transforms extends MDSEnabledComponent<TransformProps, TransformSta
                   data-test-subj="enableButton"
                 >
                   Enable
-                </EuiButton>
+                </EuiSmallButton>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiPopover
@@ -370,9 +370,9 @@ export class Transforms extends MDSEnabledComponent<TransformProps, TransformSta
                 </EuiPopover>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiButton onClick={this.onClickCreate} fill={true} data-test-subj="createTransformButton">
+                <EuiSmallButton onClick={this.onClickCreate} fill={true} data-test-subj="createTransformButton">
                   Create transform job
-                </EuiButton>
+                </EuiSmallButton>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>

--- a/public/pages/Transforms/containers/Transforms/Transforms.tsx
+++ b/public/pages/Transforms/containers/Transforms/Transforms.tsx
@@ -15,7 +15,7 @@ import {
   EuiBasicTable,
   EuiPopover,
   EuiContextMenuPanel,
-  EuiFieldSearch,
+  EuiCompressedFieldSearch,
   EuiHorizontalRule,
   EuiPagination,
   EuiLink,
@@ -381,7 +381,7 @@ export class Transforms extends MDSEnabledComponent<TransformProps, TransformSta
         <div style={{ padding: "initial" }}>
           <EuiFlexGroup style={{ padding: "0px 5px" }}>
             <EuiFlexItem>
-              <EuiFieldSearch fullWidth={true} value={search} placeholder="Search" onChange={this.onSearchChange} />
+              <EuiCompressedFieldSearch fullWidth={true} value={search} placeholder="Search" onChange={this.onSearchChange} />
             </EuiFlexItem>
             {pageCount > 1 && (
               <EuiFlexItem grow={false} style={{ justifyContent: "center" }}>

--- a/public/pages/Transforms/containers/Transforms/__snapshots__/EditTransform.test.tsx.snap
+++ b/public/pages/Transforms/containers/Transforms/__snapshots__/EditTransform.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`<EditTransform /> spec renders the component 1`] = `
           class="euiSpacer euiSpacer--s"
         />
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -67,14 +67,14 @@ exports[`<EditTransform /> spec renders the component 1`] = `
             class="euiFormRow__fieldWrapper"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
                   aria-describedby="some_html_id-help-0"
-                  class="euiFieldText"
+                  class="euiFieldText euiFieldText--compressed"
                   disabled=""
                   id="some_html_id"
                   placeholder="transform-id"
@@ -128,7 +128,7 @@ exports[`<EditTransform /> spec renders the component 1`] = `
           class="euiSpacer euiSpacer--xs"
         />
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -361,7 +361,7 @@ exports[`<EditTransform /> spec renders the component 1`] = `
         style="padding-left: 10px;"
       >
         <div
-          class="euiCheckbox"
+          class="euiCheckbox euiCheckbox--compressed"
         >
           <input
             checked=""
@@ -392,7 +392,7 @@ exports[`<EditTransform /> spec renders the component 1`] = `
             style="width: 200px;"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
@@ -410,13 +410,13 @@ exports[`<EditTransform /> spec renders the component 1`] = `
                 class="euiFormRow__fieldWrapper"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <input
-                      class="euiFieldNumber"
+                      class="euiFieldNumber euiFieldNumber--compressed"
                       id="some_html_id"
                       type="number"
                       value="2"
@@ -430,20 +430,20 @@ exports[`<EditTransform /> spec renders the component 1`] = `
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow euiFormRow--hasEmptyLabelSpace"
+              class="euiFormRow euiFormRow--hasEmptyLabelSpace euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
                 class="euiFormRow__fieldWrapper"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <select
-                      class="euiSelect"
+                      class="euiSelect euiSelect--compressed"
                       id="some_html_id"
                     >
                       <option
@@ -520,7 +520,7 @@ exports[`<EditTransform /> spec renders the component 1`] = `
                   class="euiSpacer euiSpacer--m"
                 />
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
@@ -537,14 +537,14 @@ exports[`<EditTransform /> spec renders the component 1`] = `
                     class="euiFormRow__fieldWrapper"
                   >
                     <div
-                      class="euiFormControlLayout"
+                      class="euiFormControlLayout euiFormControlLayout--compressed"
                     >
                       <div
                         class="euiFormControlLayout__childrenWrapper"
                       >
                         <input
                           aria-describedby="some_html_id-help-0"
-                          class="euiFieldNumber"
+                          class="euiFieldNumber euiFieldNumber--compressed"
                           id="some_html_id"
                           min="1"
                           placeholder="1000"
@@ -578,7 +578,7 @@ exports[`<EditTransform /> spec renders the component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButtonEmpty euiButtonEmpty--primary"
+        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
         data-test-subj="editTransformCancelButton"
         type="button"
       >
@@ -597,7 +597,7 @@ exports[`<EditTransform /> spec renders the component 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButton euiButton--primary euiButton--fill"
+        class="euiButton euiButton--primary euiButton--small euiButton--fill"
         data-test-subj="editTransformSaveButton"
         type="button"
       >

--- a/public/pages/Transforms/containers/Transforms/__snapshots__/Transforms.test.tsx.snap
+++ b/public/pages/Transforms/containers/Transforms/__snapshots__/Transforms.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`<Transforms /> spec renders the component 1`] = `
             class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <button
-              class="euiButton euiButton--primary"
+              class="euiButton euiButton--primary euiButton--small"
               data-test-subj="refreshButton"
               type="button"
             >
@@ -51,7 +51,7 @@ exports[`<Transforms /> spec renders the component 1`] = `
             class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <button
-              class="euiButton euiButton--primary euiButton-isDisabled"
+              class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
               data-test-subj="disableButton"
               disabled=""
               type="button"
@@ -71,7 +71,7 @@ exports[`<Transforms /> spec renders the component 1`] = `
             class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <button
-              class="euiButton euiButton--primary euiButton-isDisabled"
+              class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
               data-test-subj="enableButton"
               disabled=""
               type="button"
@@ -99,7 +99,7 @@ exports[`<Transforms /> spec renders the component 1`] = `
                 class="euiPopover__anchor"
               >
                 <button
-                  class="euiButton euiButton--primary euiButton-isDisabled"
+                  class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
                   data-test-subj="actionButton"
                   disabled=""
                   type="button"
@@ -122,7 +122,7 @@ exports[`<Transforms /> spec renders the component 1`] = `
             class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <button
-              class="euiButton euiButton--primary euiButton--fill"
+              class="euiButton euiButton--primary euiButton--small euiButton--fill"
               data-test-subj="createTransformButton"
               type="button"
             >
@@ -151,13 +151,13 @@ exports[`<Transforms /> spec renders the component 1`] = `
           class="euiFlexItem"
         >
           <div
-            class="euiFormControlLayout euiFormControlLayout--fullWidth"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <input
-                class="euiFieldSearch euiFieldSearch--fullWidth"
+                class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
                 placeholder="Search"
                 type="search"
                 value=""

--- a/public/pages/Transforms/utils/metadataHelper.tsx
+++ b/public/pages/Transforms/utils/metadataHelper.tsx
@@ -6,7 +6,17 @@
 import { TransformMetadata } from "../../../../models/interfaces";
 import React, { ChangeEvent } from "react";
 import moment from "moment-timezone";
-import { EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiFormRow, EuiLink, EuiSelect, EuiTextArea, EuiText } from "@elastic/eui";
+import {
+  EuiFieldNumber,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiCompressedFormRow,
+  EuiLink,
+  EuiSelect,
+  EuiTextArea,
+  EuiText,
+} from "@elastic/eui";
 import { ScheduleIntervalTimeunitOptions } from "../../CreateTransform/utils/constants";
 import ErrorModal from "../components/ErrorModal";
 import { ModalConsumer } from "../../../components/Modal";
@@ -85,12 +95,12 @@ export const selectInterval = (
   <React.Fragment>
     <EuiFlexGroup style={{ maxWidth: 400 }}>
       <EuiFlexItem grow={false} style={{ width: 200 }}>
-        <EuiFormRow label="Transform execution interval" error={intervalError} isInvalid={intervalError != ""}>
+        <EuiCompressedFormRow label="Transform execution interval" error={intervalError} isInvalid={intervalError != ""}>
           <EuiFieldNumber value={interval} onChange={onChangeInterval} isInvalid={intervalError != ""} />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </EuiFlexItem>
       <EuiFlexItem>
-        <EuiFormRow hasEmptyLabelSpace={true}>
+        <EuiCompressedFormRow hasEmptyLabelSpace={true}>
           <EuiSelect
             id="selectIntervalTimeunit"
             options={ScheduleIntervalTimeunitOptions}
@@ -98,7 +108,7 @@ export const selectInterval = (
             onChange={onChangeTimeunit}
             isInvalid={interval == undefined || interval <= 0}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </EuiFlexItem>
     </EuiFlexGroup>
   </React.Fragment>
@@ -111,12 +121,12 @@ export const selectCronExpression = (
   onCronTimeZoneChange: (e: ChangeEvent<HTMLSelectElement>) => void
 ) => (
   <React.Fragment>
-    <EuiFormRow label="Define by cron expression">
+    <EuiCompressedFormRow label="Define by cron expression">
       <EuiTextArea value={cronExpression} onChange={onCronExpressionChange} compressed={true} />
-    </EuiFormRow>
-    <EuiFormRow label="Timezone" helpText="A day starts from 00:00:00 in the specified timezone.">
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow label="Timezone" helpText="A day starts from 00:00:00 in the specified timezone.">
       <EuiSelect id="timezone" options={timezones} value={cronTimeZone} onChange={onCronTimeZoneChange} />
-    </EuiFormRow>
+    </EuiCompressedFormRow>
   </React.Fragment>
 );
 

--- a/public/pages/Transforms/utils/metadataHelper.tsx
+++ b/public/pages/Transforms/utils/metadataHelper.tsx
@@ -13,7 +13,7 @@ import {
   EuiIcon,
   EuiCompressedFormRow,
   EuiLink,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiTextArea,
   EuiText,
 } from "@elastic/eui";
@@ -101,7 +101,7 @@ export const selectInterval = (
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiCompressedFormRow hasEmptyLabelSpace={true}>
-          <EuiSelect
+          <EuiCompressedSelect
             id="selectIntervalTimeunit"
             options={ScheduleIntervalTimeunitOptions}
             value={intervalTimeunit}
@@ -125,7 +125,7 @@ export const selectCronExpression = (
       <EuiTextArea value={cronExpression} onChange={onCronExpressionChange} compressed={true} />
     </EuiCompressedFormRow>
     <EuiCompressedFormRow label="Timezone" helpText="A day starts from 00:00:00 in the specified timezone.">
-      <EuiSelect id="timezone" options={timezones} value={cronTimeZone} onChange={onCronTimeZoneChange} />
+      <EuiCompressedSelect id="timezone" options={timezones} value={cronTimeZone} onChange={onCronTimeZoneChange} />
     </EuiCompressedFormRow>
   </React.Fragment>
 );

--- a/public/pages/Transforms/utils/metadataHelper.tsx
+++ b/public/pages/Transforms/utils/metadataHelper.tsx
@@ -7,7 +7,7 @@ import { TransformMetadata } from "../../../../models/interfaces";
 import React, { ChangeEvent } from "react";
 import moment from "moment-timezone";
 import {
-  EuiFieldNumber,
+  EuiCompressedFieldNumber,
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
@@ -96,7 +96,7 @@ export const selectInterval = (
     <EuiFlexGroup style={{ maxWidth: 400 }}>
       <EuiFlexItem grow={false} style={{ width: 200 }}>
         <EuiCompressedFormRow label="Transform execution interval" error={intervalError} isInvalid={intervalError != ""}>
-          <EuiFieldNumber value={interval} onChange={onChangeInterval} isInvalid={intervalError != ""} />
+          <EuiCompressedFieldNumber value={interval} onChange={onChangeInterval} isInvalid={intervalError != ""} />
         </EuiCompressedFormRow>
       </EuiFlexItem>
       <EuiFlexItem>

--- a/public/pages/VisualCreatePolicy/components/ChannelNotification/ChannelNotification.tsx
+++ b/public/pages/VisualCreatePolicy/components/ChannelNotification/ChannelNotification.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiSpacer, EuiCompressedFormRow, EuiTextArea, EuiSelect, EuiSmallButton, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiSpacer, EuiCompressedFormRow, EuiTextArea, EuiCompressedSelect, EuiSmallButton, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import "brace/theme/github";
 import "brace/mode/json";
 import { FeatureChannelList } from "../../../../../server/models/interfaces";
@@ -39,8 +39,7 @@ const ChannelNotification = ({
       <EuiFlexGroup gutterSize="s" style={{ maxWidth: 600 }}>
         <EuiFlexItem>
           <EuiCompressedFormRow>
-            <EuiSelect
-              compressed={useNewUx}
+            <EuiCompressedSelect
               id={actionNotification ? "action-channel-id" : "channel-id"}
               placeholder="Select channel ID"
               hasNoInitialSelection
@@ -59,7 +58,6 @@ const ChannelNotification = ({
             disabled={loadingChannels}
             className="refresh-button"
             data-test-subj="channel-notification-refresh"
-            size={useNewUx ? "s" : undefined}
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>

--- a/public/pages/VisualCreatePolicy/components/ChannelNotification/ChannelNotification.tsx
+++ b/public/pages/VisualCreatePolicy/components/ChannelNotification/ChannelNotification.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiSpacer, EuiFormRow, EuiTextArea, EuiSelect, EuiSmallButton, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiSpacer, EuiCompressedFormRow, EuiTextArea, EuiSelect, EuiSmallButton, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import "brace/theme/github";
 import "brace/mode/json";
 import { FeatureChannelList } from "../../../../../server/models/interfaces";
@@ -38,7 +38,7 @@ const ChannelNotification = ({
       <EuiFormCustomLabel title="Channel ID" />
       <EuiFlexGroup gutterSize="s" style={{ maxWidth: 600 }}>
         <EuiFlexItem>
-          <EuiFormRow>
+          <EuiCompressedFormRow>
             <EuiSelect
               compressed={useNewUx}
               id={actionNotification ? "action-channel-id" : "channel-id"}
@@ -50,7 +50,7 @@ const ChannelNotification = ({
               onChange={onChangeChannelId}
               data-test-subj={actionNotification ? "create-policy-notification-action-channel-id" : "create-policy-notification-channel-id"}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiSmallButton
@@ -75,7 +75,7 @@ const ChannelNotification = ({
 
           <EuiFormCustomLabel title="Notification message" helpText="Embed variables in your message using Mustache template." />
 
-          <EuiFormRow>
+          <EuiCompressedFormRow>
             <EuiTextArea
               placeholder="The index {{ctx.index}} failed during policy execution."
               style={{ minHeight: "150px" }}
@@ -84,7 +84,7 @@ const ChannelNotification = ({
               onChange={onChangeMessage}
               data-test-subj={actionNotification ? "create-policy-notification-action-message" : "create-policy-notification-message"}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </>
       )}
     </>

--- a/public/pages/VisualCreatePolicy/components/ChannelNotification/ChannelNotification.tsx
+++ b/public/pages/VisualCreatePolicy/components/ChannelNotification/ChannelNotification.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiSpacer, EuiFormRow, EuiTextArea, EuiSelect, EuiButton, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiSpacer, EuiFormRow, EuiTextArea, EuiSelect, EuiSmallButton, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import "brace/theme/github";
 import "brace/mode/json";
 import { FeatureChannelList } from "../../../../../server/models/interfaces";
@@ -53,7 +53,7 @@ const ChannelNotification = ({
           </EuiFormRow>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             iconType="refresh"
             onClick={getChannels}
             disabled={loadingChannels}
@@ -63,9 +63,9 @@ const ChannelNotification = ({
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton iconType="popout" href="notifications-dashboards#/channels" target="_blank" size={useNewUx ? "s" : undefined}>
+          <EuiSmallButton iconType="popout" href="notifications-dashboards#/channels" target="_blank">
             Manage channels
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
 

--- a/public/pages/VisualCreatePolicy/components/DraggableItem/DraggableItem.tsx
+++ b/public/pages/VisualCreatePolicy/components/DraggableItem/DraggableItem.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { EuiFlexGroup, EuiFlexItem, EuiDraggable, EuiPanel, EuiIcon, EuiButtonIcon, EuiToolTip } from "@elastic/eui";
+import { EuiFlexGroup, EuiFlexItem, EuiDraggable, EuiPanel, EuiIcon, EuiSmallButtonIcon, EuiToolTip } from "@elastic/eui";
 
 interface DraggableItemProps {
   content: string | JSX.Element | null;
@@ -29,7 +29,7 @@ const DraggableItem = ({ content, id, idx, isLast, onClickDelete, onClickEdit, d
           <EuiFlexItem>{content}</EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiToolTip position="top" content={<p>Delete {draggableType}</p>}>
-              <EuiButtonIcon
+              <EuiSmallButtonIcon
                 iconType="trash"
                 aria-label="Delete"
                 color="danger"
@@ -40,7 +40,7 @@ const DraggableItem = ({ content, id, idx, isLast, onClickDelete, onClickEdit, d
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiToolTip position="top" content={<p>Edit {draggableType}</p>}>
-              <EuiButtonIcon
+              <EuiSmallButtonIcon
                 iconType="pencil"
                 aria-label="Edit"
                 color="primary"

--- a/public/pages/VisualCreatePolicy/components/DraggableItem/__snapshots__/DraggableItem.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/DraggableItem/__snapshots__/DraggableItem.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`<DraggableItem /> spec renders the component 1`] = `
           >
             <button
               aria-label="Delete"
-              class="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall"
+              class="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--small"
               data-test-subj="draggable-item-delete-button-some_html_id"
               type="button"
             >
@@ -64,7 +64,7 @@ exports[`<DraggableItem /> spec renders the component 1`] = `
           >
             <button
               aria-label="Edit"
-              class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
+              class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
               data-test-subj="draggable-item-edit-button-some_html_id"
               type="button"
             >

--- a/public/pages/VisualCreatePolicy/components/FlyoutFooter/FlyoutFooter.tsx
+++ b/public/pages/VisualCreatePolicy/components/FlyoutFooter/FlyoutFooter.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { EuiFlexGroup, EuiFlexItem, EuiButtonEmpty, EuiSmallButton } from "@elastic/eui";
+import { EuiFlexGroup, EuiFlexItem, EuiSmallButtonEmpty, EuiSmallButton } from "@elastic/eui";
 
 interface FlyoutFooterProps {
   edit: boolean;
@@ -31,9 +31,9 @@ const FlyoutFooter = ({
 }: FlyoutFooterProps) => (
   <EuiFlexGroup justifyContent="flexEnd">
     <EuiFlexItem grow={false}>
-      <EuiButtonEmpty size={useNewUx ? "s" : undefined} onClick={onClickCancel} flush="left" data-test-subj="flyout-footer-cancel-button">
+      <EuiSmallButtonEmpty onClick={onClickCancel} flush="left" data-test-subj="flyout-footer-cancel-button">
         Cancel
-      </EuiButtonEmpty>
+      </EuiSmallButtonEmpty>
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
       <EuiSmallButton disabled={disabledAction} onClick={onClickAction} fill data-test-subj="flyout-footer-action-button">

--- a/public/pages/VisualCreatePolicy/components/FlyoutFooter/FlyoutFooter.tsx
+++ b/public/pages/VisualCreatePolicy/components/FlyoutFooter/FlyoutFooter.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { EuiFlexGroup, EuiFlexItem, EuiButtonEmpty, EuiButton } from "@elastic/eui";
+import { EuiFlexGroup, EuiFlexItem, EuiButtonEmpty, EuiSmallButton } from "@elastic/eui";
 
 interface FlyoutFooterProps {
   edit: boolean;
@@ -36,15 +36,9 @@ const FlyoutFooter = ({
       </EuiButtonEmpty>
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
-      <EuiButton
-        size={useNewUx ? "s" : undefined}
-        disabled={disabledAction}
-        onClick={onClickAction}
-        fill
-        data-test-subj="flyout-footer-action-button"
-      >
+      <EuiSmallButton disabled={disabledAction} onClick={onClickAction} fill data-test-subj="flyout-footer-action-button">
         {text ? text : restore ? "Restore snapshot" : !save ? `${edit ? "Edit" : "Add"} ${action}` : save ? "Save" : "Create"}
-      </EuiButton>
+      </EuiSmallButton>
     </EuiFlexItem>
   </EuiFlexGroup>
 );

--- a/public/pages/VisualCreatePolicy/components/FlyoutFooter/__snapshots__/FlyoutFooter.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/FlyoutFooter/__snapshots__/FlyoutFooter.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`<FlyoutFooter /> spec renders the component 1`] = `
     class="euiFlexItem euiFlexItem--flexGrowZero"
   >
     <button
-      class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--flushLeft"
+      class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiButtonEmpty--flushLeft"
       data-test-subj="flyout-footer-cancel-button"
       type="button"
     >
@@ -27,7 +27,7 @@ exports[`<FlyoutFooter /> spec renders the component 1`] = `
     class="euiFlexItem euiFlexItem--flexGrowZero"
   >
     <button
-      class="euiButton euiButton--primary euiButton--fill"
+      class="euiButton euiButton--primary euiButton--small euiButton--fill"
       data-test-subj="flyout-footer-action-button"
       type="button"
     >

--- a/public/pages/VisualCreatePolicy/components/ISMTemplate/ISMTemplate.tsx
+++ b/public/pages/VisualCreatePolicy/components/ISMTemplate/ISMTemplate.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, useState } from "react";
-import { EuiButton, EuiFormRow, EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiFieldNumber } from "@elastic/eui";
+import { EuiSmallButton, EuiFormRow, EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiFieldNumber } from "@elastic/eui";
 import "brace/theme/github";
 import "brace/mode/json";
 import { ISMTemplate as ISMTemplateData } from "../../../../../models/interfaces";
@@ -81,9 +81,9 @@ const ISMTemplate = ({ template, onUpdateTemplate, onRemoveTemplate, isFirst, us
         </EuiFormRow>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiButton color="danger" onClick={onRemoveTemplate} data-test-subj="ism-template-remove-button" size={useNewUx ? "s" : undefined}>
+        <EuiSmallButton color="danger" onClick={onRemoveTemplate} data-test-subj="ism-template-remove-button">
           Remove
-        </EuiButton>
+        </EuiSmallButton>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/pages/VisualCreatePolicy/components/ISMTemplate/ISMTemplate.tsx
+++ b/public/pages/VisualCreatePolicy/components/ISMTemplate/ISMTemplate.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, useState } from "react";
-import { EuiSmallButton, EuiCompressedFormRow, EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiFieldNumber } from "@elastic/eui";
+import { EuiSmallButton, EuiCompressedFormRow, EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiCompressedFieldNumber } from "@elastic/eui";
 import "brace/theme/github";
 import "brace/mode/json";
 import { ISMTemplate as ISMTemplateData } from "../../../../../models/interfaces";
@@ -68,8 +68,7 @@ const ISMTemplate = ({ template, onUpdateTemplate, onRemoveTemplate, isFirst, us
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiCompressedFormRow error={null} isInvalid={false}>
-          <EuiFieldNumber
-            compressed={useNewUx}
+          <EuiCompressedFieldNumber
             value={template.priority}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const priority = e.target.valueAsNumber;

--- a/public/pages/VisualCreatePolicy/components/ISMTemplate/ISMTemplate.tsx
+++ b/public/pages/VisualCreatePolicy/components/ISMTemplate/ISMTemplate.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, useState } from "react";
-import { EuiSmallButton, EuiFormRow, EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiFieldNumber } from "@elastic/eui";
+import { EuiSmallButton, EuiCompressedFormRow, EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiFieldNumber } from "@elastic/eui";
 import "brace/theme/github";
 import "brace/mode/json";
 import { ISMTemplate as ISMTemplateData } from "../../../../../models/interfaces";
@@ -24,7 +24,7 @@ const ISMTemplate = ({ template, onUpdateTemplate, onRemoveTemplate, isFirst, us
   return (
     <EuiFlexGroup gutterSize="l" alignItems="center">
       <EuiFlexItem style={{ maxWidth: ISM_TEMPLATE_INPUT_MAX_WIDTH }}>
-        <EuiFormRow isInvalid={false} error={null}>
+        <EuiCompressedFormRow isInvalid={false} error={null}>
           <EuiComboBox
             compressed={useNewUx}
             isClearable={false}
@@ -64,10 +64,10 @@ const ISMTemplate = ({ template, onUpdateTemplate, onRemoveTemplate, isFirst, us
             isInvalid={isInvalid}
             data-test-subj="ism-template-index-pattern-input"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiFormRow error={null} isInvalid={false}>
+        <EuiCompressedFormRow error={null} isInvalid={false}>
           <EuiFieldNumber
             compressed={useNewUx}
             value={template.priority}
@@ -78,7 +78,7 @@ const ISMTemplate = ({ template, onUpdateTemplate, onRemoveTemplate, isFirst, us
             isInvalid={false}
             data-test-subj="ism-template-priority-input"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiSmallButton color="danger" onClick={onRemoveTemplate} data-test-subj="ism-template-remove-button">

--- a/public/pages/VisualCreatePolicy/components/ISMTemplate/ISMTemplate.tsx
+++ b/public/pages/VisualCreatePolicy/components/ISMTemplate/ISMTemplate.tsx
@@ -4,7 +4,14 @@
  */
 
 import React, { ChangeEvent, useState } from "react";
-import { EuiSmallButton, EuiCompressedFormRow, EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiCompressedFieldNumber } from "@elastic/eui";
+import {
+  EuiSmallButton,
+  EuiCompressedFormRow,
+  EuiCompressedComboBox,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiCompressedFieldNumber,
+} from "@elastic/eui";
 import "brace/theme/github";
 import "brace/mode/json";
 import { ISMTemplate as ISMTemplateData } from "../../../../../models/interfaces";
@@ -25,8 +32,7 @@ const ISMTemplate = ({ template, onUpdateTemplate, onRemoveTemplate, isFirst, us
     <EuiFlexGroup gutterSize="l" alignItems="center">
       <EuiFlexItem style={{ maxWidth: ISM_TEMPLATE_INPUT_MAX_WIDTH }}>
         <EuiCompressedFormRow isInvalid={false} error={null}>
-          <EuiComboBox
-            compressed={useNewUx}
+          <EuiCompressedComboBox
             isClearable={false}
             placeholder="Add index patterns"
             noSuggestions

--- a/public/pages/VisualCreatePolicy/components/ISMTemplate/__snapshots__/ISMTemplate.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/ISMTemplate/__snapshots__/ISMTemplate.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`<ISMTemplate /> spec renders the component 1`] = `
     style="max-width: 400px;"
   >
     <div
-      class="euiFormRow"
+      class="euiFormRow euiFormRow--compressed"
       id="some_html_id-row"
     >
       <div
@@ -18,18 +18,18 @@ exports[`<ISMTemplate /> spec renders the component 1`] = `
         <div
           aria-expanded="false"
           aria-haspopup="listbox"
-          class="euiComboBox"
+          class="euiComboBox euiComboBox--compressed"
           data-test-subj="ism-template-index-pattern-input"
           role="combobox"
         >
           <div
-            class="euiFormControlLayout"
+            class="euiFormControlLayout euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <div
-                class="euiComboBox__inputWrap"
+                class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed"
                 data-test-subj="comboBoxInput"
                 tabindex="-1"
               >
@@ -82,20 +82,20 @@ exports[`<ISMTemplate /> spec renders the component 1`] = `
     class="euiFlexItem euiFlexItem--flexGrowZero"
   >
     <div
-      class="euiFormRow"
+      class="euiFormRow euiFormRow--compressed"
       id="some_html_id-row"
     >
       <div
         class="euiFormRow__fieldWrapper"
       >
         <div
-          class="euiFormControlLayout"
+          class="euiFormControlLayout euiFormControlLayout--compressed"
         >
           <div
             class="euiFormControlLayout__childrenWrapper"
           >
             <input
-              class="euiFieldNumber"
+              class="euiFieldNumber euiFieldNumber--compressed"
               data-test-subj="ism-template-priority-input"
               id="some_html_id"
               type="number"
@@ -110,7 +110,7 @@ exports[`<ISMTemplate /> spec renders the component 1`] = `
     class="euiFlexItem euiFlexItem--flexGrowZero"
   >
     <button
-      class="euiButton euiButton--danger"
+      class="euiButton euiButton--danger euiButton--small"
       data-test-subj="ism-template-remove-button"
       type="button"
     >

--- a/public/pages/VisualCreatePolicy/components/ISMTemplates/ISMTemplates.tsx
+++ b/public/pages/VisualCreatePolicy/components/ISMTemplates/ISMTemplates.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { EuiButton, EuiSpacer, EuiFlexGroup, EuiEmptyPrompt, EuiFlexItem, EuiText, EuiLink, EuiIcon } from "@elastic/eui";
+import { EuiSmallButton, EuiSpacer, EuiFlexGroup, EuiEmptyPrompt, EuiFlexItem, EuiText, EuiLink, EuiIcon } from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
 import "brace/theme/github";
 import "brace/mode/json";
@@ -24,15 +24,14 @@ interface ISMTemplatesProps {
 const ISMTemplates = ({ policy, onChangePolicy, useNewUx }: ISMTemplatesProps) => {
   const templates = convertTemplatesToArray(policy.ism_template);
   const addTemplateButton = (
-    <EuiButton
-      size={useNewUx ? "s" : undefined}
+    <EuiSmallButton
       onClick={() => {
         onChangePolicy({ ...policy, ism_template: [...templates, { index_patterns: [], priority: 1 }] });
       }}
       data-test-subj="ism-templates-add-template-button"
     >
       Add template
-    </EuiButton>
+    </EuiSmallButton>
   );
   const paddingStyle = useNewUx ? { padding: "0px 0px" } : { padding: "5px 0px" };
   return (

--- a/public/pages/VisualCreatePolicy/components/ISMTemplates/__snapshots__/ISMTemplates.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/ISMTemplates/__snapshots__/ISMTemplates.test.tsx.snap
@@ -109,7 +109,7 @@ exports[`<ISMTemplates /> spec renders the component 1`] = `
           class="euiSpacer euiSpacer--l"
         />
         <button
-          class="euiButton euiButton--primary"
+          class="euiButton euiButton--primary euiButton--small"
           data-test-subj="ism-templates-add-template-button"
           type="button"
         >

--- a/public/pages/VisualCreatePolicy/components/LegacyNotification/LegacyNotification.tsx
+++ b/public/pages/VisualCreatePolicy/components/LegacyNotification/LegacyNotification.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { EuiFormRow, EuiCodeEditor, EuiCallOut, EuiSmallButton, EuiSpacer } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiCodeEditor, EuiCallOut, EuiSmallButton, EuiSpacer } from "@elastic/eui";
 import "brace/theme/github";
 import "brace/mode/json";
 import { DarkModeConsumer } from "../../../../components/DarkMode";
@@ -34,7 +34,7 @@ const LegacyNotification = ({
         <EuiSmallButton onClick={onSwitchToChannels}>Switch to using Channel ID</EuiSmallButton>
       </EuiCallOut>
       <EuiSpacer size="m" />
-      <EuiFormRow fullWidth isInvalid={isInvalid} error={null} style={{ maxWidth: "100%" }}>
+      <EuiCompressedFormRow fullWidth isInvalid={isInvalid} error={null} style={{ maxWidth: "100%" }}>
         <DarkModeConsumer>
           {(isDarkMode) => (
             <EuiCodeEditor
@@ -50,7 +50,7 @@ const LegacyNotification = ({
             />
           )}
         </DarkModeConsumer>
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </>
   );
 };

--- a/public/pages/VisualCreatePolicy/components/LegacyNotification/LegacyNotification.tsx
+++ b/public/pages/VisualCreatePolicy/components/LegacyNotification/LegacyNotification.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { EuiFormRow, EuiCodeEditor, EuiCallOut, EuiButton, EuiSpacer } from "@elastic/eui";
+import { EuiFormRow, EuiCodeEditor, EuiCallOut, EuiSmallButton, EuiSpacer } from "@elastic/eui";
 import "brace/theme/github";
 import "brace/mode/json";
 import { DarkModeConsumer } from "../../../../components/DarkMode";
@@ -31,7 +31,7 @@ const LegacyNotification = ({
           Using Channel ID will give you more control to manage notifications across OpenSearch dashboards. If you do decide to switch, you
           will lose your current error notification settings.
         </p>
-        <EuiButton onClick={onSwitchToChannels}>Switch to using Channel ID</EuiButton>
+        <EuiSmallButton onClick={onSwitchToChannels}>Switch to using Channel ID</EuiSmallButton>
       </EuiCallOut>
       <EuiSpacer size="m" />
       <EuiFormRow fullWidth isInvalid={isInvalid} error={null} style={{ maxWidth: "100%" }}>

--- a/public/pages/VisualCreatePolicy/components/LegacyNotification/__snapshots__/LegacyNotification.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/LegacyNotification/__snapshots__/LegacyNotification.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`<LegacyNotification /> spec renders the component 1`] = `
         Using Channel ID will give you more control to manage notifications across OpenSearch dashboards. If you do decide to switch, you will lose your current error notification settings.
       </p>
       <button
-        class="euiButton euiButton--primary"
+        class="euiButton euiButton--primary euiButton--small"
         type="button"
       >
         <span

--- a/public/pages/VisualCreatePolicy/components/PolicyInfo/PolicyInfo.tsx
+++ b/public/pages/VisualCreatePolicy/components/PolicyInfo/PolicyInfo.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiSpacer, EuiFormRow, EuiFieldText, EuiTextArea } from "@elastic/eui";
+import { EuiSpacer, EuiCompressedFormRow, EuiFieldText, EuiTextArea } from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
 import "brace/theme/github";
 import "brace/mode/json";
@@ -24,7 +24,7 @@ const PolicyInfo = ({ isEdit, policyId, policyIdError, description, onChangePoli
     <div style={{ padding: "10px 0px 0px 10px" }}>
       <EuiFormCustomLabel title="Policy ID" helpText="Specify a unique and descriptive ID that is easy to recognize and remember." />
 
-      <EuiFormRow isInvalid={!!policyIdError} error={policyIdError}>
+      <EuiCompressedFormRow isInvalid={!!policyIdError} error={policyIdError}>
         <EuiFieldText
           disabled={isEdit}
           isInvalid={!!policyIdError}
@@ -34,13 +34,13 @@ const PolicyInfo = ({ isEdit, policyId, policyIdError, description, onChangePoli
           onChange={onChangePolicyId}
           data-test-subj="create-policy-policy-id"
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
 
       <EuiSpacer size="m" />
 
       <EuiFormCustomLabel title="Description" helpText="Describe the policy." />
 
-      <EuiFormRow isInvalid={false} error={null}>
+      <EuiCompressedFormRow isInvalid={false} error={null}>
         <EuiTextArea
           style={{ minHeight: "150px" }}
           compressed={true}
@@ -48,7 +48,7 @@ const PolicyInfo = ({ isEdit, policyId, policyIdError, description, onChangePoli
           onChange={onChangeDescription}
           data-test-subj="create-policy-description"
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </div>
   </ContentPanel>
 );

--- a/public/pages/VisualCreatePolicy/components/PolicyInfo/PolicyInfo.tsx
+++ b/public/pages/VisualCreatePolicy/components/PolicyInfo/PolicyInfo.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiSpacer, EuiCompressedFormRow, EuiFieldText, EuiTextArea } from "@elastic/eui";
+import { EuiSpacer, EuiCompressedFormRow, EuiCompressedFieldText, EuiTextArea } from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
 import "brace/theme/github";
 import "brace/mode/json";
@@ -25,7 +25,7 @@ const PolicyInfo = ({ isEdit, policyId, policyIdError, description, onChangePoli
       <EuiFormCustomLabel title="Policy ID" helpText="Specify a unique and descriptive ID that is easy to recognize and remember." />
 
       <EuiCompressedFormRow isInvalid={!!policyIdError} error={policyIdError}>
-        <EuiFieldText
+        <EuiCompressedFieldText
           disabled={isEdit}
           isInvalid={!!policyIdError}
           placeholder="hot_cold_workflow"

--- a/public/pages/VisualCreatePolicy/components/PolicyInfo/__snapshots__/PolicyInfo.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/PolicyInfo/__snapshots__/PolicyInfo.test.tsx.snap
@@ -55,20 +55,20 @@ exports[`<PolicyInfo /> spec renders the component 1`] = `
         </p>
       </div>
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
           class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormControlLayout"
+            class="euiFormControlLayout euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <input
-                class="euiFieldText"
+                class="euiFieldText euiFieldText--compressed"
                 data-test-subj="create-policy-policy-id"
                 id="some_html_id"
                 placeholder="hot_cold_workflow"
@@ -103,7 +103,7 @@ exports[`<PolicyInfo /> spec renders the component 1`] = `
         </p>
       </div>
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div

--- a/public/pages/VisualCreatePolicy/components/States/State.tsx
+++ b/public/pages/VisualCreatePolicy/components/States/State.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { EuiAccordion, EuiText, EuiPanel, EuiFlexGroup, EuiFlexItem, EuiButtonIcon, EuiToolTip } from "@elastic/eui";
+import { EuiAccordion, EuiText, EuiPanel, EuiFlexGroup, EuiFlexItem, EuiSmallButtonIcon, EuiToolTip } from "@elastic/eui";
 import "brace/theme/github";
 import "brace/mode/json";
 import { State as StateData } from "../../../../../models/interfaces";
@@ -64,7 +64,7 @@ const State = ({ state, isInitialState, idx, onClickEditState, onClickDeleteStat
             <ModalConsumer>
               {({ onShow, onClose }) => (
                 <EuiToolTip position="top" content={<p>Delete state</p>}>
-                  <EuiButtonIcon
+                  <EuiSmallButtonIcon
                     iconType="trash"
                     aria-label="Delete"
                     color="danger"
@@ -94,7 +94,7 @@ const State = ({ state, isInitialState, idx, onClickEditState, onClickDeleteStat
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiToolTip position="top" content={<p>Edit state</p>}>
-              <EuiButtonIcon iconType="pencil" aria-label="Edit" color="primary" onClick={() => onClickEditState(state)} />
+              <EuiSmallButtonIcon iconType="pencil" aria-label="Edit" color="primary" onClick={() => onClickEditState(state)} />
             </EuiToolTip>
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/public/pages/VisualCreatePolicy/components/States/States.tsx
+++ b/public/pages/VisualCreatePolicy/components/States/States.tsx
@@ -5,7 +5,7 @@
 
 import React, { ChangeEvent } from "react";
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiText,
   EuiHorizontalRule,
   EuiFlexGroup,
@@ -99,9 +99,9 @@ const States = ({
           (!!policy.states.length ? (
             <>
               <EuiSpacer />
-              <EuiButton onClick={onOpenFlyout} data-test-subj="states-add-state-button" size={useNewUx ? "s" : undefined}>
+              <EuiSmallButton onClick={onOpenFlyout} data-test-subj="states-add-state-button">
                 Add state
-              </EuiButton>
+              </EuiSmallButton>
             </>
           ) : (
             <EuiEmptyPrompt
@@ -109,14 +109,9 @@ const States = ({
               titleSize="s"
               body={<p>Your policy currently has no states defined. Add states to manage your index lifecycle.</p>}
               actions={
-                <EuiButton
-                  color="primary"
-                  onClick={onOpenFlyout}
-                  data-test-subj="states-add-state-button"
-                  size={useNewUx ? "s" : undefined}
-                >
+                <EuiSmallButton color="primary" onClick={onOpenFlyout} data-test-subj="states-add-state-button">
                   Add state
-                </EuiButton>
+                </EuiSmallButton>
               }
             />
           ))}

--- a/public/pages/VisualCreatePolicy/components/States/States.tsx
+++ b/public/pages/VisualCreatePolicy/components/States/States.tsx
@@ -14,7 +14,7 @@ import {
   EuiLink,
   EuiIcon,
   EuiEmptyPrompt,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSelect,
 } from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
@@ -65,7 +65,7 @@ const States = ({
       <div style={{ padding: "0px 10px" }}>
         {!isReadOnly && (
           <>
-            <EuiFormRow style={{ maxWidth: "300px", padding: "15px" }} isInvalid={false} error={null}>
+            <EuiCompressedFormRow style={{ maxWidth: "300px", padding: "15px" }} isInvalid={false} error={null}>
               <EuiSelect
                 compressed
                 prepend="Initial state"
@@ -73,7 +73,7 @@ const States = ({
                 value={policy.default_state}
                 onChange={onChangeDefaultState}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer size="s" />
             <EuiHorizontalRule margin="none" />
           </>

--- a/public/pages/VisualCreatePolicy/components/States/__snapshots__/State.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/States/__snapshots__/State.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`<State /> spec renders the component 1`] = `
           >
             <button
               aria-label="Delete"
-              class="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall"
+              class="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--small"
               data-test-subj="state-delete-button"
               type="button"
             >
@@ -134,7 +134,7 @@ exports[`<State /> spec renders the component 1`] = `
           >
             <button
               aria-label="Edit"
-              class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
+              class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
               type="button"
             >
               EuiIconMock

--- a/public/pages/VisualCreatePolicy/components/States/__snapshots__/States.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/States/__snapshots__/States.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`<States /> spec renders the component 1`] = `
       style="padding: 0px 10px;"
     >
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
         style="max-width: 300px; padding: 15px;"
       >
@@ -242,7 +242,7 @@ exports[`<States /> spec renders the component 1`] = `
                     >
                       <button
                         aria-label="Delete"
-                        class="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall"
+                        class="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--small"
                         data-test-subj="state-delete-button"
                         type="button"
                       >
@@ -258,7 +258,7 @@ exports[`<States /> spec renders the component 1`] = `
                     >
                       <button
                         aria-label="Edit"
-                        class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
+                        class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
                         type="button"
                       >
                         EuiIconMock
@@ -445,7 +445,7 @@ exports[`<States /> spec renders the component 1`] = `
                     >
                       <button
                         aria-label="Delete"
-                        class="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall"
+                        class="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--small"
                         data-test-subj="state-delete-button"
                         type="button"
                       >
@@ -461,7 +461,7 @@ exports[`<States /> spec renders the component 1`] = `
                     >
                       <button
                         aria-label="Edit"
-                        class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
+                        class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
                         type="button"
                       >
                         EuiIconMock
@@ -547,7 +547,7 @@ exports[`<States /> spec renders the component 1`] = `
         class="euiSpacer euiSpacer--l"
       />
       <button
-        class="euiButton euiButton--primary"
+        class="euiButton euiButton--primary euiButton--small"
         data-test-subj="states-add-state-button"
         type="button"
       >

--- a/public/pages/VisualCreatePolicy/components/TimeoutRetrySettings/TimeoutRetrySettings.tsx
+++ b/public/pages/VisualCreatePolicy/components/TimeoutRetrySettings/TimeoutRetrySettings.tsx
@@ -12,7 +12,7 @@ import {
   EuiCompressedFormRow,
   EuiCompressedFieldNumber,
   EuiCompressedFieldText,
-  EuiSelect,
+  EuiCompressedSelect,
 } from "@elastic/eui";
 import "brace/theme/github";
 import "brace/mode/json";
@@ -88,7 +88,7 @@ const TimeoutRetrySettings = ({ action, editAction, onChangeAction }: TimeoutRet
       <EuiFlexItem>
         <EuiFormCustomLabel title="Retry backoff" helpText="The backoff policy type to use when retrying." />
         <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
-          <EuiSelect
+          <EuiCompressedSelect
             id="retry-backoff-type"
             fullWidth
             options={options}

--- a/public/pages/VisualCreatePolicy/components/TimeoutRetrySettings/TimeoutRetrySettings.tsx
+++ b/public/pages/VisualCreatePolicy/components/TimeoutRetrySettings/TimeoutRetrySettings.tsx
@@ -4,7 +4,16 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiAccordion, EuiText, EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiFieldNumber, EuiFieldText, EuiSelect } from "@elastic/eui";
+import {
+  EuiAccordion,
+  EuiText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiCompressedFormRow,
+  EuiFieldNumber,
+  EuiFieldText,
+  EuiSelect,
+} from "@elastic/eui";
 import "brace/theme/github";
 import "brace/mode/json";
 import { Action, UIAction } from "../../../../../models/interfaces";
@@ -36,7 +45,7 @@ const TimeoutRetrySettings = ({ action, editAction, onChangeAction }: TimeoutRet
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiFormCustomLabel title="Timeout" helpText={`The timeout period for the action. Accepts time units, e.g. "5h" or "1d".`} />
-        <EuiFormRow fullWidth isInvalid={false} error={null}>
+        <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
           <EuiFlexGroup>
             <EuiFlexItem>
               <EuiFieldText
@@ -50,14 +59,14 @@ const TimeoutRetrySettings = ({ action, editAction, onChangeAction }: TimeoutRet
               />
             </EuiFlexItem>
           </EuiFlexGroup>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiFormCustomLabel
           title="Retry count"
           helpText="The number of times the action should be retried if it fails. Must be greater than 0."
         />
-        <EuiFormRow fullWidth isInvalid={false} error={null}>
+        <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
           <EuiFlexGroup>
             <EuiFlexItem>
               <EuiFieldNumber
@@ -74,11 +83,11 @@ const TimeoutRetrySettings = ({ action, editAction, onChangeAction }: TimeoutRet
               />
             </EuiFlexItem>
           </EuiFlexGroup>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiFormCustomLabel title="Retry backoff" helpText="The backoff policy type to use when retrying." />
-        <EuiFormRow fullWidth isInvalid={false} error={null}>
+        <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
           <EuiSelect
             id="retry-backoff-type"
             fullWidth
@@ -89,11 +98,11 @@ const TimeoutRetrySettings = ({ action, editAction, onChangeAction }: TimeoutRet
               onChangeAction(action.clone({ ...action.action, retry: { ...action.action.retry, backoff } }));
             }}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiFormCustomLabel title="Retry delay" helpText={`The time to wait between retries. Accepts time units, e.g. "2h" or "1d"`} />
-        <EuiFormRow fullWidth isInvalid={false} error={null}>
+        <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
           <EuiFlexGroup>
             <EuiFlexItem>
               <EuiFieldText
@@ -107,7 +116,7 @@ const TimeoutRetrySettings = ({ action, editAction, onChangeAction }: TimeoutRet
               />
             </EuiFlexItem>
           </EuiFlexGroup>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </EuiFlexItem>
     </EuiFlexGroup>
   </EuiAccordion>

--- a/public/pages/VisualCreatePolicy/components/TimeoutRetrySettings/TimeoutRetrySettings.tsx
+++ b/public/pages/VisualCreatePolicy/components/TimeoutRetrySettings/TimeoutRetrySettings.tsx
@@ -10,8 +10,8 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
-  EuiFieldNumber,
-  EuiFieldText,
+  EuiCompressedFieldNumber,
+  EuiCompressedFieldText,
   EuiSelect,
 } from "@elastic/eui";
 import "brace/theme/github";
@@ -48,7 +48,7 @@ const TimeoutRetrySettings = ({ action, editAction, onChangeAction }: TimeoutRet
         <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
           <EuiFlexGroup>
             <EuiFlexItem>
-              <EuiFieldText
+              <EuiCompressedFieldText
                 isInvalid={false}
                 fullWidth
                 value={action.action.timeout || ""}
@@ -69,7 +69,7 @@ const TimeoutRetrySettings = ({ action, editAction, onChangeAction }: TimeoutRet
         <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
           <EuiFlexGroup>
             <EuiFlexItem>
-              <EuiFieldNumber
+              <EuiCompressedFieldNumber
                 isInvalid={false}
                 fullWidth
                 min={0}
@@ -105,7 +105,7 @@ const TimeoutRetrySettings = ({ action, editAction, onChangeAction }: TimeoutRet
         <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
           <EuiFlexGroup>
             <EuiFlexItem>
-              <EuiFieldText
+              <EuiCompressedFieldText
                 isInvalid={false}
                 fullWidth
                 value={action.action.retry?.delay || ""}

--- a/public/pages/VisualCreatePolicy/components/TimeoutRetrySettings/__snapshots__/TimeoutRetrySettings.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/TimeoutRetrySettings/__snapshots__/TimeoutRetrySettings.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`<TimeoutRetrySettings /> spec renders the component 1`] = `
               </p>
             </div>
             <div
-              class="euiFormRow euiFormRow--fullWidth"
+              class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
@@ -94,13 +94,13 @@ exports[`<TimeoutRetrySettings /> spec renders the component 1`] = `
                     class="euiFlexItem"
                   >
                     <div
-                      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                     >
                       <div
                         class="euiFormControlLayout__childrenWrapper"
                       >
                         <input
-                          class="euiFieldText euiFieldText--fullWidth"
+                          class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
                           type="text"
                           value=""
                         />
@@ -135,7 +135,7 @@ exports[`<TimeoutRetrySettings /> spec renders the component 1`] = `
               </p>
             </div>
             <div
-              class="euiFormRow euiFormRow--fullWidth"
+              class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
@@ -149,13 +149,13 @@ exports[`<TimeoutRetrySettings /> spec renders the component 1`] = `
                     class="euiFlexItem"
                   >
                     <div
-                      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                     >
                       <div
                         class="euiFormControlLayout__childrenWrapper"
                       >
                         <input
-                          class="euiFieldNumber euiFieldNumber--fullWidth"
+                          class="euiFieldNumber euiFieldNumber--fullWidth euiFieldNumber--compressed"
                           min="0"
                           type="number"
                           value=""
@@ -191,20 +191,20 @@ exports[`<TimeoutRetrySettings /> spec renders the component 1`] = `
               </p>
             </div>
             <div
-              class="euiFormRow euiFormRow--fullWidth"
+              class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
                 class="euiFormRow__fieldWrapper"
               >
                 <div
-                  class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                  class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <select
-                      class="euiSelect euiSelect--fullWidth"
+                      class="euiSelect euiSelect--fullWidth euiSelect--compressed"
                       id="some_html_id"
                     >
                       <option
@@ -261,7 +261,7 @@ exports[`<TimeoutRetrySettings /> spec renders the component 1`] = `
               </p>
             </div>
             <div
-              class="euiFormRow euiFormRow--fullWidth"
+              class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
@@ -275,13 +275,13 @@ exports[`<TimeoutRetrySettings /> spec renders the component 1`] = `
                     class="euiFlexItem"
                   >
                     <div
-                      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                     >
                       <div
                         class="euiFormControlLayout__childrenWrapper"
                       >
                         <input
-                          class="euiFieldText euiFieldText--fullWidth"
+                          class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
                           type="text"
                           value=""
                         />

--- a/public/pages/VisualCreatePolicy/components/Transition/Transition.tsx
+++ b/public/pages/VisualCreatePolicy/components/Transition/Transition.tsx
@@ -4,7 +4,15 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiLink, EuiIcon, EuiCompressedFormRow, EuiSelect, EuiSpacer, EuiFieldText, EuiFieldNumber } from "@elastic/eui";
+import {
+  EuiLink,
+  EuiIcon,
+  EuiCompressedFormRow,
+  EuiSelect,
+  EuiSpacer,
+  EuiCompressedFieldText,
+  EuiCompressedFieldNumber,
+} from "@elastic/eui";
 import moment from "moment-timezone";
 import EuiFormCustomLabel from "../EuiFormCustomLabel";
 import { UITransition } from "../../../../../models/interfaces";
@@ -67,7 +75,7 @@ const Transition = ({ uiTransition, onChangeTransition, useNewUx }: TransitionPr
         <>
           <EuiFormCustomLabel title="Minimum index age" helpText="The minimum age required to transition to the next state." />
           <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
-            <EuiFieldText
+            <EuiCompressedFieldText
               fullWidth
               value={conditions?.min_index_age}
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
@@ -95,7 +103,7 @@ const Transition = ({ uiTransition, onChangeTransition, useNewUx }: TransitionPr
             helpText="The minimum number of documents required to transition to the next state."
           />
           <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
-            <EuiFieldNumber
+            <EuiCompressedFieldNumber
               fullWidth
               value={typeof conditions?.min_doc_count === "undefined" ? "" : conditions?.min_doc_count}
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
@@ -125,7 +133,7 @@ const Transition = ({ uiTransition, onChangeTransition, useNewUx }: TransitionPr
             helpText="The minimum size of the total primary shard storage required to transition to the next state."
           />
           <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
-            <EuiFieldText
+            <EuiCompressedFieldText
               fullWidth
               value={conditions?.min_size}
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
@@ -153,7 +161,7 @@ const Transition = ({ uiTransition, onChangeTransition, useNewUx }: TransitionPr
             helpText="The minimum age after a rollover has occurred that is required to transition to the next state."
           />
           <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
-            <EuiFieldText
+            <EuiCompressedFieldText
               fullWidth
               value={conditions?.min_rollover_age}
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
@@ -186,7 +194,7 @@ const Transition = ({ uiTransition, onChangeTransition, useNewUx }: TransitionPr
             }
           />
           <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
-            <EuiFieldText
+            <EuiCompressedFieldText
               fullWidth
               value={conditions?.cron?.cron.expression}
               onChange={(e: ChangeEvent<HTMLInputElement>) => {

--- a/public/pages/VisualCreatePolicy/components/Transition/Transition.tsx
+++ b/public/pages/VisualCreatePolicy/components/Transition/Transition.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiLink, EuiIcon, EuiFormRow, EuiSelect, EuiSpacer, EuiFieldText, EuiFieldNumber } from "@elastic/eui";
+import { EuiLink, EuiIcon, EuiCompressedFormRow, EuiSelect, EuiSpacer, EuiFieldText, EuiFieldNumber } from "@elastic/eui";
 import moment from "moment-timezone";
 import EuiFormCustomLabel from "../EuiFormCustomLabel";
 import { UITransition } from "../../../../../models/interfaces";
@@ -34,7 +34,7 @@ const Transition = ({ uiTransition, onChangeTransition, useNewUx }: TransitionPr
   return (
     <>
       <EuiFormCustomLabel title="Condition" helpText="Specify the condition needed to be met to transition to the destination state." />
-      <EuiFormRow fullWidth isInvalid={false} error={null}>
+      <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
         <EuiSelect
           compressed={useNewUx}
           fullWidth
@@ -59,14 +59,14 @@ const Transition = ({ uiTransition, onChangeTransition, useNewUx }: TransitionPr
           }}
           data-test-subj="create-state-action-type"
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
 
       <EuiSpacer />
 
       {conditionType === "min_index_age" && (
         <>
           <EuiFormCustomLabel title="Minimum index age" helpText="The minimum age required to transition to the next state." />
-          <EuiFormRow fullWidth isInvalid={false} error={null}>
+          <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
             <EuiFieldText
               fullWidth
               value={conditions?.min_index_age}
@@ -84,7 +84,7 @@ const Transition = ({ uiTransition, onChangeTransition, useNewUx }: TransitionPr
               }}
               data-test-subj="transition-render-conditions-min-index-age"
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </>
       )}
 
@@ -94,7 +94,7 @@ const Transition = ({ uiTransition, onChangeTransition, useNewUx }: TransitionPr
             title="Minimum doc count"
             helpText="The minimum number of documents required to transition to the next state."
           />
-          <EuiFormRow fullWidth isInvalid={false} error={null}>
+          <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
             <EuiFieldNumber
               fullWidth
               value={typeof conditions?.min_doc_count === "undefined" ? "" : conditions?.min_doc_count}
@@ -114,7 +114,7 @@ const Transition = ({ uiTransition, onChangeTransition, useNewUx }: TransitionPr
               }}
               data-test-subj="transition-render-conditions-min-doc-count"
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </>
       )}
 
@@ -124,7 +124,7 @@ const Transition = ({ uiTransition, onChangeTransition, useNewUx }: TransitionPr
             title="Minimum index size"
             helpText="The minimum size of the total primary shard storage required to transition to the next state."
           />
-          <EuiFormRow fullWidth isInvalid={false} error={null}>
+          <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
             <EuiFieldText
               fullWidth
               value={conditions?.min_size}
@@ -142,7 +142,7 @@ const Transition = ({ uiTransition, onChangeTransition, useNewUx }: TransitionPr
               }}
               data-test-subj="transition-render-conditions-min-size"
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </>
       )}
 
@@ -152,7 +152,7 @@ const Transition = ({ uiTransition, onChangeTransition, useNewUx }: TransitionPr
             title="Minimum rollover age"
             helpText="The minimum age after a rollover has occurred that is required to transition to the next state."
           />
-          <EuiFormRow fullWidth isInvalid={false} error={null}>
+          <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
             <EuiFieldText
               fullWidth
               value={conditions?.min_rollover_age}
@@ -170,7 +170,7 @@ const Transition = ({ uiTransition, onChangeTransition, useNewUx }: TransitionPr
               }}
               data-test-subj="transition-render-conditions-min-rollover-age"
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </>
       )}
 
@@ -185,7 +185,7 @@ const Transition = ({ uiTransition, onChangeTransition, useNewUx }: TransitionPr
               </EuiLink>
             }
           />
-          <EuiFormRow fullWidth isInvalid={false} error={null}>
+          <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
             <EuiFieldText
               fullWidth
               value={conditions?.cron?.cron.expression}
@@ -208,12 +208,12 @@ const Transition = ({ uiTransition, onChangeTransition, useNewUx }: TransitionPr
               }}
               data-test-subj="transition-render-conditions-min-size"
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
 
           <EuiSpacer />
 
           <EuiFormCustomLabel title="Timezone" helpText="A day starts from 00:00:00 in the specified timezone." />
-          <EuiFormRow fullWidth isInvalid={false} error={null}>
+          <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
             <EuiSelect
               fullWidth
               id="timezone"
@@ -237,7 +237,7 @@ const Transition = ({ uiTransition, onChangeTransition, useNewUx }: TransitionPr
                 });
               }}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </>
       )}
     </>

--- a/public/pages/VisualCreatePolicy/components/Transition/Transition.tsx
+++ b/public/pages/VisualCreatePolicy/components/Transition/Transition.tsx
@@ -8,7 +8,7 @@ import {
   EuiLink,
   EuiIcon,
   EuiCompressedFormRow,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiSpacer,
   EuiCompressedFieldText,
   EuiCompressedFieldNumber,
@@ -43,8 +43,7 @@ const Transition = ({ uiTransition, onChangeTransition, useNewUx }: TransitionPr
     <>
       <EuiFormCustomLabel title="Condition" helpText="Specify the condition needed to be met to transition to the destination state." />
       <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
-        <EuiSelect
-          compressed={useNewUx}
+        <EuiCompressedSelect
           fullWidth
           id="condition-type"
           options={conditionTypeOptions}
@@ -222,7 +221,7 @@ const Transition = ({ uiTransition, onChangeTransition, useNewUx }: TransitionPr
 
           <EuiFormCustomLabel title="Timezone" helpText="A day starts from 00:00:00 in the specified timezone." />
           <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
-            <EuiSelect
+            <EuiCompressedSelect
               fullWidth
               id="timezone"
               options={timezones}

--- a/public/pages/VisualCreatePolicy/components/UIActions/AliasUIAction/AliasUIActionComponent.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/AliasUIAction/AliasUIActionComponent.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { Component } from "react";
-import { EuiComboBox, EuiComboBoxOptionOption, EuiCompressedFormRow, EuiSpacer, EuiSwitch } from "@elastic/eui";
+import { EuiComboBox, EuiComboBoxOptionOption, EuiCompressedFormRow, EuiSpacer, EuiCompressedSwitch } from "@elastic/eui";
 import { AliasAction, AliasActionItem, AliasActions, UIAction } from "../../../../../../models/interfaces";
 import AliasUIAction, { MAX_ALIAS_ACTIONS } from "./AliasUIAction";
 import { inputLimitText } from "../../../../CreatePolicy/utils/helpers";
@@ -83,7 +83,7 @@ export default class AliasUIActionComponent extends Component<AliasUIActionCompo
     const { addAliasToggle, removeAliasToggle } = this.state;
     return (
       <>
-        <EuiSwitch
+        <EuiCompressedSwitch
           label={"Add aliases"}
           checked={addAliasToggle}
           onChange={(e) => {
@@ -126,7 +126,7 @@ export default class AliasUIActionComponent extends Component<AliasUIActionCompo
 
         <EuiSpacer size={"l"} />
 
-        <EuiSwitch
+        <EuiCompressedSwitch
           label={"Remove aliases"}
           checked={removeAliasToggle}
           onChange={(e) => {

--- a/public/pages/VisualCreatePolicy/components/UIActions/AliasUIAction/AliasUIActionComponent.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/AliasUIAction/AliasUIActionComponent.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { Component } from "react";
-import { EuiComboBox, EuiComboBoxOptionOption, EuiFormRow, EuiSpacer, EuiSwitch } from "@elastic/eui";
+import { EuiComboBox, EuiComboBoxOptionOption, EuiCompressedFormRow, EuiSpacer, EuiSwitch } from "@elastic/eui";
 import { AliasAction, AliasActionItem, AliasActions, UIAction } from "../../../../../../models/interfaces";
 import AliasUIAction, { MAX_ALIAS_ACTIONS } from "./AliasUIAction";
 import { inputLimitText } from "../../../../CreatePolicy/utils/helpers";
@@ -96,7 +96,7 @@ export default class AliasUIActionComponent extends Component<AliasUIActionCompo
         {addAliasToggle && (
           <>
             <EuiSpacer size={"m"} />
-            <EuiFormRow
+            <EuiCompressedFormRow
               label={"Select aliases to add to indexes"}
               fullWidth
               style={{ maxWidth: "100%" }}
@@ -120,7 +120,7 @@ export default class AliasUIActionComponent extends Component<AliasUIActionCompo
                 />
                 {inputLimitText(selectedItems.add?.length, MAX_ALIAS_ACTIONS, "alias", "aliases")}
               </>
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </>
         )}
 
@@ -139,7 +139,7 @@ export default class AliasUIActionComponent extends Component<AliasUIActionCompo
         {removeAliasToggle && (
           <>
             <EuiSpacer size={"m"} />
-            <EuiFormRow
+            <EuiCompressedFormRow
               label={"Select aliases to remove from indexes"}
               fullWidth
               style={{ maxWidth: "100%" }}
@@ -163,7 +163,7 @@ export default class AliasUIActionComponent extends Component<AliasUIActionCompo
                 />
                 {inputLimitText(selectedItems.remove?.length, MAX_ALIAS_ACTIONS, "alias", "aliases")}
               </>
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </>
         )}
       </>

--- a/public/pages/VisualCreatePolicy/components/UIActions/AliasUIAction/AliasUIActionComponent.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/AliasUIAction/AliasUIActionComponent.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { Component } from "react";
-import { EuiComboBox, EuiComboBoxOptionOption, EuiCompressedFormRow, EuiSpacer, EuiCompressedSwitch } from "@elastic/eui";
+import { EuiCompressedComboBox, EuiComboBoxOptionOption, EuiCompressedFormRow, EuiSpacer, EuiCompressedSwitch } from "@elastic/eui";
 import { AliasAction, AliasActionItem, AliasActions, UIAction } from "../../../../../../models/interfaces";
 import AliasUIAction, { MAX_ALIAS_ACTIONS } from "./AliasUIAction";
 import { inputLimitText } from "../../../../CreatePolicy/utils/helpers";
@@ -105,7 +105,7 @@ export default class AliasUIActionComponent extends Component<AliasUIActionCompo
               data-test-subj={"add-alias-row"}
             >
               <>
-                <EuiComboBox
+                <EuiCompressedComboBox
                   placeholder={"Enter aliases to add"}
                   noSuggestions={true}
                   selectedOptions={selectedItems.add || []}
@@ -148,7 +148,7 @@ export default class AliasUIActionComponent extends Component<AliasUIActionCompo
               data-test-subj={"remove-alias-row"}
             >
               <>
-                <EuiComboBox
+                <EuiCompressedComboBox
                   placeholder={"Enter aliases to remove"}
                   noSuggestions={true}
                   selectedOptions={selectedItems.remove || []}

--- a/public/pages/VisualCreatePolicy/components/UIActions/AliasUIAction/__snapshots__/AliasUIAction.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/UIActions/AliasUIAction/__snapshots__/AliasUIAction.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`AliasUIAction component renders with blank action 1`] = `
 <div>
   <div
-    class="euiSwitch euiSwitch--primary"
+    class="euiSwitch euiSwitch--primary euiSwitch--compressed"
   >
     <button
       aria-checked="true"
@@ -22,10 +22,7 @@ exports[`AliasUIAction component renders with blank action 1`] = `
         />
         <span
           class="euiSwitch__track"
-        >
-          EuiIconMock
-          EuiIconMock
-        </span>
+        />
       </span>
     </button>
     <span
@@ -39,7 +36,7 @@ exports[`AliasUIAction component renders with blank action 1`] = `
     class="euiSpacer euiSpacer--m"
   />
   <div
-    class="euiFormRow euiFormRow--fullWidth"
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
     data-test-subj="add-alias-row"
     id="some_html_id-row"
     style="max-width: 100%;"
@@ -61,18 +58,18 @@ exports[`AliasUIAction component renders with blank action 1`] = `
       <div
         aria-expanded="false"
         aria-haspopup="listbox"
-        class="euiComboBox"
+        class="euiComboBox euiComboBox--compressed"
         data-test-subj="add-alias-combo-box"
         role="combobox"
       >
         <div
-          class="euiFormControlLayout"
+          class="euiFormControlLayout euiFormControlLayout--compressed"
         >
           <div
             class="euiFormControlLayout__childrenWrapper"
           >
             <div
-              class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+              class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
               data-test-subj="comboBoxInput"
               tabindex="-1"
             >
@@ -115,7 +112,7 @@ exports[`AliasUIAction component renders with blank action 1`] = `
     class="euiSpacer euiSpacer--l"
   />
   <div
-    class="euiSwitch euiSwitch--primary"
+    class="euiSwitch euiSwitch--primary euiSwitch--compressed"
   >
     <button
       aria-checked="true"
@@ -134,10 +131,7 @@ exports[`AliasUIAction component renders with blank action 1`] = `
         />
         <span
           class="euiSwitch__track"
-        >
-          EuiIconMock
-          EuiIconMock
-        </span>
+        />
       </span>
     </button>
     <span
@@ -151,7 +145,7 @@ exports[`AliasUIAction component renders with blank action 1`] = `
     class="euiSpacer euiSpacer--m"
   />
   <div
-    class="euiFormRow euiFormRow--fullWidth"
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
     data-test-subj="remove-alias-row"
     id="some_html_id-row"
     style="max-width: 100%;"
@@ -173,18 +167,18 @@ exports[`AliasUIAction component renders with blank action 1`] = `
       <div
         aria-expanded="false"
         aria-haspopup="listbox"
-        class="euiComboBox"
+        class="euiComboBox euiComboBox--compressed"
         data-test-subj="remove-alias-combo-box"
         role="combobox"
       >
         <div
-          class="euiFormControlLayout"
+          class="euiFormControlLayout euiFormControlLayout--compressed"
         >
           <div
             class="euiFormControlLayout__childrenWrapper"
           >
             <div
-              class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+              class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
               data-test-subj="comboBoxInput"
               tabindex="-1"
             >
@@ -229,7 +223,7 @@ exports[`AliasUIAction component renders with blank action 1`] = `
 exports[`AliasUIAction component renders with pre-defined actions 1`] = `
 <div>
   <div
-    class="euiSwitch euiSwitch--primary"
+    class="euiSwitch euiSwitch--primary euiSwitch--compressed"
   >
     <button
       aria-checked="true"
@@ -248,10 +242,7 @@ exports[`AliasUIAction component renders with pre-defined actions 1`] = `
         />
         <span
           class="euiSwitch__track"
-        >
-          EuiIconMock
-          EuiIconMock
-        </span>
+        />
       </span>
     </button>
     <span
@@ -265,7 +256,7 @@ exports[`AliasUIAction component renders with pre-defined actions 1`] = `
     class="euiSpacer euiSpacer--m"
   />
   <div
-    class="euiFormRow euiFormRow--fullWidth"
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
     data-test-subj="add-alias-row"
     id="some_html_id-row"
     style="max-width: 100%;"
@@ -287,18 +278,18 @@ exports[`AliasUIAction component renders with pre-defined actions 1`] = `
       <div
         aria-expanded="false"
         aria-haspopup="listbox"
-        class="euiComboBox"
+        class="euiComboBox euiComboBox--compressed"
         data-test-subj="add-alias-combo-box"
         role="combobox"
       >
         <div
-          class="euiFormControlLayout"
+          class="euiFormControlLayout euiFormControlLayout--compressed"
         >
           <div
             class="euiFormControlLayout__childrenWrapper"
           >
             <div
-              class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+              class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
               data-test-subj="comboBoxInput"
               tabindex="-1"
             >
@@ -433,7 +424,7 @@ exports[`AliasUIAction component renders with pre-defined actions 1`] = `
             >
               <button
                 aria-label="Clear input"
-                class="euiFormControlLayoutClearButton"
+                class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                 data-test-subj="comboBoxClearButton"
                 type="button"
               >
@@ -458,7 +449,7 @@ exports[`AliasUIAction component renders with pre-defined actions 1`] = `
     class="euiSpacer euiSpacer--l"
   />
   <div
-    class="euiSwitch euiSwitch--primary"
+    class="euiSwitch euiSwitch--primary euiSwitch--compressed"
   >
     <button
       aria-checked="true"
@@ -477,10 +468,7 @@ exports[`AliasUIAction component renders with pre-defined actions 1`] = `
         />
         <span
           class="euiSwitch__track"
-        >
-          EuiIconMock
-          EuiIconMock
-        </span>
+        />
       </span>
     </button>
     <span
@@ -494,7 +482,7 @@ exports[`AliasUIAction component renders with pre-defined actions 1`] = `
     class="euiSpacer euiSpacer--m"
   />
   <div
-    class="euiFormRow euiFormRow--fullWidth"
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
     data-test-subj="remove-alias-row"
     id="some_html_id-row"
     style="max-width: 100%;"
@@ -516,18 +504,18 @@ exports[`AliasUIAction component renders with pre-defined actions 1`] = `
       <div
         aria-expanded="false"
         aria-haspopup="listbox"
-        class="euiComboBox"
+        class="euiComboBox euiComboBox--compressed"
         data-test-subj="remove-alias-combo-box"
         role="combobox"
       >
         <div
-          class="euiFormControlLayout"
+          class="euiFormControlLayout euiFormControlLayout--compressed"
         >
           <div
             class="euiFormControlLayout__childrenWrapper"
           >
             <div
-              class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+              class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
               data-test-subj="comboBoxInput"
               tabindex="-1"
             >
@@ -640,7 +628,7 @@ exports[`AliasUIAction component renders with pre-defined actions 1`] = `
             >
               <button
                 aria-label="Clear input"
-                class="euiFormControlLayoutClearButton"
+                class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                 data-test-subj="comboBoxClearButton"
                 type="button"
               >

--- a/public/pages/VisualCreatePolicy/components/UIActions/AllocationUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/AllocationUIAction.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { EuiFormRow, EuiCodeEditor } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiCodeEditor } from "@elastic/eui";
 import { AllocationAction, UIAction } from "../../../../../models/interfaces";
 import { makeId } from "../../../../utils/helpers";
 import { ActionType } from "../../utils/constants";
@@ -45,7 +45,7 @@ export default class AllocationUIAction implements UIAction<AllocationAction> {
 
   render = (action: UIAction<AllocationAction>, onChangeAction: (action: UIAction<AllocationAction>) => void) => {
     return (
-      <EuiFormRow fullWidth isInvalid={!this.isValid()} error={null} style={{ maxWidth: "100%" }}>
+      <EuiCompressedFormRow fullWidth isInvalid={!this.isValid()} error={null} style={{ maxWidth: "100%" }}>
         <DarkModeConsumer>
           {(isDarkMode) => (
             <EuiCodeEditor
@@ -66,7 +66,7 @@ export default class AllocationUIAction implements UIAction<AllocationAction> {
             />
           )}
         </DarkModeConsumer>
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     );
   };
 

--- a/public/pages/VisualCreatePolicy/components/UIActions/ForceMergeUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ForceMergeUIAction.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiFormRow, EuiFieldNumber } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiFieldNumber } from "@elastic/eui";
 import EuiFormCustomLabel from "../EuiFormCustomLabel";
 import { ForceMergeAction, UIAction } from "../../../../../models/interfaces";
 import { makeId } from "../../../../utils/helpers";
@@ -34,7 +34,7 @@ export default class ForceMergeUIAction implements UIAction<ForceMergeAction> {
     return (
       <>
         <EuiFormCustomLabel title="Max num segments" helpText="The number of segments to merge to." isInvalid={!this.isValid()} />
-        <EuiFormRow fullWidth isInvalid={!this.isValid()} error={null}>
+        <EuiCompressedFormRow fullWidth isInvalid={!this.isValid()} error={null}>
           <EuiFieldNumber
             fullWidth
             value={typeof segments === "undefined" ? "" : segments}
@@ -46,7 +46,7 @@ export default class ForceMergeUIAction implements UIAction<ForceMergeAction> {
             }}
             data-test-subj="action-render-force-merge"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </>
     );
   };

--- a/public/pages/VisualCreatePolicy/components/UIActions/ForceMergeUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ForceMergeUIAction.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiCompressedFormRow, EuiFieldNumber } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiCompressedFieldNumber } from "@elastic/eui";
 import EuiFormCustomLabel from "../EuiFormCustomLabel";
 import { ForceMergeAction, UIAction } from "../../../../../models/interfaces";
 import { makeId } from "../../../../utils/helpers";
@@ -35,7 +35,7 @@ export default class ForceMergeUIAction implements UIAction<ForceMergeAction> {
       <>
         <EuiFormCustomLabel title="Max num segments" helpText="The number of segments to merge to." isInvalid={!this.isValid()} />
         <EuiCompressedFormRow fullWidth isInvalid={!this.isValid()} error={null}>
-          <EuiFieldNumber
+          <EuiCompressedFieldNumber
             fullWidth
             value={typeof segments === "undefined" ? "" : segments}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {

--- a/public/pages/VisualCreatePolicy/components/UIActions/IndexPriorityUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/IndexPriorityUIAction.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiFormRow, EuiFieldNumber } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiFieldNumber } from "@elastic/eui";
 import EuiFormCustomLabel from "../EuiFormCustomLabel";
 import { IndexPriorityAction, UIAction } from "../../../../../models/interfaces";
 import { makeId } from "../../../../utils/helpers";
@@ -38,7 +38,7 @@ export default class IndexPriorityUIAction implements UIAction<IndexPriorityActi
           helpText="Higher priority indices are recovered first when possible."
           isInvalid={!this.isValid()}
         />
-        <EuiFormRow fullWidth isInvalid={!this.isValid()} error={null}>
+        <EuiCompressedFormRow fullWidth isInvalid={!this.isValid()} error={null}>
           <EuiFieldNumber
             fullWidth
             value={typeof priority === "undefined" ? "" : priority}
@@ -50,7 +50,7 @@ export default class IndexPriorityUIAction implements UIAction<IndexPriorityActi
             }}
             data-test-subj="action-render-index-priority"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </>
     );
   };

--- a/public/pages/VisualCreatePolicy/components/UIActions/IndexPriorityUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/IndexPriorityUIAction.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiCompressedFormRow, EuiFieldNumber } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiCompressedFieldNumber } from "@elastic/eui";
 import EuiFormCustomLabel from "../EuiFormCustomLabel";
 import { IndexPriorityAction, UIAction } from "../../../../../models/interfaces";
 import { makeId } from "../../../../utils/helpers";
@@ -39,7 +39,7 @@ export default class IndexPriorityUIAction implements UIAction<IndexPriorityActi
           isInvalid={!this.isValid()}
         />
         <EuiCompressedFormRow fullWidth isInvalid={!this.isValid()} error={null}>
-          <EuiFieldNumber
+          <EuiCompressedFieldNumber
             fullWidth
             value={typeof priority === "undefined" ? "" : priority}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {

--- a/public/pages/VisualCreatePolicy/components/UIActions/ReplicaCountUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ReplicaCountUIAction.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiFormRow, EuiFieldNumber } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiFieldNumber } from "@elastic/eui";
 import { ReplicaCountAction, UIAction } from "../../../../../models/interfaces";
 import { makeId } from "../../../../utils/helpers";
 import { ActionType } from "../../utils/constants";
@@ -38,7 +38,7 @@ export default class ReplicaCountUIAction implements UIAction<ReplicaCountAction
           helpText="The number of replicas to set for the index."
           isInvalid={!this.isValid()}
         />
-        <EuiFormRow fullWidth isInvalid={!this.isValid()} error={null}>
+        <EuiCompressedFormRow fullWidth isInvalid={!this.isValid()} error={null}>
           <EuiFieldNumber
             fullWidth
             value={typeof replicas === "undefined" ? "" : replicas}
@@ -50,7 +50,7 @@ export default class ReplicaCountUIAction implements UIAction<ReplicaCountAction
             }}
             data-test-subj="action-render-replica-count"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </>
     );
   };

--- a/public/pages/VisualCreatePolicy/components/UIActions/ReplicaCountUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ReplicaCountUIAction.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiCompressedFormRow, EuiFieldNumber } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiCompressedFieldNumber } from "@elastic/eui";
 import { ReplicaCountAction, UIAction } from "../../../../../models/interfaces";
 import { makeId } from "../../../../utils/helpers";
 import { ActionType } from "../../utils/constants";
@@ -39,7 +39,7 @@ export default class ReplicaCountUIAction implements UIAction<ReplicaCountAction
           isInvalid={!this.isValid()}
         />
         <EuiCompressedFormRow fullWidth isInvalid={!this.isValid()} error={null}>
-          <EuiFieldNumber
+          <EuiCompressedFieldNumber
             fullWidth
             value={typeof replicas === "undefined" ? "" : replicas}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {

--- a/public/pages/VisualCreatePolicy/components/UIActions/RolloverUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/RolloverUIAction.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiCompressedFormRow, EuiFieldNumber, EuiFieldText, EuiSpacer } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiCompressedFieldNumber, EuiCompressedFieldText, EuiSpacer } from "@elastic/eui";
 import { RolloverAction, UIAction } from "../../../../../models/interfaces";
 import { makeId } from "../../../../utils/helpers";
 import { ActionType } from "../../utils/constants";
@@ -48,7 +48,7 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
           isInvalid={!this.isValid()}
         />
         <EuiCompressedFormRow fullWidth isInvalid={!this.isValid()} error={null}>
-          <EuiFieldText
+          <EuiCompressedFieldText
             fullWidth
             value={rollover.min_index_age || ""}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
@@ -68,7 +68,7 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
           isInvalid={!this.isValid()}
         />
         <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
-          <EuiFieldNumber
+          <EuiCompressedFieldNumber
             fullWidth
             value={typeof rollover.min_doc_count === "undefined" ? "" : rollover.min_doc_count}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
@@ -88,7 +88,7 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
           isInvalid={!this.isValid()}
         />
         <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
-          <EuiFieldText
+          <EuiCompressedFieldText
             fullWidth
             value={rollover.min_size || ""}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
@@ -108,7 +108,7 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
           isInvalid={!this.isValid()}
         />
         <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
-          <EuiFieldText
+          <EuiCompressedFieldText
             fullWidth
             value={rollover.min_primary_shard_size || ""}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {

--- a/public/pages/VisualCreatePolicy/components/UIActions/RolloverUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/RolloverUIAction.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiFormRow, EuiFieldNumber, EuiFieldText, EuiSpacer } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiFieldNumber, EuiFieldText, EuiSpacer } from "@elastic/eui";
 import { RolloverAction, UIAction } from "../../../../../models/interfaces";
 import { makeId } from "../../../../utils/helpers";
 import { ActionType } from "../../utils/constants";
@@ -47,7 +47,7 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
           helpText={`The minimum age required to roll over the index. Accepts time units, e.g. "5h" or "1d".`}
           isInvalid={!this.isValid()}
         />
-        <EuiFormRow fullWidth isInvalid={!this.isValid()} error={null}>
+        <EuiCompressedFormRow fullWidth isInvalid={!this.isValid()} error={null}>
           <EuiFieldText
             fullWidth
             value={rollover.min_index_age || ""}
@@ -60,14 +60,14 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
             }}
             data-test-subj="action-render-rollover-min-index-age"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <EuiSpacer size="s" />
         <EuiFormCustomLabel
           title="Minimum doc count"
           helpText="The minimum number of documents required to roll over the index."
           isInvalid={!this.isValid()}
         />
-        <EuiFormRow fullWidth isInvalid={false} error={null}>
+        <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
           <EuiFieldNumber
             fullWidth
             value={typeof rollover.min_doc_count === "undefined" ? "" : rollover.min_doc_count}
@@ -80,14 +80,14 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
             }}
             data-test-subj="action-render-rollover-min-doc-count"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <EuiSpacer size="s" />
         <EuiFormCustomLabel
           title="Minimum index size"
           helpText={`The minimum size of the total primary shard storage required to roll over the index. Accepts byte units, e.g. "500mb" or "50gb".`}
           isInvalid={!this.isValid()}
         />
-        <EuiFormRow fullWidth isInvalid={false} error={null}>
+        <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
           <EuiFieldText
             fullWidth
             value={rollover.min_size || ""}
@@ -100,14 +100,14 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
             }}
             data-test-subj="action-render-rollover-min-size"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <EuiSpacer size="s" />
         <EuiFormCustomLabel
           title="Minimum primary shard size"
           helpText={`The minimum size of a single primary shard required to roll over the index. Accepts byte units, e.g. "500mb" or "50gb".`}
           isInvalid={!this.isValid()}
         />
-        <EuiFormRow fullWidth isInvalid={false} error={null}>
+        <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
           <EuiFieldText
             fullWidth
             value={rollover.min_primary_shard_size || ""}
@@ -120,7 +120,7 @@ export default class RolloverUIAction implements UIAction<RolloverAction> {
             }}
             data-test-subj="action-render-rollover-min-primary-shard-size"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </>
     );
   };

--- a/public/pages/VisualCreatePolicy/components/UIActions/RollupUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/RollupUIAction.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { EuiFormRow, EuiCodeEditor } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiCodeEditor } from "@elastic/eui";
 import { RollupAction, UIAction } from "../../../../../models/interfaces";
 import { makeId } from "../../../../utils/helpers";
 import { DarkModeConsumer } from "../../../../components/DarkMode";
@@ -46,7 +46,7 @@ export default class RollupUIAction implements UIAction<RollupAction> {
   render = (action: UIAction<RollupAction>, onChangeAction: (action: UIAction<RollupAction>) => void) => {
     // If we don't have a JSON string yet it just means we haven't converted the rollup to it yet
     return (
-      <EuiFormRow fullWidth isInvalid={!this.isValid()} error={null} style={{ maxWidth: "100%" }}>
+      <EuiCompressedFormRow fullWidth isInvalid={!this.isValid()} error={null} style={{ maxWidth: "100%" }}>
         <DarkModeConsumer>
           {(isDarkMode) => (
             <EuiCodeEditor
@@ -67,7 +67,7 @@ export default class RollupUIAction implements UIAction<RollupAction> {
             />
           )}
         </DarkModeConsumer>
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     );
   };
 

--- a/public/pages/VisualCreatePolicy/components/UIActions/ShrinkUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ShrinkUIAction.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiCompressedFormRow, EuiCodeEditor, EuiFieldText, EuiSpacer, EuiRadioGroup, EuiCallOut } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiCodeEditor, EuiCompressedFieldText, EuiSpacer, EuiRadioGroup, EuiCallOut } from "@elastic/eui";
 import { ShrinkAction, UIAction } from "../../../../../models/interfaces";
 import { makeId } from "../../../../utils/helpers";
 import { ActionType } from "../../utils/constants";
@@ -110,7 +110,7 @@ export default class ShrinkUIAction implements UIAction<ShrinkAction> {
           isInvalid={!this.isValidNumShards()}
         />
         <EuiCompressedFormRow fullWidth isInvalid={!this.isValidNumShards()} error={null}>
-          <EuiFieldText
+          <EuiCompressedFieldText
             fullWidth
             value={typeof shrink.num_new_shards === "undefined" ? "" : shrink.num_new_shards}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
@@ -134,7 +134,7 @@ export default class ShrinkUIAction implements UIAction<ShrinkAction> {
           isInvalid={!this.isValidNumShards()}
         />
         <EuiCompressedFormRow fullWidth isInvalid={!this.isValidNumShards()} error={null}>
-          <EuiFieldText
+          <EuiCompressedFieldText
             fullWidth
             value={shrink.max_shard_size || ""}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
@@ -158,7 +158,7 @@ export default class ShrinkUIAction implements UIAction<ShrinkAction> {
           isInvalid={!this.isValidNumShards()}
         />
         <EuiCompressedFormRow fullWidth isInvalid={!this.isValidNumShards()} error={null}>
-          <EuiFieldText
+          <EuiCompressedFieldText
             fullWidth
             value={typeof shrink.percentage_of_source_shards === "undefined" ? "" : shrink.percentage_of_source_shards}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {

--- a/public/pages/VisualCreatePolicy/components/UIActions/ShrinkUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ShrinkUIAction.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiCompressedFormRow, EuiCodeEditor, EuiCompressedFieldText, EuiSpacer, EuiRadioGroup, EuiCallOut } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiCodeEditor, EuiCompressedFieldText, EuiSpacer, EuiCompressedRadioGroup, EuiCallOut } from "@elastic/eui";
 import { ShrinkAction, UIAction } from "../../../../../models/interfaces";
 import { makeId } from "../../../../utils/helpers";
 import { ActionType } from "../../utils/constants";
@@ -214,7 +214,7 @@ export default class ShrinkUIAction implements UIAction<ShrinkAction> {
           isInvalid={false}
         />
         <EuiCompressedFormRow fullWidth isInvalid={false} error={null} style={{ maxWidth: "100%" }}>
-          <EuiRadioGroup
+          <EuiCompressedRadioGroup
             options={radios}
             idSelected={this.action.force_unsafe_input}
             onChange={(id) => {

--- a/public/pages/VisualCreatePolicy/components/UIActions/ShrinkUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/ShrinkUIAction.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiFormRow, EuiCodeEditor, EuiFieldText, EuiSpacer, EuiRadioGroup, EuiCallOut } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiCodeEditor, EuiFieldText, EuiSpacer, EuiRadioGroup, EuiCallOut } from "@elastic/eui";
 import { ShrinkAction, UIAction } from "../../../../../models/interfaces";
 import { makeId } from "../../../../utils/helpers";
 import { ActionType } from "../../utils/constants";
@@ -109,7 +109,7 @@ export default class ShrinkUIAction implements UIAction<ShrinkAction> {
           }
           isInvalid={!this.isValidNumShards()}
         />
-        <EuiFormRow fullWidth isInvalid={!this.isValidNumShards()} error={null}>
+        <EuiCompressedFormRow fullWidth isInvalid={!this.isValidNumShards()} error={null}>
           <EuiFieldText
             fullWidth
             value={typeof shrink.num_new_shards === "undefined" ? "" : shrink.num_new_shards}
@@ -122,7 +122,7 @@ export default class ShrinkUIAction implements UIAction<ShrinkAction> {
             }}
             data-test-subj="action-render-shrink-num-new-shards"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <EuiSpacer size="s" />
         <EuiFormCustomLabel
           title="Maximum shard size"
@@ -133,7 +133,7 @@ export default class ShrinkUIAction implements UIAction<ShrinkAction> {
           }
           isInvalid={!this.isValidNumShards()}
         />
-        <EuiFormRow fullWidth isInvalid={!this.isValidNumShards()} error={null}>
+        <EuiCompressedFormRow fullWidth isInvalid={!this.isValidNumShards()} error={null}>
           <EuiFieldText
             fullWidth
             value={shrink.max_shard_size || ""}
@@ -146,7 +146,7 @@ export default class ShrinkUIAction implements UIAction<ShrinkAction> {
             }}
             data-test-subj="action-render-shrink-max-shard-size"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <EuiSpacer size="s" />
         <EuiFormCustomLabel
           title="Percentage of source shards"
@@ -157,7 +157,7 @@ export default class ShrinkUIAction implements UIAction<ShrinkAction> {
           }
           isInvalid={!this.isValidNumShards()}
         />
-        <EuiFormRow fullWidth isInvalid={!this.isValidNumShards()} error={null}>
+        <EuiCompressedFormRow fullWidth isInvalid={!this.isValidNumShards()} error={null}>
           <EuiFieldText
             fullWidth
             value={typeof shrink.percentage_of_source_shards === "undefined" ? "" : shrink.percentage_of_source_shards}
@@ -170,7 +170,7 @@ export default class ShrinkUIAction implements UIAction<ShrinkAction> {
             }}
             data-test-subj="action-render-shrink-percentage-of-source-shards"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <EuiSpacer size="s" />
         <EuiFormCustomLabel
           title="Target Index Name Template"
@@ -179,7 +179,7 @@ export default class ShrinkUIAction implements UIAction<ShrinkAction> {
           isInvalid={!this.isValidIndexNameTemplateJson()}
           isOptional={true}
         />
-        <EuiFormRow fullWidth isInvalid={!this.isValidIndexNameTemplateJson()} error={null} style={{ maxWidth: "100%" }}>
+        <EuiCompressedFormRow fullWidth isInvalid={!this.isValidIndexNameTemplateJson()} error={null} style={{ maxWidth: "100%" }}>
           <DarkModeConsumer>
             {(isDarkMode) => (
               <EuiCodeEditor
@@ -200,7 +200,7 @@ export default class ShrinkUIAction implements UIAction<ShrinkAction> {
               />
             )}
           </DarkModeConsumer>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <EuiSpacer size="s" />
         <EuiCallOut color="warning" hidden={!this.action.shrink.force_unsafe}>
           <p>
@@ -213,7 +213,7 @@ export default class ShrinkUIAction implements UIAction<ShrinkAction> {
           helpText={`If this is set to 'No' then the shrink action will fail for indices which do not have replica shards.`}
           isInvalid={false}
         />
-        <EuiFormRow fullWidth isInvalid={false} error={null} style={{ maxWidth: "100%" }}>
+        <EuiCompressedFormRow fullWidth isInvalid={false} error={null} style={{ maxWidth: "100%" }}>
           <EuiRadioGroup
             options={radios}
             idSelected={this.action.force_unsafe_input}
@@ -231,7 +231,7 @@ export default class ShrinkUIAction implements UIAction<ShrinkAction> {
             }}
             name="forceUnsafe"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <EuiSpacer size="s" />
         <EuiFormCustomLabel
           title="Aliases"
@@ -239,7 +239,7 @@ export default class ShrinkUIAction implements UIAction<ShrinkAction> {
           isInvalid={!this.isValidAliasesJson()}
           isOptional={true}
         />
-        <EuiFormRow fullWidth isInvalid={!this.isValidAliasesJson()} error={null} style={{ maxWidth: "100%" }}>
+        <EuiCompressedFormRow fullWidth isInvalid={!this.isValidAliasesJson()} error={null} style={{ maxWidth: "100%" }}>
           <DarkModeConsumer>
             {(isDarkMode) => (
               <EuiCodeEditor
@@ -261,7 +261,7 @@ export default class ShrinkUIAction implements UIAction<ShrinkAction> {
               />
             )}
           </DarkModeConsumer>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </>
     );
   };

--- a/public/pages/VisualCreatePolicy/components/UIActions/SnapshotUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/SnapshotUIAction.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiFormRow, EuiFieldText, EuiSpacer } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiFieldText, EuiSpacer } from "@elastic/eui";
 import { SnapshotAction, UIAction } from "../../../../../models/interfaces";
 import { makeId } from "../../../../utils/helpers";
 import { ActionType } from "../../utils/constants";
@@ -36,7 +36,7 @@ export default class SnapshotUIAction implements UIAction<SnapshotAction> {
           helpText="The repository name that you register through the native snapshot API operations."
           isInvalid={!this.isValid()}
         />
-        <EuiFormRow fullWidth isInvalid={!this.isValid()} error={null}>
+        <EuiCompressedFormRow fullWidth isInvalid={!this.isValid()} error={null}>
           <EuiFieldText
             fullWidth
             value={(action.action as SnapshotAction).snapshot.repository}
@@ -53,10 +53,10 @@ export default class SnapshotUIAction implements UIAction<SnapshotAction> {
             }}
             data-test-subj="action-render-snapshot-repository"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <EuiSpacer size="s" />
         <EuiFormCustomLabel title="Snapshot" helpText="The name of the snapshot." isInvalid={!this.isValid()} />
-        <EuiFormRow fullWidth isInvalid={!this.isValid()} error={null}>
+        <EuiCompressedFormRow fullWidth isInvalid={!this.isValid()} error={null}>
           <EuiFieldText
             fullWidth
             value={(action.action as SnapshotAction).snapshot.snapshot}
@@ -73,7 +73,7 @@ export default class SnapshotUIAction implements UIAction<SnapshotAction> {
             }}
             data-test-subj="action-render-snapshot-snapshot"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </>
     );
   };

--- a/public/pages/VisualCreatePolicy/components/UIActions/SnapshotUIAction.tsx
+++ b/public/pages/VisualCreatePolicy/components/UIActions/SnapshotUIAction.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent } from "react";
-import { EuiCompressedFormRow, EuiFieldText, EuiSpacer } from "@elastic/eui";
+import { EuiCompressedFormRow, EuiCompressedFieldText, EuiSpacer } from "@elastic/eui";
 import { SnapshotAction, UIAction } from "../../../../../models/interfaces";
 import { makeId } from "../../../../utils/helpers";
 import { ActionType } from "../../utils/constants";
@@ -37,7 +37,7 @@ export default class SnapshotUIAction implements UIAction<SnapshotAction> {
           isInvalid={!this.isValid()}
         />
         <EuiCompressedFormRow fullWidth isInvalid={!this.isValid()} error={null}>
-          <EuiFieldText
+          <EuiCompressedFieldText
             fullWidth
             value={(action.action as SnapshotAction).snapshot.repository}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
@@ -57,7 +57,7 @@ export default class SnapshotUIAction implements UIAction<SnapshotAction> {
         <EuiSpacer size="s" />
         <EuiFormCustomLabel title="Snapshot" helpText="The name of the snapshot." isInvalid={!this.isValid()} />
         <EuiCompressedFormRow fullWidth isInvalid={!this.isValid()} error={null}>
-          <EuiFieldText
+          <EuiCompressedFieldText
             fullWidth
             value={(action.action as SnapshotAction).snapshot.snapshot}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {

--- a/public/pages/VisualCreatePolicy/containers/CreateAction/CreateAction.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateAction/CreateAction.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { Component, ChangeEvent } from "react";
-import { EuiText, EuiLink, EuiFlyoutBody, EuiFlyoutFooter, EuiTitle, EuiFormRow, EuiSelect, EuiSpacer } from "@elastic/eui";
+import { EuiText, EuiLink, EuiFlyoutBody, EuiFlyoutFooter, EuiTitle, EuiCompressedFormRow, EuiSelect, EuiSpacer } from "@elastic/eui";
 import { UIAction, Action } from "../../../../../models/interfaces";
 import TimeoutRetrySettings from "../../components/TimeoutRetrySettings";
 import { actionRepoSingleton, getActionOptions } from "../../utils/helpers";
@@ -78,7 +78,7 @@ export default class CreateAction extends Component<CreateActionProps, CreateAct
           <EuiSpacer />
 
           <EuiFormCustomLabel title="Action type" helpText="Select the action you want to add to this state." />
-          <EuiFormRow fullWidth isInvalid={false} error={null}>
+          <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
             <EuiSelect
               compressed={useNewUx}
               fullWidth
@@ -92,7 +92,7 @@ export default class CreateAction extends Component<CreateActionProps, CreateAct
               onChange={this.onChangeSelectedAction}
               data-test-subj="create-state-action-type"
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
 
           <EuiSpacer />
 

--- a/public/pages/VisualCreatePolicy/containers/CreateAction/CreateAction.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateAction/CreateAction.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { Component, ChangeEvent } from "react";
-import { EuiText, EuiLink, EuiFlyoutBody, EuiFlyoutFooter, EuiTitle, EuiCompressedFormRow, EuiSelect, EuiSpacer } from "@elastic/eui";
+import { EuiText, EuiLink, EuiFlyoutBody, EuiFlyoutFooter, EuiTitle, EuiCompressedFormRow, EuiCompressedSelect, EuiSpacer } from "@elastic/eui";
 import { UIAction, Action } from "../../../../../models/interfaces";
 import TimeoutRetrySettings from "../../components/TimeoutRetrySettings";
 import { actionRepoSingleton, getActionOptions } from "../../utils/helpers";
@@ -79,8 +79,7 @@ export default class CreateAction extends Component<CreateActionProps, CreateAct
 
           <EuiFormCustomLabel title="Action type" helpText="Select the action you want to add to this state." />
           <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
-            <EuiSelect
-              compressed={useNewUx}
+            <EuiCompressedSelect
               fullWidth
               placeholder="Select action type"
               id="action-type"

--- a/public/pages/VisualCreatePolicy/containers/CreateAction/__snapshots__/CreateAction.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateAction/__snapshots__/CreateAction.test.tsx.snap
@@ -61,20 +61,20 @@ exports[`<CreateAction /> spec renders the component 1`] = `
         </p>
       </div>
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
           class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormControlLayout euiFormControlLayout--fullWidth"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <select
-                class="euiSelect euiSelect--fullWidth"
+                class="euiSelect euiSelect--fullWidth euiSelect--compressed"
                 data-test-subj="create-state-action-type"
                 id="some_html_id"
                 placeholder="Select action type"
@@ -201,20 +201,20 @@ exports[`<CreateAction /> spec renders the component 1`] = `
         </p>
       </div>
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
           class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormControlLayout euiFormControlLayout--fullWidth"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <input
-                class="euiFieldText euiFieldText--fullWidth"
+                class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
                 data-test-subj="action-render-rollover-min-index-age"
                 id="some_html_id"
                 type="text"
@@ -248,20 +248,20 @@ exports[`<CreateAction /> spec renders the component 1`] = `
         </p>
       </div>
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
           class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormControlLayout euiFormControlLayout--fullWidth"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <input
-                class="euiFieldNumber euiFieldNumber--fullWidth"
+                class="euiFieldNumber euiFieldNumber--fullWidth euiFieldNumber--compressed"
                 data-test-subj="action-render-rollover-min-doc-count"
                 id="some_html_id"
                 type="number"
@@ -295,20 +295,20 @@ exports[`<CreateAction /> spec renders the component 1`] = `
         </p>
       </div>
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
           class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormControlLayout euiFormControlLayout--fullWidth"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <input
-                class="euiFieldText euiFieldText--fullWidth"
+                class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
                 data-test-subj="action-render-rollover-min-size"
                 id="some_html_id"
                 type="text"
@@ -342,20 +342,20 @@ exports[`<CreateAction /> spec renders the component 1`] = `
         </p>
       </div>
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
           class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormControlLayout euiFormControlLayout--fullWidth"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <input
-                class="euiFieldText euiFieldText--fullWidth"
+                class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
                 data-test-subj="action-render-rollover-min-primary-shard-size"
                 id="some_html_id"
                 type="text"
@@ -447,7 +447,7 @@ exports[`<CreateAction /> spec renders the component 1`] = `
                     </p>
                   </div>
                   <div
-                    class="euiFormRow euiFormRow--fullWidth"
+                    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                     id="some_html_id-row"
                   >
                     <div
@@ -461,13 +461,13 @@ exports[`<CreateAction /> spec renders the component 1`] = `
                           class="euiFlexItem"
                         >
                           <div
-                            class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                            class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                           >
                             <div
                               class="euiFormControlLayout__childrenWrapper"
                             >
                               <input
-                                class="euiFieldText euiFieldText--fullWidth"
+                                class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
                                 type="text"
                                 value=""
                               />
@@ -502,7 +502,7 @@ exports[`<CreateAction /> spec renders the component 1`] = `
                     </p>
                   </div>
                   <div
-                    class="euiFormRow euiFormRow--fullWidth"
+                    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                     id="some_html_id-row"
                   >
                     <div
@@ -516,13 +516,13 @@ exports[`<CreateAction /> spec renders the component 1`] = `
                           class="euiFlexItem"
                         >
                           <div
-                            class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                            class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                           >
                             <div
                               class="euiFormControlLayout__childrenWrapper"
                             >
                               <input
-                                class="euiFieldNumber euiFieldNumber--fullWidth"
+                                class="euiFieldNumber euiFieldNumber--fullWidth euiFieldNumber--compressed"
                                 min="0"
                                 type="number"
                                 value=""
@@ -558,20 +558,20 @@ exports[`<CreateAction /> spec renders the component 1`] = `
                     </p>
                   </div>
                   <div
-                    class="euiFormRow euiFormRow--fullWidth"
+                    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                     id="some_html_id-row"
                   >
                     <div
                       class="euiFormRow__fieldWrapper"
                     >
                       <div
-                        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                        class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                       >
                         <div
                           class="euiFormControlLayout__childrenWrapper"
                         >
                           <select
-                            class="euiSelect euiSelect--fullWidth"
+                            class="euiSelect euiSelect--fullWidth euiSelect--compressed"
                             id="some_html_id"
                           >
                             <option
@@ -628,7 +628,7 @@ exports[`<CreateAction /> spec renders the component 1`] = `
                     </p>
                   </div>
                   <div
-                    class="euiFormRow euiFormRow--fullWidth"
+                    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                     id="some_html_id-row"
                   >
                     <div
@@ -642,13 +642,13 @@ exports[`<CreateAction /> spec renders the component 1`] = `
                           class="euiFlexItem"
                         >
                           <div
-                            class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                            class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                           >
                             <div
                               class="euiFormControlLayout__childrenWrapper"
                             >
                               <input
-                                class="euiFieldText euiFieldText--fullWidth"
+                                class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
                                 type="text"
                                 value=""
                               />

--- a/public/pages/VisualCreatePolicy/containers/CreateState/Actions.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/Actions.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { EuiButton, EuiFormRow, EuiDragDropContext, EuiDroppable, EuiSpacer, EuiText, DropResult } from "@elastic/eui";
+import { EuiSmallButton, EuiFormRow, EuiDragDropContext, EuiDroppable, EuiSpacer, EuiText, DropResult } from "@elastic/eui";
 import DraggableItem from "../../components/DraggableItem";
 import EuiFormCustomLabel from "../../components/EuiFormCustomLabel";
 import { Action, UIAction } from "../../../../../models/interfaces";
@@ -56,9 +56,7 @@ const Actions = ({ actions, onClickDeleteAction, onClickEditAction, onDragEndAct
 
       <EuiSpacer />
 
-      <EuiButton onClick={onClickAddAction} size={useNewUx ? "s" : undefined}>
-        + Add action
-      </EuiButton>
+      <EuiSmallButton onClick={onClickAddAction}>+ Add action</EuiSmallButton>
     </>
   );
 };

--- a/public/pages/VisualCreatePolicy/containers/CreateState/Actions.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/Actions.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { EuiSmallButton, EuiFormRow, EuiDragDropContext, EuiDroppable, EuiSpacer, EuiText, DropResult } from "@elastic/eui";
+import { EuiSmallButton, EuiCompressedFormRow, EuiDragDropContext, EuiDroppable, EuiSpacer, EuiText, DropResult } from "@elastic/eui";
 import DraggableItem from "../../components/DraggableItem";
 import EuiFormCustomLabel from "../../components/EuiFormCustomLabel";
 import { Action, UIAction } from "../../../../../models/interfaces";
@@ -24,7 +24,7 @@ const Actions = ({ actions, onClickDeleteAction, onClickEditAction, onDragEndAct
       <EuiFormCustomLabel title="Actions" helpText="Actions are the operations ISM performs when an index is in a certain state." />
 
       {!!actions.length && (
-        <EuiFormRow fullWidth isInvalid={false} error={null}>
+        <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
           <EuiDragDropContext onDragEnd={onDragEndActions}>
             <EuiDroppable droppableId="STATE_ACTIONS_DROPPABLE_AREA">
               {actions.map((action, idx) => (
@@ -41,7 +41,7 @@ const Actions = ({ actions, onClickDeleteAction, onClickEditAction, onDragEndAct
               ))}
             </EuiDroppable>
           </EuiDragDropContext>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       )}
 
       <EuiSpacer size="s" />

--- a/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
@@ -14,7 +14,7 @@ import {
   EuiFlexItem,
   EuiSmallButtonEmpty,
   EuiSmallButton,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiFieldText,
   EuiHorizontalRule,
   euiDragDropReorder,
@@ -202,7 +202,7 @@ export default class CreateState extends Component<CreateStateProps, CreateState
           <span /> {/* Dummy span to get rid of last child styling on h5 */}
         </EuiText>
 
-        <EuiFormRow fullWidth isInvalid={!!nameError} error={nameError}>
+        <EuiCompressedFormRow fullWidth isInvalid={!!nameError} error={nameError}>
           <EuiFieldText
             compressed={useNewUx}
             fullWidth
@@ -213,7 +213,7 @@ export default class CreateState extends Component<CreateStateProps, CreateState
             onChange={this.onChangeStateName}
             data-test-subj="create-state-state-name"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
 
         <EuiSpacer />
 
@@ -224,7 +224,7 @@ export default class CreateState extends Component<CreateStateProps, CreateState
 
         <EuiFlexGroup>
           <EuiFlexItem>
-            <EuiFormRow>
+            <EuiCompressedFormRow>
               <EuiSelect
                 compressed={useNewUx}
                 disabled={disableOrderSelections}
@@ -236,10 +236,10 @@ export default class CreateState extends Component<CreateStateProps, CreateState
                 onChange={(e) => this.setState({ order: e.target.value })}
                 aria-label="Retry failed policy from"
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiFormRow>
+            <EuiCompressedFormRow>
               <EuiSelect
                 compressed={useNewUx}
                 disabled={disableOrderSelections}
@@ -248,7 +248,7 @@ export default class CreateState extends Component<CreateStateProps, CreateState
                 onChange={(e) => this.setState({ afterBeforeState: e.target.value })}
                 aria-label="Retry failed policy from"
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiFlexItem>
         </EuiFlexGroup>
 

--- a/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
@@ -15,7 +15,7 @@ import {
   EuiSmallButtonEmpty,
   EuiSmallButton,
   EuiCompressedFormRow,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiHorizontalRule,
   euiDragDropReorder,
   DropResult,
@@ -203,8 +203,7 @@ export default class CreateState extends Component<CreateStateProps, CreateState
         </EuiText>
 
         <EuiCompressedFormRow fullWidth isInvalid={!!nameError} error={nameError}>
-          <EuiFieldText
-            compressed={useNewUx}
+          <EuiCompressedFieldText
             fullWidth
             isInvalid={!!nameError}
             placeholder="sample_hot_state"

--- a/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
@@ -12,7 +12,7 @@ import {
   EuiTitle,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiSmallButton,
   EuiFormRow,
   EuiFieldText,
@@ -284,9 +284,9 @@ export default class CreateState extends Component<CreateStateProps, CreateState
     return (
       <EuiFlexGroup justifyContent="spaceBetween">
         <EuiFlexItem grow={false}>
-          <EuiButtonEmpty size={useNewUx ? "s" : undefined} iconType="cross" onClick={onCloseFlyout} flush="left">
+          <EuiSmallButtonEmpty iconType="cross" onClick={onCloseFlyout} flush="left">
             Cancel
-          </EuiButtonEmpty>
+          </EuiSmallButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiSmallButton fill disabled={!name.trim().length || !!nameError} onClick={this.onClickSaveState}>

--- a/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
@@ -13,7 +13,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiButtonEmpty,
-  EuiButton,
+  EuiSmallButton,
   EuiFormRow,
   EuiFieldText,
   EuiHorizontalRule,
@@ -289,9 +289,9 @@ export default class CreateState extends Component<CreateStateProps, CreateState
           </EuiButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton size={useNewUx ? "s" : undefined} fill disabled={!name.trim().length || !!nameError} onClick={this.onClickSaveState}>
+          <EuiSmallButton fill disabled={!name.trim().length || !!nameError} onClick={this.onClickSaveState}>
             {isEditing ? "Update state" : "Save state"}
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     );

--- a/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
@@ -19,7 +19,7 @@ import {
   EuiHorizontalRule,
   euiDragDropReorder,
   DropResult,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiSpacer,
   EuiText,
   EuiPortal,
@@ -224,8 +224,7 @@ export default class CreateState extends Component<CreateStateProps, CreateState
         <EuiFlexGroup>
           <EuiFlexItem>
             <EuiCompressedFormRow>
-              <EuiSelect
-                compressed={useNewUx}
+              <EuiCompressedSelect
                 disabled={disableOrderSelections}
                 options={[
                   { value: "after", text: "Add after" },
@@ -239,8 +238,7 @@ export default class CreateState extends Component<CreateStateProps, CreateState
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiCompressedFormRow>
-              <EuiSelect
-                compressed={useNewUx}
+              <EuiCompressedSelect
                 disabled={disableOrderSelections}
                 options={stateOptions}
                 value={afterBeforeState}

--- a/public/pages/VisualCreatePolicy/containers/CreateState/Transitions.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/Transitions.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { EuiSmallButton, EuiFormRow, EuiDragDropContext, EuiDroppable, EuiSpacer, EuiText, DropResult } from "@elastic/eui";
+import { EuiSmallButton, EuiCompressedFormRow, EuiDragDropContext, EuiDroppable, EuiSpacer, EuiText, DropResult } from "@elastic/eui";
 import EuiFormCustomLabel from "../../components/EuiFormCustomLabel";
 import DraggableItem from "../../components/DraggableItem";
 import { UITransition } from "../../../../../models/interfaces";
@@ -34,7 +34,7 @@ const Transitions = ({
         helpText="Transitions define the conditions that need to be met for a state to change. After all actions in the current state are completed, the policy starts checking the conditions for transitions."
       />
       {!!transitions.length && (
-        <EuiFormRow fullWidth isInvalid={false} error={null}>
+        <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
           <EuiDragDropContext onDragEnd={onDragEndTransitions}>
             <EuiDroppable droppableId="STATE_TRANSITIONS_DROPPABLE_AREA">
               {transitions.map((transition, idx) => (
@@ -51,7 +51,7 @@ const Transitions = ({
               ))}
             </EuiDroppable>
           </EuiDragDropContext>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       )}
 
       <EuiSpacer size="s" />

--- a/public/pages/VisualCreatePolicy/containers/CreateState/Transitions.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/Transitions.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { EuiButton, EuiFormRow, EuiDragDropContext, EuiDroppable, EuiSpacer, EuiText, DropResult } from "@elastic/eui";
+import { EuiSmallButton, EuiFormRow, EuiDragDropContext, EuiDroppable, EuiSpacer, EuiText, DropResult } from "@elastic/eui";
 import EuiFormCustomLabel from "../../components/EuiFormCustomLabel";
 import DraggableItem from "../../components/DraggableItem";
 import { UITransition } from "../../../../../models/interfaces";
@@ -66,9 +66,7 @@ const Transitions = ({
 
       <EuiSpacer />
 
-      <EuiButton onClick={onClickAddTransition} size={useNewUx ? "s" : undefined}>
-        + Add Transition
-      </EuiButton>
+      <EuiSmallButton onClick={onClickAddTransition}>+ Add Transition</EuiSmallButton>
     </>
   );
 };

--- a/public/pages/VisualCreatePolicy/containers/CreateTransition/CreateTransition.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateTransition/CreateTransition.tsx
@@ -4,7 +4,17 @@
  */
 
 import React, { Component } from "react";
-import { EuiText, EuiLink, EuiIcon, EuiFlyoutBody, EuiFlyoutFooter, EuiTitle, EuiFormRow, EuiSpacer, EuiComboBox } from "@elastic/eui";
+import {
+  EuiText,
+  EuiLink,
+  EuiIcon,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiTitle,
+  EuiCompressedFormRow,
+  EuiSpacer,
+  EuiComboBox,
+} from "@elastic/eui";
 import { Transition as ITransition, UITransition } from "../../../../../models/interfaces";
 import FlyoutFooter from "../../components/FlyoutFooter";
 import EuiFormCustomLabel from "../../components/EuiFormCustomLabel";
@@ -103,7 +113,7 @@ export default class CreateTransition extends Component<CreateTransitionProps, C
             helpText="If entering a state that does not exist yet then you must create it before creating the policy."
           />
 
-          <EuiFormRow fullWidth isInvalid={false} error={null}>
+          <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
             <EuiComboBox
               compressed={useNewUx}
               fullWidth
@@ -116,7 +126,7 @@ export default class CreateTransition extends Component<CreateTransitionProps, C
               onCreateOption={this.onCreateOption}
               customOptionText="Add {searchValue} state"
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
 
           <EuiSpacer />
 

--- a/public/pages/VisualCreatePolicy/containers/CreateTransition/CreateTransition.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateTransition/CreateTransition.tsx
@@ -13,7 +13,7 @@ import {
   EuiTitle,
   EuiCompressedFormRow,
   EuiSpacer,
-  EuiComboBox,
+  EuiCompressedComboBox,
 } from "@elastic/eui";
 import { Transition as ITransition, UITransition } from "../../../../../models/interfaces";
 import FlyoutFooter from "../../components/FlyoutFooter";
@@ -114,8 +114,7 @@ export default class CreateTransition extends Component<CreateTransitionProps, C
           />
 
           <EuiCompressedFormRow fullWidth isInvalid={false} error={null}>
-            <EuiComboBox
-              compressed={useNewUx}
+            <EuiCompressedComboBox
               fullWidth
               isClearable={false}
               placeholder="Select a single option"

--- a/public/pages/VisualCreatePolicy/containers/CreateTransition/__snapshots__/CreateTransition.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateTransition/__snapshots__/CreateTransition.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`<CreateTransition /> spec renders the component 1`] = `
         </p>
       </div>
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -70,17 +70,17 @@ exports[`<CreateTransition /> spec renders the component 1`] = `
           <div
             aria-expanded="false"
             aria-haspopup="listbox"
-            class="euiComboBox euiComboBox--fullWidth"
+            class="euiComboBox euiComboBox--compressed euiComboBox--fullWidth"
             role="combobox"
           >
             <div
-              class="euiFormControlLayout euiFormControlLayout--fullWidth"
+              class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <div
-                  class="euiComboBox__inputWrap euiComboBox__inputWrap--fullWidth euiComboBox__inputWrap--noWrap"
+                  class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--fullWidth euiComboBox__inputWrap--noWrap"
                   data-test-subj="comboBoxInput"
                   tabindex="-1"
                 >
@@ -147,20 +147,20 @@ exports[`<CreateTransition /> spec renders the component 1`] = `
         </p>
       </div>
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
           class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormControlLayout euiFormControlLayout--fullWidth"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <select
-                class="euiSelect euiSelect--fullWidth"
+                class="euiSelect euiSelect--fullWidth euiSelect--compressed"
                 data-test-subj="create-state-action-type"
                 id="some_html_id"
                 style="text-transform: capitalize;"
@@ -233,20 +233,20 @@ exports[`<CreateTransition /> spec renders the component 1`] = `
         </p>
       </div>
       <div
-        class="euiFormRow euiFormRow--fullWidth"
+        class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
           class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormControlLayout euiFormControlLayout--fullWidth"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <input
-                class="euiFieldText euiFieldText--fullWidth"
+                class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
                 data-test-subj="transition-render-conditions-min-index-age"
                 id="some_html_id"
                 type="text"

--- a/public/pages/VisualCreatePolicy/containers/ErrorNotification/__snapshots__/ErrorNotification.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/ErrorNotification/__snapshots__/ErrorNotification.test.tsx.snap
@@ -104,20 +104,20 @@ exports[`<ErrorNotification /> spec renders the component 1`] = `
           class="euiFlexItem"
         >
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             id="some_html_id-row"
           >
             <div
               class="euiFormRow__fieldWrapper"
             >
               <div
-                class="euiFormControlLayout"
+                class="euiFormControlLayout euiFormControlLayout--compressed"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <select
-                    class="euiSelect euiSelect-isLoading"
+                    class="euiSelect euiSelect--compressed euiSelect-isLoading"
                     data-test-subj="create-policy-notification-channel-id"
                     id="some_html_id"
                     placeholder="Select channel ID"
@@ -152,7 +152,7 @@ exports[`<ErrorNotification /> spec renders the component 1`] = `
           class="euiFlexItem euiFlexItem--flexGrowZero"
         >
           <button
-            class="euiButton euiButton--primary euiButton-isDisabled refresh-button"
+            class="euiButton euiButton--primary euiButton--small euiButton-isDisabled refresh-button"
             data-test-subj="channel-notification-refresh"
             disabled=""
             type="button"
@@ -171,7 +171,7 @@ exports[`<ErrorNotification /> spec renders the component 1`] = `
           class="euiFlexItem euiFlexItem--flexGrowZero"
         >
           <a
-            class="euiButton euiButton--primary"
+            class="euiButton euiButton--primary euiButton--small"
             href="notifications-dashboards#/channels"
             rel="noopener noreferrer"
             target="_blank"
@@ -213,7 +213,7 @@ exports[`<ErrorNotification /> spec renders the component 1`] = `
         </p>
       </div>
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div

--- a/public/pages/VisualCreatePolicy/containers/VisualCreatePolicy/VisualCreatePolicy.tsx
+++ b/public/pages/VisualCreatePolicy/containers/VisualCreatePolicy/VisualCreatePolicy.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, Component, useContext } from "react";
-import { EuiText, EuiSpacer, EuiTitle, EuiFlexGroup, EuiFlexItem, EuiButton, EuiLink, EuiIcon } from "@elastic/eui";
+import { EuiText, EuiSpacer, EuiTitle, EuiFlexGroup, EuiFlexItem, EuiSmallButton, EuiLink, EuiIcon } from "@elastic/eui";
 import { RouteComponentProps } from "react-router-dom";
 import queryString from "query-string";
 import { EMPTY_DEFAULT_POLICY } from "../../utils/constants";
@@ -372,14 +372,12 @@ export class VisualCreatePolicy extends Component<VisualCreatePolicyProps, Visua
 
         <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
           <EuiFlexItem grow={false}>
-            <EuiButton onClick={this.onCancel} size={useNewUX ? "s" : undefined}>
-              Cancel
-            </EuiButton>
+            <EuiSmallButton onClick={this.onCancel}>Cancel</EuiSmallButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton fill onClick={this.onSubmit} size={useNewUX ? "s" : undefined}>
+            <EuiSmallButton fill onClick={this.onSubmit}>
               {isEdit ? "Update" : "Create"}
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </div>

--- a/public/temporary/EuiRefreshPicker.tsx
+++ b/public/temporary/EuiRefreshPicker.tsx
@@ -7,7 +7,7 @@
 // Used under the Apache-2.0 license.
 
 import React, { Component } from "react";
-import { EuiSuperDatePicker } from "@elastic/eui";
+import { EuiCompressedSuperDatePicker } from "@elastic/eui";
 import AsyncInterval from "./AsyncInterval";
 
 interface EuiRefreshPickerProps {
@@ -63,7 +63,7 @@ export default class EuiRefreshPicker extends Component<EuiRefreshPickerProps> {
 
   render() {
     return (
-      <EuiSuperDatePicker
+      <EuiCompressedSuperDatePicker
         isAutoRefreshOnly
         isPaused={this.props.isPaused}
         refreshInterval={this.props.refreshInterval}


### PR DESCRIPTION
### Description
Replace instances of `EuiButton` that don't have an explicit sizing attribute to `EuiSmallButton*`.
Replace instances of `Eui<form elements>` that don't have density attributes to `EuiCompressed<form elements>`.

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
