### PR TITLE
update newHeader for component template pages

### DIFF
--- a/public/components/FilterGroup/index.tsx
+++ b/public/components/FilterGroup/index.tsx
@@ -5,10 +5,11 @@ export interface IFilterGroupProps {
   options: { label: string }[];
   value?: string[];
   filterButtonProps?: EuiFilterButtonProps;
+  useNewUx?: boolean;
   onChange?: (val: IFilterGroupProps["value"]) => void;
 }
 
-export default function FilterGroup({ options, value, filterButtonProps, onChange }: IFilterGroupProps) {
+export default function FilterGroup({ options, value, filterButtonProps, useNewUx, onChange }: IFilterGroupProps) {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
   const onButtonClick = () => {
@@ -30,6 +31,7 @@ export default function FilterGroup({ options, value, filterButtonProps, onChang
             numFilters={options?.length}
             hasActiveFilters={!!value?.length}
             numActiveFilters={value?.length}
+            size={useNewUx ? "s" : undefined}
             {...filterButtonProps}
           />
         }

--- a/public/components/IndexMapping/IndexMapping.tsx
+++ b/public/components/IndexMapping/IndexMapping.tsx
@@ -20,7 +20,7 @@ export * from "./helper";
 export * from "./interfaces";
 
 const IndexMapping = (
-  { value: propsValue, onChange: propsOnChange, isEdit, oldValue, readonly, docVersion }: IndexMappingProps,
+  { value: propsValue, onChange: propsOnChange, isEdit, oldValue, readonly, docVersion, useNewUx }: IndexMappingProps,
   ref: Ref<IIndexMappingsRef>
 ) => {
   const value = propsValue?.properties || [];
@@ -194,10 +194,16 @@ const IndexMapping = (
           {readonly ? null : (
             <>
               <EuiSpacer />
-              <EuiButton style={{ marginRight: 8 }} data-test-subj="createIndexAddFieldButton" onClick={() => addField("")}>
+              <EuiButton
+                size={useNewUx ? "s" : undefined}
+                style={{ marginRight: 8 }}
+                data-test-subj="createIndexAddFieldButton"
+                onClick={() => addField("")}
+              >
                 Add new field
               </EuiButton>
               <EuiButton
+                size={useNewUx ? "s" : undefined}
                 data-test-subj="createIndexAddObjectFieldButton"
                 onClick={() =>
                   addField("", {

--- a/public/components/IndexMapping/interfaces.ts
+++ b/public/components/IndexMapping/interfaces.ts
@@ -23,6 +23,7 @@ export interface IndexMappingProps {
   oldMappingsEditable?: boolean; // in template edit case, existing mappings is editable
   readonly?: boolean;
   docVersion: string;
+  useNewUx?: boolean;
 }
 
 export enum EDITOR_MODE {

--- a/public/pages/ComposableTemplates/components/IndexControls/IndexControls.tsx
+++ b/public/pages/ComposableTemplates/components/IndexControls/IndexControls.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useEffect, useState } from "react";
-import { EuiFieldSearch, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import { EuiButton, EuiFieldSearch, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import FilterGroup from "../../../../components/FilterGroup";
 import { IndicesUpdateMode } from "../../../../utils/constants";
 
@@ -13,6 +13,7 @@ export interface SearchControlsProps {
     search: string;
     selectedTypes: string[];
   };
+  useNewUX?: boolean;
   onSearchChange: (args: SearchControlsProps["value"]) => void;
 }
 
@@ -32,7 +33,13 @@ export default function SearchControls(props: SearchControlsProps) {
   return (
     <EuiFlexGroup style={{ padding: "0px 5px" }} alignItems="center">
       <EuiFlexItem>
-        <EuiFieldSearch fullWidth placeholder="Search..." value={state.search} onChange={(e) => onChange("search", e.target.value)} />
+        <EuiFieldSearch
+          compressed={props.useNewUX}
+          fullWidth
+          placeholder="Search..."
+          value={state.search}
+          onChange={(e) => onChange("search", e.target.value)}
+        />
       </EuiFlexItem>
       <EuiFlexItem style={{ flexBasis: "100px" }} grow={false}>
         <FilterGroup
@@ -41,6 +48,7 @@ export default function SearchControls(props: SearchControlsProps) {
           }}
           onChange={(val) => onChange("selectedTypes", val || [])}
           value={state.selectedTypes}
+          useNewUx={props.useNewUX}
           options={[
             {
               label: IndicesUpdateMode.alias,

--- a/public/pages/ComposableTemplates/containers/ComposableTemplates/ComposableTemplates.test.tsx
+++ b/public/pages/ComposableTemplates/containers/ComposableTemplates/ComposableTemplates.test.tsx
@@ -15,6 +15,23 @@ import { ROUTES } from "../../../../utils/constants";
 import { CoreServicesContext } from "../../../../components/core_services";
 import userEvent from "@testing-library/user-event";
 import { ICatComposableTemplate } from "../../interface";
+import { getApplication, getNavigationUI, getUISettings } from "../../../../services/Services";
+
+jest.mock("../../../../services/Services", () => ({
+  ...jest.requireActual("../../../../services/Services"),
+  getUISettings: jest.fn(),
+  getApplication: jest.fn(),
+  getNavigationUI: jest.fn(),
+}));
+
+beforeEach(() => {
+  (getUISettings as jest.Mock).mockReturnValue({
+    get: jest.fn().mockReturnValue(false), // or false, depending on your test case
+  });
+  (getApplication as jest.Mock).mockReturnValue({});
+
+  (getNavigationUI as jest.Mock).mockReturnValue({});
+});
 
 function renderWithRouter() {
   return {

--- a/public/pages/ComposableTemplates/containers/ComposableTemplates/ComposableTemplates.tsx
+++ b/public/pages/ComposableTemplates/containers/ComposableTemplates/ComposableTemplates.tsx
@@ -473,6 +473,7 @@ class ComposableTemplates extends MDSEnabledComponent<ComposableTemplatesProps, 
                         this.props.history.push(ROUTES.CREATE_COMPOSABLE_TEMPLATE);
                       }}
                       data-test-subj="CreateComponentTemplateWhenNoTemplateFound"
+                      size={useNewUX ? "s" : undefined}
                     >
                       Create component template
                     </EuiButton>,

--- a/public/pages/CreateComposableTemplate/containers/CreateComposableTemplate/CreateComposableTemplate.test.tsx
+++ b/public/pages/CreateComposableTemplate/containers/CreateComposableTemplate/CreateComposableTemplate.test.tsx
@@ -12,6 +12,23 @@ import { ServicesContext } from "../../../../services";
 import { browserServicesMock, coreServicesMock, apiCallerMock } from "../../../../../test/mocks";
 import { ROUTES } from "../../../../utils/constants";
 import { CoreServicesContext } from "../../../../components/core_services";
+import { getApplication, getNavigationUI, getUISettings } from "../../../../services/Services";
+
+jest.mock("../../../../services/Services", () => ({
+  ...jest.requireActual("../../../../services/Services"),
+  getUISettings: jest.fn(),
+  getApplication: jest.fn(),
+  getNavigationUI: jest.fn(),
+}));
+
+beforeEach(() => {
+  (getUISettings as jest.Mock).mockReturnValue({
+    get: jest.fn().mockReturnValue(false), // or false, depending on your test case
+  });
+  (getApplication as jest.Mock).mockReturnValue({});
+
+  (getNavigationUI as jest.Mock).mockReturnValue({});
+});
 
 function renderCreateComposableTemplateWithRouter(initialEntries = [ROUTES.CREATE_COMPOSABLE_TEMPLATE] as string[]) {
   return {

--- a/public/pages/CreateComposableTemplate/containers/CreateComposableTemplate/CreateComposableTemplate.tsx
+++ b/public/pages/CreateComposableTemplate/containers/CreateComposableTemplate/CreateComposableTemplate.tsx
@@ -11,6 +11,7 @@ import { CoreServicesContext } from "../../../../components/core_services";
 import { isEqual } from "lodash";
 import { DataSourceMenuContext, DataSourceMenuProperties } from "../../../../services/DataSourceMenuContext";
 import { useUpdateUrlWithDataSourceProperties } from "../../../../components/MDSEnabledComponent";
+import { getUISettings } from "../../../../services/Services";
 
 interface CreateComposableTemplateProps extends RouteComponentProps<{ template?: string; mode?: string }>, DataSourceMenuProperties {}
 
@@ -23,6 +24,12 @@ class CreateComposableTemplate extends Component<CreateComposableTemplateProps> 
 
   get readonly() {
     return this.props.match.params.mode === "readonly";
+  }
+
+  get useNewUX(): boolean {
+    const uiSettings = getUISettings();
+    const useNewUx = uiSettings.get("home:useNewHomePage");
+    return useNewUx;
   }
 
   setBreadCrumb() {
@@ -42,7 +49,9 @@ class CreateComposableTemplate extends Component<CreateComposableTemplateProps> 
     } else {
       lastBread = BREADCRUMBS.CREATE_COMPOSABLE_TEMPLATE;
     }
-    this.context.chrome.setBreadcrumbs([BREADCRUMBS.INDEX_MANAGEMENT, BREADCRUMBS.COMPOSABLE_TEMPLATES, lastBread]);
+    this.useNewUX
+      ? this.context.chrome.setBreadcrumbs([BREADCRUMBS.COMPOSABLE_TEMPLATES, lastBread])
+      : this.context.chrome.setBreadcrumbs([BREADCRUMBS.INDEX_MANAGEMENT, BREADCRUMBS.COMPOSABLE_TEMPLATES, lastBread]);
   }
 
   componentDidUpdate(prevProps: Readonly<CreateComposableTemplateProps>): void {
@@ -60,8 +69,9 @@ class CreateComposableTemplate extends Component<CreateComposableTemplateProps> 
   };
 
   render() {
+    const paddingStyle = this.useNewUX ? { padding: "0px 0px" } : { padding: "0px 50px" };
     return (
-      <div style={{ padding: "0px 50px" }}>
+      <div style={paddingStyle}>
         <TemplateDetail
           history={this.props.history}
           readonly={this.readonly}
@@ -69,6 +79,7 @@ class CreateComposableTemplate extends Component<CreateComposableTemplateProps> 
           onCancel={this.onCancel}
           onSubmitSuccess={() => this.props.history.push(ROUTES.COMPOSABLE_TEMPLATES)}
           dataSourceId={this.props.dataSourceId}
+          useNewUX={this.useNewUX}
         />
       </div>
     );

--- a/public/pages/CreateComposableTemplate/containers/TemplateDetail/TemplateDetail.test.tsx
+++ b/public/pages/CreateComposableTemplate/containers/TemplateDetail/TemplateDetail.test.tsx
@@ -12,6 +12,23 @@ import { CoreServicesContext } from "../../../../components/core_services";
 import { HashRouter, Route } from "react-router-dom";
 import { ROUTES } from "../../../../utils/constants";
 import userEvent from "@testing-library/user-event";
+import { getApplication, getNavigationUI, getUISettings } from "../../../../services/Services";
+
+jest.mock("../../../../services/Services", () => ({
+  ...jest.requireActual("../../../../services/Services"),
+  getUISettings: jest.fn(),
+  getApplication: jest.fn(),
+  getNavigationUI: jest.fn(),
+}));
+
+beforeEach(() => {
+  (getUISettings as jest.Mock).mockReturnValue({
+    get: jest.fn().mockReturnValue(false), // or false, depending on your test case
+  });
+  (getApplication as jest.Mock).mockReturnValue({});
+
+  (getNavigationUI as jest.Mock).mockReturnValue({});
+});
 
 function renderCreateComposableTemplate(props: Omit<TemplateDetailProps, "history">) {
   return {

--- a/public/pages/CreateComposableTemplate/containers/TemplateDetail/TemplateDetail.tsx
+++ b/public/pages/CreateComposableTemplate/containers/TemplateDetail/TemplateDetail.tsx
@@ -131,6 +131,7 @@ const TemplateDetail = (props: TemplateDetailProps, ref: Ref<IComponentTemplateD
     isEdit,
     field,
     noPanel,
+    useNewUX,
   };
 
   const diffedNumber = isEdit
@@ -296,19 +297,25 @@ const TemplateDetail = (props: TemplateDetailProps, ref: Ref<IComponentTemplateD
       <EuiSpacer />
       <IndexSettings {...subCompontentProps} />
       <EuiSpacer />
-      <TemplateMappings {...subCompontentProps} />
+      <TemplateMappings useNewUx={useNewUX} {...subCompontentProps} />
       <EuiSpacer />
       {isEdit || hideButton ? null : (
         <>
           <EuiSpacer />
           <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty onClick={onCancel} data-test-subj="CreateComposableTemplateCancelButton">
+              <EuiButtonEmpty onClick={onCancel} data-test-subj="CreateComposableTemplateCancelButton" size={useNewUX ? "s" : undefined}>
                 Cancel
               </EuiButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton fill onClick={onClickSubmit} isLoading={isSubmitting} data-test-subj="CreateComposableTemplateCreateButton">
+              <EuiButton
+                fill
+                onClick={onClickSubmit}
+                isLoading={isSubmitting}
+                data-test-subj="CreateComposableTemplateCreateButton"
+                size={useNewUX ? "s" : undefined}
+              >
                 Create component template
               </EuiButton>
             </EuiFlexItem>

--- a/public/pages/CreateComposableTemplate/containers/TemplateDetail/TemplateDetail.tsx
+++ b/public/pages/CreateComposableTemplate/containers/TemplateDetail/TemplateDetail.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { forwardRef, useContext, useEffect, useImperativeHandle, useRef, Ref, useState } from "react";
-import { EuiButton, EuiButtonEmpty, EuiCodeBlock, EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer, EuiTitle } from "@elastic/eui";
+import { EuiButton, EuiButtonEmpty, EuiCodeBlock, EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer, EuiText, EuiTitle } from "@elastic/eui";
 import { RouteComponentProps } from "react-router-dom";
 import { IComposableTemplate, IComposableTemplateRemote } from "../../../../../models/interfaces";
 import useField from "../../../../lib/field";
@@ -27,6 +27,9 @@ import { ComponentTemplateEdit } from "../../interface";
 import { formatTemplate } from "../../hooks";
 import UnsavedChangesBottomBar from "../../../../components/UnsavedChangesBottomBar";
 import { useCallback } from "react";
+import { getApplication, getNavigationUI, getUISettings } from "../../../../services/Services";
+import { TopNavControlButtonData, TopNavControlIconData } from "src/plugins/navigation/public";
+import DeleteIndexModal from "../../../ComposableTemplates/containers/DeleteComposableTemplatesModal";
 
 export interface TemplateDetailProps {
   templateName?: string;
@@ -40,6 +43,7 @@ export interface TemplateDetailProps {
   hideButton?: boolean;
   noPanel?: boolean;
   dataSourceId: string;
+  useNewUX?: boolean;
 }
 
 export interface IComponentTemplateDetailInstance {
@@ -47,11 +51,12 @@ export interface IComponentTemplateDetailInstance {
 }
 
 const TemplateDetail = (props: TemplateDetailProps, ref: Ref<IComponentTemplateDetailInstance>) => {
-  const { templateName, onCancel, onSubmitSuccess, hideTitle, hideButton, noPanel } = props;
+  const { templateName, onCancel, onSubmitSuccess, hideTitle, hideButton, noPanel, useNewUX } = props;
   const isEdit = !!templateName;
   const services = useContext(ServicesContext) as BrowserServices;
   const coreServices = useContext(CoreServicesContext) as CoreStart;
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [deleteIndexModalVisible, setDeleteIndexModalVisible] = useState(false);
   const oldValue = useRef<IComposableTemplate | undefined>(undefined);
   const field = useField({
     values: {
@@ -141,14 +146,90 @@ const TemplateDetail = (props: TemplateDetailProps, ref: Ref<IComponentTemplateD
       )
     : 0;
 
+  const onClickViewJson = () => {
+    const showValue: ComponentTemplateEdit = JSON.parse(
+      JSON.stringify({
+        ...values,
+        template: IndexForm.transformIndexDetailToRemote(values.template),
+      } as IComposableTemplateRemote)
+    );
+    const { includes, ...others } = showValue;
+    Modal.show({
+      locale: {
+        ok: "Close",
+      },
+      style: {
+        width: 800,
+      },
+      "data-test-subj": "templateJSONDetailModal",
+      title: values.name,
+      content: (
+        <EuiCodeBlock language="json" isCopyable>
+          {JSON.stringify(others, null, 2)}
+        </EuiCodeBlock>
+      ),
+    });
+  };
+
+  const onDelete = () => {
+    props.history.replace(ROUTES.COMPOSABLE_TEMPLATES);
+  };
+
+  const onDeleteIndexModalClose = () => {
+    setDeleteIndexModalVisible(false);
+  };
+
+  const onDeleteIndexModalOpen = () => {
+    setDeleteIndexModalVisible(true);
+  };
+
+  const deleteModal = () => {
+    return (
+      deleteIndexModalVisible && (
+        <DeleteIndexModal
+          selectedItems={[templateName || ""]}
+          visible={deleteIndexModalVisible}
+          onClose={onDeleteIndexModalClose}
+          onDelete={() => {
+            onDeleteIndexModalClose();
+            onDelete();
+          }}
+        />
+      )
+    );
+  };
+
+  const { HeaderControl } = getNavigationUI();
+  const { setAppRightControls, setAppDescriptionControls } = getApplication();
+
+  const descriptionData = [
+    {
+      renderComponent: (
+        <EuiText size="s" color="subdued">
+          Component templates are reusable building blocks for composing index or data stream templates.
+          <br /> You can define component templates with common index configurations and associate them to an index template.{" "}
+          <EuiLink external target="_blank" href={coreServices.docLinks.links.opensearch.indexTemplates.composable}>
+            Learn more
+          </EuiLink>
+        </EuiText>
+      ),
+    },
+  ];
+
   return (
     <>
       {hideTitle ? null : (
         <>
           <EuiFlexGroup alignItems="center">
             <EuiFlexItem>
-              <EuiTitle size="l">{isEdit ? <h1 title={templateName}>{templateName}</h1> : <h1>Create component template</h1>}</EuiTitle>
-              {isEdit ? null : (
+              {useNewUX ? (
+                <></>
+              ) : (
+                <EuiTitle size="l">{isEdit ? <h1 title={templateName}>{templateName}</h1> : <h1>Create component template</h1>}</EuiTitle>
+              )}
+              {isEdit ? null : useNewUX ? (
+                <HeaderControl setMountPoint={setAppDescriptionControls} controls={descriptionData} />
+              ) : (
                 <CustomFormRow
                   fullWidth
                   label=""
@@ -167,45 +248,45 @@ const TemplateDetail = (props: TemplateDetailProps, ref: Ref<IComponentTemplateD
               )}
             </EuiFlexItem>
             {isEdit ? (
-              <EuiFlexItem grow={false} style={{ flexDirection: "row" }}>
-                <EuiButton
-                  style={{ marginRight: 20 }}
-                  onClick={() => {
-                    const showValue: ComponentTemplateEdit = JSON.parse(
-                      JSON.stringify({
-                        ...values,
-                        template: IndexForm.transformIndexDetailToRemote(values.template),
-                      } as IComposableTemplateRemote)
-                    );
-                    const { includes, ...others } = showValue;
-                    Modal.show({
-                      locale: {
-                        ok: "Close",
-                      },
-                      style: {
-                        width: 800,
-                      },
-                      "data-test-subj": "templateJSONDetailModal",
-                      title: values.name,
-                      content: (
-                        <EuiCodeBlock language="json" isCopyable>
-                          {JSON.stringify(others, null, 2)}
-                        </EuiCodeBlock>
-                      ),
-                    });
-                  }}
-                >
-                  View JSON
-                </EuiButton>
-                <ComposableTemplatesActions
-                  selectedItems={[templateName || ""]}
-                  history={props.history}
-                  onDelete={() => props.history.replace(ROUTES.COMPOSABLE_TEMPLATES)}
-                />
-              </EuiFlexItem>
+              <>
+                {useNewUX ? (
+                  <>
+                    <HeaderControl
+                      setMountPoint={setAppRightControls}
+                      controls={[
+                        {
+                          iconType: "trash",
+                          testId: "deleteButton",
+                          color: "danger",
+                          ariaLabel: "delete",
+                          run: onDeleteIndexModalOpen,
+                          controlType: "icon",
+                          display: "base",
+                        } as TopNavControlIconData,
+                        {
+                          id: "View JSON",
+                          label: "View JSON",
+                          testId: "viewJSONButton",
+                          run: onClickViewJson,
+                          fill: false,
+                          controlType: "button",
+                        } as TopNavControlButtonData,
+                      ]}
+                    />
+                    {deleteModal()}
+                  </>
+                ) : (
+                  <EuiFlexItem grow={false} style={{ flexDirection: "row" }}>
+                    <EuiButton style={{ marginRight: 20 }} onClick={onClickViewJson}>
+                      View JSON
+                    </EuiButton>
+                    <ComposableTemplatesActions selectedItems={[templateName || ""]} history={props.history} onDelete={onDelete} />
+                  </EuiFlexItem>
+                )}
+              </>
             ) : null}
           </EuiFlexGroup>
-          <EuiSpacer />
+          {useNewUX ? <></> : <EuiSpacer />}
         </>
       )}
       <DefineTemplate {...subCompontentProps} />

--- a/public/pages/CreateComposableTemplate/containers/TemplateMappings/TemplateMappings.tsx
+++ b/public/pages/CreateComposableTemplate/containers/TemplateMappings/TemplateMappings.tsx
@@ -9,7 +9,7 @@ import { AllBuiltInComponents } from "../../../../components/FormGenerator";
 import { IndicesUpdateMode } from "../../../../utils/constants";
 
 export default function TemplateMappings(props: SubDetailProps) {
-  const { field, noPanel } = props;
+  const { field, noPanel, useNewUx } = props;
   const values = field.getValues();
   const mappingsRef = useRef<IIndexMappingsRef>(null);
   const coreServices = useContext(CoreServicesContext) as CoreStart;
@@ -76,6 +76,7 @@ export default function TemplateMappings(props: SubDetailProps) {
                   },
                 ],
               })}
+              useNewUx={useNewUx}
               isEdit
               ref={mappingsRef}
               oldMappingsEditable

--- a/public/pages/CreateComposableTemplate/interface.ts
+++ b/public/pages/CreateComposableTemplate/interface.ts
@@ -15,6 +15,7 @@ export interface SubDetailProps extends TemplateDetailProps {
   field: FieldInstance;
   isEdit: boolean;
   noPanel?: boolean;
+  useNewUx?: boolean;
 }
 
 export interface ComponentTemplateEdit extends IComposableTemplate {

--- a/public/pages/CreateIndexTemplate/containers/TemplateDetail/TemplateDetail.test.tsx
+++ b/public/pages/CreateIndexTemplate/containers/TemplateDetail/TemplateDetail.test.tsx
@@ -14,6 +14,23 @@ import { browserServicesMock, coreServicesMock } from "../../../../../test/mocks
 import { CoreServicesContext } from "../../../../components/core_services";
 import { ROUTES } from "../../../../utils/constants";
 import { FieldInstance } from "../../../../lib/field";
+import { getApplication, getNavigationUI, getUISettings } from "../../../../services/Services";
+
+jest.mock("../../../../services/Services", () => ({
+  ...jest.requireActual("../../../../services/Services"),
+  getUISettings: jest.fn(),
+  getApplication: jest.fn(),
+  getNavigationUI: jest.fn(),
+}));
+
+beforeEach(() => {
+  (getUISettings as jest.Mock).mockReturnValue({
+    get: jest.fn().mockReturnValue(false), // or false, depending on your test case
+  });
+  (getApplication as jest.Mock).mockReturnValue({});
+
+  (getNavigationUI as jest.Mock).mockReturnValue({});
+});
 
 function renderCreateIndexTemplate(props: Omit<TemplateDetailProps, "history" | "location">) {
   return renderHook(() => {

--- a/public/pages/CreateIndexTemplate/containers/TemplateDetail/TemplateDetail.test.tsx
+++ b/public/pages/CreateIndexTemplate/containers/TemplateDetail/TemplateDetail.test.tsx
@@ -14,23 +14,6 @@ import { browserServicesMock, coreServicesMock } from "../../../../../test/mocks
 import { CoreServicesContext } from "../../../../components/core_services";
 import { ROUTES } from "../../../../utils/constants";
 import { FieldInstance } from "../../../../lib/field";
-import { getApplication, getNavigationUI, getUISettings } from "../../../../services/Services";
-
-jest.mock("../../../../services/Services", () => ({
-  ...jest.requireActual("../../../../services/Services"),
-  getUISettings: jest.fn(),
-  getApplication: jest.fn(),
-  getNavigationUI: jest.fn(),
-}));
-
-beforeEach(() => {
-  (getUISettings as jest.Mock).mockReturnValue({
-    get: jest.fn().mockReturnValue(false), // or false, depending on your test case
-  });
-  (getApplication as jest.Mock).mockReturnValue({});
-
-  (getNavigationUI as jest.Mock).mockReturnValue({});
-});
 
 function renderCreateIndexTemplate(props: Omit<TemplateDetailProps, "history" | "location">) {
   return renderHook(() => {

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -247,7 +247,7 @@ export class IndexManagementPlugin implements Plugin<IndexManagementPluginSetup,
         description: ISM_FEATURE_DESCRIPTION.component_templates,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
-          return mountWrapper(params, ROUTES.TEMPLATES);
+          return mountWrapper(params, ROUTES.COMPOSABLE_TEMPLATES);
         },
       });
 


### PR DESCRIPTION
### Description
This PR updates the new header for component template pages

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

### component template pages (when `useNewHomePage` is disabled) : 
List view : 
![image](https://github.com/user-attachments/assets/db2116b4-166e-4734-a625-ea8a31e813a3)

Create view : 
![image](https://github.com/user-attachments/assets/df8a4c8a-4efb-4ce5-a6a9-15e62c913495)

Detail view : 
![image](https://github.com/user-attachments/assets/96683f43-1f04-40b6-9bff-53d9089552a1)

### component template pages (when `useNewHomePage` is enabled) : 
List view : 
![image](https://github.com/user-attachments/assets/9d9f4f8a-d8af-4ab3-876d-fe722440ecd4)

Create view : 
![image](https://github.com/user-attachments/assets/26c09222-a024-4ad6-bf48-7badae4f7f86)

Detail view : 
![image](https://github.com/user-attachments/assets/436fddb1-1833-4cc1-b3e2-7832ae8e80d6)
