### PR TITLE
Incorporate feel and look good guide changes for snapshots pages, datastreams, rollups and notification settings

### DIFF
--- a/public/components/ContentPanel/ContentPanel.tsx
+++ b/public/components/ContentPanel/ContentPanel.tsx
@@ -72,10 +72,10 @@ const ContentPanel: React.SFC<ContentPanelProps> = ({
         <EuiFlexItem>
           {typeof title === "string" ? (
             <EuiTitle size={titleSize}>
-              <h3>
+              <h1>
                 {title}
                 <span className="panel-header-count"> {itemCount > 0 ? `(${itemCount})` : null} </span>
-              </h3>
+              </h1>
             </EuiTitle>
           ) : (
             title

--- a/public/components/ContentPanel/__snapshots__/ContentPanel.test.tsx.snap
+++ b/public/components/ContentPanel/__snapshots__/ContentPanel.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<ContentPanel /> spec renders the component 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h3
+      <h1
         class="euiTitle euiTitle--large"
       >
         Testing
@@ -22,7 +22,7 @@ exports[`<ContentPanel /> spec renders the component 1`] = `
            
            
         </span>
-      </h3>
+      </h1>
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/public/components/DeleteModal/DeleteModal.tsx
+++ b/public/components/DeleteModal/DeleteModal.tsx
@@ -54,7 +54,7 @@ export default function DeleteTemplateModal(props: DeleteModalProps) {
             ))}
           </ul>
           <EuiSpacer />
-          <EuiText color="subdued">
+          <EuiText color="subdued" size="s">
             To confirm your action, type <b style={{ color: "#000" }}>delete</b>.
           </EuiText>
           <EuiFieldText

--- a/public/components/DeleteModal/__snapshots__/DeleteModal.test.tsx.snap
+++ b/public/components/DeleteModal/__snapshots__/DeleteModal.test.tsx.snap
@@ -65,7 +65,7 @@ HTMLCollection [
                   class="euiSpacer euiSpacer--l"
                 />
                 <div
-                  class="euiText euiText--medium"
+                  class="euiText euiText--small"
                 >
                   <div
                     class="euiTextColor euiTextColor--subdued"

--- a/public/components/IndexDetail/__snapshots__/IndexDetail.test.tsx.snap
+++ b/public/components/IndexDetail/__snapshots__/IndexDetail.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<IndexDetail /> spec renders the component 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h3
+      <h1
         class="euiTitle euiTitle--small"
       >
         Define index
@@ -22,7 +22,7 @@ exports[`<IndexDetail /> spec renders the component 1`] = `
            
            
         </span>
-      </h3>
+      </h1>
     </div>
   </div>
   <hr

--- a/public/containers/IndexDetail/__snapshots__/IndexDetail.test.tsx.snap
+++ b/public/containers/IndexDetail/__snapshots__/IndexDetail.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`<IndexDetail /> spec render the component 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--small"
         >
           Source index details
@@ -23,7 +23,7 @@ exports[`<IndexDetail /> spec render the component 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr

--- a/public/containers/IndexForm/__snapshots__/IndexForm.test.tsx.snap
+++ b/public/containers/IndexForm/__snapshots__/IndexForm.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`<IndexForm /> spec render page 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--small"
         >
           Define index
@@ -23,7 +23,7 @@ exports[`<IndexForm /> spec render page 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr
@@ -195,7 +195,7 @@ exports[`<IndexForm /> spec render page 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--small"
         >
           Index settings
@@ -205,7 +205,7 @@ exports[`<IndexForm /> spec render page 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr

--- a/public/pages/ChangePolicy/components/ChangeManagedIndices/__snapshots__/ChangeManagedIndices.test.tsx.snap
+++ b/public/pages/ChangePolicy/components/ChangeManagedIndices/__snapshots__/ChangeManagedIndices.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<ChangeManagedIndices /> spec renders the component 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h3
+      <h1
         class="euiTitle euiTitle--small"
       >
         Choose managed indices
@@ -22,7 +22,7 @@ exports[`<ChangeManagedIndices /> spec renders the component 1`] = `
            
            
         </span>
-      </h3>
+      </h1>
     </div>
   </div>
   <hr

--- a/public/pages/ChangePolicy/components/NewPolicy/__snapshots__/NewPolicy.test.tsx.snap
+++ b/public/pages/ChangePolicy/components/NewPolicy/__snapshots__/NewPolicy.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<NewPolicy /> spec renders the component 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h3
+      <h1
         class="euiTitle euiTitle--small"
       >
         Choose new policy
@@ -22,7 +22,7 @@ exports[`<NewPolicy /> spec renders the component 1`] = `
            
            
         </span>
-      </h3>
+      </h1>
     </div>
   </div>
   <hr

--- a/public/pages/ChangePolicy/containers/ChangePolicy/__snapshots__/ChangePolicy.test.tsx.snap
+++ b/public/pages/ChangePolicy/containers/ChangePolicy/__snapshots__/ChangePolicy.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--small"
         >
           Choose managed indices
@@ -33,7 +33,7 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr
@@ -223,7 +223,7 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--small"
         >
           Choose new policy
@@ -233,7 +233,7 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr

--- a/public/pages/Commons/BaseAggregationAndMetricSettings.tsx
+++ b/public/pages/Commons/BaseAggregationAndMetricSettings.tsx
@@ -92,7 +92,7 @@ export const BaseMetricsColumns: Readonly<EuiTableFieldDataColumnType<MetricItem
 export function sequenceTableComponents(selectedDimensionField, items, columns, pagination, sorting, onChange) {
   if (selectedDimensionField.length == 0) {
     return (
-      <EuiText>
+      <EuiText size="xs">
         <dd>No fields added for aggregation</dd>
       </EuiText>
     );
@@ -120,12 +120,12 @@ export function additionalMetricsComponent(selectedMetrics) {
   return (
     <EuiFlexGroup gutterSize="xs">
       <EuiFlexItem grow={false}>
-        <EuiText>
+        <EuiText size="s">
           <h3>Additional metrics</h3>
         </EuiText>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiText color="subdued" textAlign="left">
+        <EuiText color="subdued" textAlign="left" size="s">
           <h3>{`(${selectedMetrics.length})`}</h3>
         </EuiText>
       </EuiFlexItem>
@@ -136,7 +136,7 @@ export function additionalMetricsComponent(selectedMetrics) {
 export function sourceFieldComponents(selectedMetrics, items, columns, pagination, sorting, onChange) {
   if (selectedMetrics.length == 0) {
     return (
-      <EuiText>
+      <EuiText size="xs">
         <dd>No fields added for metrics</dd>
       </EuiText>
     );

--- a/public/pages/CreateComposableTemplate/containers/CreateComposableTemplate/__snapshots__/CreateComposableTemplate.test.tsx.snap
+++ b/public/pages/CreateComposableTemplate/containers/CreateComposableTemplate/__snapshots__/CreateComposableTemplate.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`<CreateComposableTemplate /> spec it goes to templates page when click 
         <div
           class="euiFlexItem"
         >
-          <h3
+          <h1
             class="euiTitle euiTitle--small"
           >
             Define component template
@@ -78,7 +78,7 @@ exports[`<CreateComposableTemplate /> spec it goes to templates page when click 
                
                
             </span>
-          </h3>
+          </h1>
         </div>
       </div>
       <hr
@@ -272,7 +272,7 @@ exports[`<CreateComposableTemplate /> spec it goes to templates page when click 
         <div
           class="euiFlexItem"
         >
-          <h3
+          <h1
             class="euiTitle euiTitle--small"
           >
             Index settings
@@ -282,7 +282,7 @@ exports[`<CreateComposableTemplate /> spec it goes to templates page when click 
                
                
             </span>
-          </h3>
+          </h1>
         </div>
         <div
           class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/public/pages/CreateComposableTemplate/containers/TemplateDetail/__snapshots__/TemplateDetail.test.tsx.snap
+++ b/public/pages/CreateComposableTemplate/containers/TemplateDetail/__snapshots__/TemplateDetail.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`<TemplateDetail /> spec render component 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--small"
         >
           Define component template
@@ -63,7 +63,7 @@ exports[`<TemplateDetail /> spec render component 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr
@@ -307,7 +307,7 @@ exports[`<TemplateDetail /> spec render component 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--small"
         >
           Index settings
@@ -317,7 +317,7 @@ exports[`<TemplateDetail /> spec render component 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
       <div
         class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/public/pages/CreateDataStream/containers/CreateDataStream/__snapshots__/CreateDataStream.test.tsx.snap
+++ b/public/pages/CreateDataStream/containers/CreateDataStream/__snapshots__/CreateDataStream.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`<CreateDataStream /> spec it goes to data streams page when click cance
         <div
           class="euiFlexItem"
         >
-          <h3
+          <h1
             class="euiTitle euiTitle--small"
           >
             Define data stream
@@ -110,7 +110,7 @@ exports[`<CreateDataStream /> spec it goes to data streams page when click cance
                
                
             </span>
-          </h3>
+          </h1>
         </div>
       </div>
       <hr

--- a/public/pages/CreateDataStream/containers/DataStreamDetail/DataStreamDetail.tsx
+++ b/public/pages/CreateDataStream/containers/DataStreamDetail/DataStreamDetail.tsx
@@ -117,8 +117,7 @@ const DataStreamDetail = (props: DataStreamDetailProps, ref: Ref<FieldInstance>)
         <EuiText size="s" color="subdued">
           A data stream is composed of multiple backing indexes. Search requests are routed to all the backing indexes, while indexing
           requests <br></br>
-          are routed to the latest write index.
-          <ExternalLink href={coreServices.docLinks.links.opensearch.dataStreams} />
+          are routed to the latest write index. <ExternalLink href={coreServices.docLinks.links.opensearch.dataStreams} />
         </EuiText>
       ),
     },

--- a/public/pages/CreateDataStream/containers/DataStreamDetail/__snapshots__/DataStreamDetail.test.tsx.snap
+++ b/public/pages/CreateDataStream/containers/DataStreamDetail/__snapshots__/DataStreamDetail.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`<DataStreamDetail /> spec render component 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--small"
         >
           Define data stream
@@ -107,7 +107,7 @@ exports[`<DataStreamDetail /> spec render component 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr

--- a/public/pages/CreateIndexTemplate/components/DefineTemplate/__snapshots__/DefineTemplate.test.tsx.snap
+++ b/public/pages/CreateIndexTemplate/components/DefineTemplate/__snapshots__/DefineTemplate.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`<ComposableTemplatesActions /> spec renders the component in edit mode 
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--small"
         >
           Template settings
@@ -23,7 +23,7 @@ exports[`<ComposableTemplatesActions /> spec renders the component in edit mode 
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr
@@ -408,7 +408,7 @@ exports[`<ComposableTemplatesActions /> spec renders the component in non-edit m
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--small"
         >
           Template settings
@@ -418,7 +418,7 @@ exports[`<ComposableTemplatesActions /> spec renders the component in non-edit m
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr

--- a/public/pages/CreateIndexTemplate/containers/CreateIndexTemplate/__snapshots__/CreateIndexTemplate.test.tsx.snap
+++ b/public/pages/CreateIndexTemplate/containers/CreateIndexTemplate/__snapshots__/CreateIndexTemplate.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`<CreateIndexTemplate /> spec render template pages 1`] = `
         <div
           class="euiFlexItem"
         >
-          <h3
+          <h1
             class="euiTitle euiTitle--small"
           >
             Overview
@@ -77,7 +77,7 @@ exports[`<CreateIndexTemplate /> spec render template pages 1`] = `
                
                
             </span>
-          </h3>
+          </h1>
         </div>
       </div>
       <hr
@@ -215,7 +215,7 @@ exports[`<CreateIndexTemplate /> spec render template pages 1`] = `
         <div
           class="euiFlexItem"
         >
-          <h3
+          <h1
             class="euiTitle euiTitle--small"
           >
             Preview template
@@ -225,7 +225,7 @@ exports[`<CreateIndexTemplate /> spec render template pages 1`] = `
                
                
             </span>
-          </h3>
+          </h1>
         </div>
       </div>
       <hr

--- a/public/pages/CreateIndexTemplate/containers/TemplateDetail/__snapshots__/TemplateDetail.test.tsx.snap
+++ b/public/pages/CreateIndexTemplate/containers/TemplateDetail/__snapshots__/TemplateDetail.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--small"
         >
           Template settings
@@ -72,7 +72,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr
@@ -473,7 +473,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--small"
         >
           Template definition
@@ -483,7 +483,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr

--- a/public/pages/CreatePolicy/components/ConfigurePolicy/__snapshots__/ConfigurePolicy.test.tsx.snap
+++ b/public/pages/CreatePolicy/components/ConfigurePolicy/__snapshots__/ConfigurePolicy.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<ConfigurePolicy /> spec renders the component 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h3
+      <h1
         class="euiTitle euiTitle--small"
       >
         Name policy
@@ -22,7 +22,7 @@ exports[`<ConfigurePolicy /> spec renders the component 1`] = `
            
            
         </span>
-      </h3>
+      </h1>
     </div>
   </div>
   <hr

--- a/public/pages/CreatePolicy/components/DefinePolicy/__snapshots__/DefinePolicy.test.tsx.snap
+++ b/public/pages/CreatePolicy/components/DefinePolicy/__snapshots__/DefinePolicy.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<DefinePolicy /> spec renders the component 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h3
+      <h1
         class="euiTitle euiTitle--small"
       >
         Define policy
@@ -22,7 +22,7 @@ exports[`<DefinePolicy /> spec renders the component 1`] = `
            
            
         </span>
-      </h3>
+      </h1>
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/public/pages/CreatePolicy/containers/CreatePolicy/__snapshots__/CreatePolicy.test.tsx.snap
+++ b/public/pages/CreatePolicy/containers/CreatePolicy/__snapshots__/CreatePolicy.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`<CreatePolicy /> spec renders the create component 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--small"
         >
           Name policy
@@ -34,7 +34,7 @@ exports[`<CreatePolicy /> spec renders the create component 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr
@@ -115,7 +115,7 @@ exports[`<CreatePolicy /> spec renders the create component 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--small"
         >
           Define policy
@@ -125,7 +125,7 @@ exports[`<CreatePolicy /> spec renders the create component 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
       <div
         class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -367,7 +367,7 @@ exports[`<CreatePolicy /> spec renders the edit component 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--small"
         >
           Name policy
@@ -377,7 +377,7 @@ exports[`<CreatePolicy /> spec renders the edit component 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr
@@ -459,7 +459,7 @@ exports[`<CreatePolicy /> spec renders the edit component 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--small"
         >
           Define policy
@@ -469,7 +469,7 @@ exports[`<CreatePolicy /> spec renders the edit component 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
       <div
         class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/public/pages/CreateRollup/components/AdvancedAggregation/AdvancedAggregation.tsx
+++ b/public/pages/CreateRollup/components/AdvancedAggregation/AdvancedAggregation.tsx
@@ -355,17 +355,12 @@ export default class AdvancedAggregation extends Component<AdvancedAggregationPr
               <EuiFlexItem>
                 <EuiFlexGroup gutterSize="xs">
                   <EuiFlexItem grow={false}>
-                    <EuiTitle size="m">
-                      <h3>Additional aggregation </h3>
+                    <EuiTitle size="s">
+                      <h1>Additional aggregation{` (${selectedDimensionField.length})`} </h1>
                     </EuiTitle>
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
-                    <EuiText size="m" color="subdued">
-                      <h2>{` (${selectedDimensionField.length})`}</h2>
-                    </EuiText>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiTitle size="m">
+                    <EuiTitle size="s">
                       <i> – optional </i>
                     </EuiTitle>
                   </EuiFlexItem>

--- a/public/pages/CreateRollup/components/ConfigureRollup/ConfigureRollup.tsx
+++ b/public/pages/CreateRollup/components/ConfigureRollup/ConfigureRollup.tsx
@@ -17,7 +17,7 @@ interface ConfigureRollupProps {
 }
 
 const ConfigureRollup = ({ isEdit, rollupId, rollupIdError, onChangeName, onChangeDescription, description }: ConfigureRollupProps) => (
-  <ContentPanel bodyStyles={{ padding: "initial" }} title="Job name and description" titleSize="m">
+  <ContentPanel bodyStyles={{ padding: "initial" }} title="Job name and description" titleSize="s">
     <div style={{ paddingLeft: "10px" }}>
       <EuiSpacer size="s" />
       <EuiFormRow label="Name" helpText="Specify a unique, descriptive name." isInvalid={!!rollupIdError} error={rollupIdError}>

--- a/public/pages/CreateRollup/components/HistogramAndMetrics/HistogramAndMetrics.tsx
+++ b/public/pages/CreateRollup/components/HistogramAndMetrics/HistogramAndMetrics.tsx
@@ -201,11 +201,11 @@ export default class HistogramAndMetrics extends Component<HistogramAndMetricsPr
         }
         bodyStyles={{ padding: "initial" }}
         title={AGGREGATION_AND_METRIC_SETTINGS}
-        titleSize="m"
+        titleSize="s"
       >
         <div style={{ padding: "15px" }}>
           <EuiSpacer size="xs" />
-          <EuiText>
+          <EuiText size="s">
             <h3>Time aggregation</h3>
           </EuiText>
           <EuiSpacer size="s" />
@@ -232,13 +232,8 @@ export default class HistogramAndMetrics extends Component<HistogramAndMetricsPr
           <EuiSpacer size="m" />
           <EuiFlexGroup gutterSize="xs">
             <EuiFlexItem grow={false}>
-              <EuiText>
-                <h3>Additional aggregations</h3>
-              </EuiText>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiText color="subdued" textAlign="left">
-                <h3>{`(${selectedDimensionField.length})`}</h3>
+              <EuiText size="s">
+                <h3>Additional aggregations {`(${selectedDimensionField.length})`}</h3>
               </EuiText>
             </EuiFlexItem>
           </EuiFlexGroup>
@@ -252,9 +247,8 @@ export default class HistogramAndMetrics extends Component<HistogramAndMetricsPr
             this.onDimensionTableChange
           )}
 
-          <EuiSpacer size="m" />
+          <EuiSpacer size="s" />
 
-          <EuiSpacer />
           {additionalMetricsComponent(selectedMetrics)}
 
           {sourceFieldComponents(selectedMetrics, this.parseMetric(metricsShown), metricsColumns, pagination, sorting, this.onTableChange)}

--- a/public/pages/CreateRollup/components/JobNameAndIndices/JobNameAndIndices.tsx
+++ b/public/pages/CreateRollup/components/JobNameAndIndices/JobNameAndIndices.tsx
@@ -45,7 +45,7 @@ export default class JobNameAndIndices extends Component<JobNameAndIndicesProps>
         }
         bodyStyles={{ padding: "initial" }}
         title="Job name and indexes"
-        titleSize="m"
+        titleSize="s"
       >
         <div style={{ padding: "15px" }}>
           <EuiSpacer size="s" />

--- a/public/pages/CreateRollup/components/MetricsCalculation/MetricsCalculation.tsx
+++ b/public/pages/CreateRollup/components/MetricsCalculation/MetricsCalculation.tsx
@@ -512,17 +512,12 @@ export default class MetricsCalculation extends Component<MetricsCalculationProp
           <EuiFlexItem>
             <EuiFlexGroup gutterSize="xs">
               <EuiFlexItem grow={false}>
-                <EuiTitle size="m">
-                  <h3>Additional metrics </h3>
+                <EuiTitle size="s">
+                  <h1>Additional metrics{` (${selectedMetrics.length})`} </h1>
                 </EuiTitle>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiText size="m" color="subdued">
-                  <h2>{` (${selectedMetrics.length})`}</h2>
-                </EuiText>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiTitle size="m">
+                <EuiTitle size="s">
                   <i> – optional </i>
                 </EuiTitle>
               </EuiFlexItem>

--- a/public/pages/CreateRollup/components/RollupIndices/RollupIndices.tsx
+++ b/public/pages/CreateRollup/components/RollupIndices/RollupIndices.tsx
@@ -121,7 +121,7 @@ export default class RollupIndices extends Component<RollupIndicesProps, RollupI
     } = this.props;
     const { isLoading, indexOptions, targetIndexOptions } = this.state;
     return (
-      <ContentPanel bodyStyles={{ padding: "initial" }} title="Indices" titleSize="m">
+      <ContentPanel bodyStyles={{ padding: "initial" }} title="Indices" titleSize="s">
         <div style={{ paddingLeft: "10px" }}>
           <EuiSpacer size="s" />
           <EuiCallOut color="warning">

--- a/public/pages/CreateRollup/components/ScheduleRolesAndNotifications/ScheduleRolesAndNotifications.tsx
+++ b/public/pages/CreateRollup/components/ScheduleRolesAndNotifications/ScheduleRolesAndNotifications.tsx
@@ -64,7 +64,7 @@ export default class ScheduleRolesAndNotifications extends Component<ScheduleRol
         }
         bodyStyles={{ padding: "initial" }}
         title="Schedule"
-        titleSize="m"
+        titleSize="s"
       >
         <div style={{ padding: "15px" }}>
           <EuiSpacer size="s" />

--- a/public/pages/CreateRollup/components/TimeAggregations/TimeAggregation.tsx
+++ b/public/pages/CreateRollup/components/TimeAggregations/TimeAggregation.tsx
@@ -83,8 +83,8 @@ export default class TimeAggregation extends Component<TimeAggregationProps, Tim
 
     return (
       <EuiPanel>
-        <EuiTitle size="m">
-          <h3>Time aggregation </h3>
+        <EuiTitle size="s">
+          <h1>Time aggregation </h1>
         </EuiTitle>
         <EuiFormHelpText>
           Your source indices must include a timestamp field. The rollup job creates a date histogram for the field you specify." "

--- a/public/pages/CreateRollup/containers/CreateRollupForm/__snapshots__/CreateRollupForm.test.tsx.snap
+++ b/public/pages/CreateRollup/containers/CreateRollupForm/__snapshots__/CreateRollupForm.test.tsx.snap
@@ -170,8 +170,8 @@ exports[`<CreateRollupForm /> spec renders the component 1`] = `
               <div
                 class="euiFlexItem"
               >
-                <h3
-                  class="euiTitle euiTitle--medium"
+                <h1
+                  class="euiTitle euiTitle--small"
                 >
                   Job name and description
                   <span
@@ -180,7 +180,7 @@ exports[`<CreateRollupForm /> spec renders the component 1`] = `
                      
                      
                   </span>
-                </h3>
+                </h1>
               </div>
             </div>
             <hr
@@ -305,8 +305,8 @@ exports[`<CreateRollupForm /> spec renders the component 1`] = `
               <div
                 class="euiFlexItem"
               >
-                <h3
-                  class="euiTitle euiTitle--medium"
+                <h1
+                  class="euiTitle euiTitle--small"
                 >
                   Indices
                   <span
@@ -315,7 +315,7 @@ exports[`<CreateRollupForm /> spec renders the component 1`] = `
                      
                      
                   </span>
-                </h3>
+                </h1>
               </div>
             </div>
             <hr

--- a/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
+++ b/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
@@ -582,7 +582,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
           </>
         )}
 
-        <ContentPanel title="Policy settings" titleSize="m">
+        <ContentPanel title="Policy settings" titleSize="s">
           <CustomLabel title="Policy name" />
           <EuiFormRow isInvalid={!!policyIdError} error={policyIdError}>
             <EuiFieldText placeholder="e.g. daily-snapshot" value={policyId} onChange={this.onChangePolicyName} disabled={isEdit} />
@@ -604,7 +604,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
 
         <EuiSpacer />
 
-        <ContentPanel title="Source and destination" titleSize="m">
+        <ContentPanel title="Source and destination" titleSize="s">
           <SnapshotIndicesRepoInput
             indexOptions={indexOptions}
             selectedIndexOptions={selectedIndexOptions}
@@ -629,7 +629,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
 
         <EuiSpacer />
 
-        <ContentPanel title="Snapshot schedule" titleSize="m">
+        <ContentPanel title="Snapshot schedule" titleSize="s">
           <CronSchedule
             frequencyTitle="Snapshot frequency"
             frequencyType={creationScheduleFrequencyType}
@@ -656,8 +656,8 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
 
         <EuiSpacer />
 
-        <ContentPanel title="Retention period" titleSize="m">
-          <EuiRadioGroup
+        <ContentPanel title="Retention period" titleSize="s">
+          <EuiCompressedRadioGroup
             options={rententionEnableRadios}
             idSelected={deleteConditionEnabled ? "retention_enabled" : "retention_disabled"}
             onChange={(id) => {
@@ -754,7 +754,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
 
         <EuiSpacer />
 
-        <ContentPanel title="Notifications" titleSize="m">
+        <ContentPanel title="Notifications" titleSize="s">
           <div style={{ padding: "10px 10px" }}>
             <EuiText>Notify on snapshot activities</EuiText>
 
@@ -817,10 +817,10 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
               />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiTitle size="m">
-                <h3>
+              <EuiTitle size="s">
+                <h1>
                   Advanced settings <i>– optional</i>
-                </h3>
+                </h1>
               </EuiTitle>
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/public/pages/CreateTransform/containers/CreateTransformForm/__snapshots__/CreateTransformForm.test.tsx.snap
+++ b/public/pages/CreateTransform/containers/CreateTransformForm/__snapshots__/CreateTransformForm.test.tsx.snap
@@ -172,7 +172,7 @@ exports[`<CreateTransformForm /> spec renders the component 1`] = `
               <div
                 class="euiFlexItem"
               >
-                <h3
+                <h1
                   class="euiTitle euiTitle--medium"
                 >
                   Job name and description
@@ -182,7 +182,7 @@ exports[`<CreateTransformForm /> spec renders the component 1`] = `
                      
                      
                   </span>
-                </h3>
+                </h1>
               </div>
             </div>
             <hr
@@ -303,7 +303,7 @@ exports[`<CreateTransformForm /> spec renders the component 1`] = `
                 <div
                   class="euiFlexItem"
                 >
-                  <h3
+                  <h1
                     class="euiTitle euiTitle--medium"
                   >
                     Indices
@@ -313,7 +313,7 @@ exports[`<CreateTransformForm /> spec renders the component 1`] = `
                        
                        
                     </span>
-                  </h3>
+                  </h1>
                 </div>
               </div>
               <hr

--- a/public/pages/DataStreams/containers/DataStreams/DataStreams.tsx
+++ b/public/pages/DataStreams/containers/DataStreams/DataStreams.tsx
@@ -285,19 +285,20 @@ class DataStreams extends MDSEnabledComponent<DataStreamsProps, DataStreamsState
           <EuiText size="s" color="subdued">
             Data streams simplify the management of time-series data. Data streams are composed of multiple backing indexes. Search{" "}
             <br></br>
-            requests are routed to all backing indexes, while indexing requests are routed to the latest write index.
+            requests are routed to all backing indexes, while indexing requests are routed to the latest write index.{" "}
             <ExternalLink href={(this.context as CoreStart).docLinks.links.opensearch.dataStreams} />
           </EuiText>
         ),
       },
     ];
+    const searchbar_padding = { padding: "0px 0px 16px 0px" };
 
     return useNewUX ? (
       <>
         <HeaderControl setMountPoint={setAppRightControls} controls={constrolsData} />
         <HeaderControl setMountPoint={setAppDescriptionControls} controls={descriptionData} />
         <ContentPanel>
-          <EuiFlexGroup gutterSize="s" alignItems="center">
+          <EuiFlexGroup gutterSize="s" alignItems="center" style={searchbar_padding}>
             <EuiFlexItem grow={true}>
               <IndexControls
                 value={{
@@ -395,19 +396,19 @@ class DataStreams extends MDSEnabledComponent<DataStreamsProps, DataStreamsState
               ) ? (
                 <EuiEmptyPrompt
                   body={
-                    <EuiText>
+                    <EuiText size="s">
                       <p>You have no data streams.</p>
                     </EuiText>
                   }
                   actions={[
-                    <EuiButton
+                    <EuiSmallButton
                       fill
                       onClick={() => {
                         this.props.history.push(ROUTES.CREATE_DATA_STREAM);
                       }}
                     >
                       Create data stream
-                    </EuiButton>,
+                    </EuiSmallButton>,
                   ]}
                 />
               ) : (
@@ -418,7 +419,7 @@ class DataStreams extends MDSEnabledComponent<DataStreamsProps, DataStreamsState
                     </EuiText>
                   }
                   actions={[
-                    <EuiButton
+                    <EuiSmallButton
                       fill
                       onClick={() => {
                         this.setState(defaultFilter, () => {
@@ -427,7 +428,7 @@ class DataStreams extends MDSEnabledComponent<DataStreamsProps, DataStreamsState
                       }}
                     >
                       Reset filters
-                    </EuiButton>,
+                    </EuiSmallButton>,
                   ]}
                 />
               )
@@ -466,7 +467,7 @@ class DataStreams extends MDSEnabledComponent<DataStreamsProps, DataStreamsState
           bodyStyles={{ padding: "initial" }}
           title={
             <>
-              <EuiTitle>
+              <EuiTitle size="s">
                 <span>Data streams</span>
               </EuiTitle>
               <EuiFormRow

--- a/public/pages/DataStreams/containers/DataStreams/__snapshots__/DataStreams.test.tsx.snap
+++ b/public/pages/DataStreams/containers/DataStreams/__snapshots__/DataStreams.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`<DataStreams /> spec renders the component 1`] = `
       class="euiFlexItem"
     >
       <span
-        class="euiTitle euiTitle--medium"
+        class="euiTitle euiTitle--small"
       >
         Data streams
       </span>

--- a/public/pages/DataStreams/containers/DataStreamsActions/index.tsx
+++ b/public/pages/DataStreams/containers/DataStreamsActions/index.tsx
@@ -50,7 +50,7 @@ export default function DataStreamsActions(props: DataStreamsActionsProps) {
     <>
       <SimplePopover
         data-test-subj="moreAction"
-        panelPaddingSize="none"
+        panelPaddingSize="s"
         button={
           <EuiButton iconType="arrowDown" iconSide="right" size={useNewUX ? "s" : undefined}>
             Actions
@@ -58,6 +58,7 @@ export default function DataStreamsActions(props: DataStreamsActionsProps) {
         }
       >
         <EuiContextMenu
+          size="s"
           initialPanelId={0}
           // The EuiContextMenu has bug when testing in jest
           // the props change won't make it rerender

--- a/public/pages/DataStreams/containers/DeleteDataStreamsModal/__snapshots__/DeleteDataStreamsModal.test.tsx.snap
+++ b/public/pages/DataStreams/containers/DeleteDataStreamsModal/__snapshots__/DeleteDataStreamsModal.test.tsx.snap
@@ -61,7 +61,7 @@ HTMLCollection [
                   class="euiSpacer euiSpacer--l"
                 />
                 <div
-                  class="euiText euiText--medium"
+                  class="euiText euiText--small"
                 >
                   <div
                     class="euiTextColor euiTextColor--subdued"

--- a/public/pages/EditRollup/containers/__snapshots__/EditRollup.test.tsx.snap
+++ b/public/pages/EditRollup/containers/__snapshots__/EditRollup.test.tsx.snap
@@ -23,8 +23,8 @@ exports[`<EditRollup /> spec renders the component 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
-          class="euiTitle euiTitle--medium"
+        <h1
+          class="euiTitle euiTitle--small"
         >
           Job name and description
           <span
@@ -33,7 +33,7 @@ exports[`<EditRollup /> spec renders the component 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr
@@ -159,7 +159,7 @@ exports[`<EditRollup /> spec renders the component 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--small"
         >
           Schedule
@@ -169,7 +169,7 @@ exports[`<EditRollup /> spec renders the component 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr

--- a/public/pages/ForceMerge/container/ForceMerge/ForceMerge.tsx
+++ b/public/pages/ForceMerge/container/ForceMerge/ForceMerge.tsx
@@ -253,7 +253,7 @@ export default function ForceMergeWrapper(props: Omit<ForceMergeProps, "services
 
       <EuiSpacer />
 
-      <ContentPanel title={advanceTitle} noExtraPadding>
+      <ContentPanel title={advanceTitle} noExtraPadding titleSize="s">
         {advancedSettingsOpen && (
           <>
             <EuiSpacer size="s" />

--- a/public/pages/ForceMerge/container/ForceMerge/__snapshots__/ForceMerge.test.tsx.snap
+++ b/public/pages/ForceMerge/container/ForceMerge/__snapshots__/ForceMerge.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`<ForceMerge /> spec renders the component 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--small"
         >
           Configure source index
@@ -48,7 +48,7 @@ exports[`<ForceMerge /> spec renders the component 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr

--- a/public/pages/Indices/containers/Indices/__snapshots__/Indices.test.tsx.snap
+++ b/public/pages/Indices/containers/Indices/__snapshots__/Indices.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<Indices /> spec renders the component 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h3
+      <h1
         class="euiTitle euiTitle--large"
       >
         Indexes
@@ -22,7 +22,7 @@ exports[`<Indices /> spec renders the component 1`] = `
            
            
         </span>
-      </h3>
+      </h1>
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/public/pages/ManagedIndices/containers/ManagedIndices/__snapshots__/ManagedIndices.test.tsx.snap
+++ b/public/pages/ManagedIndices/containers/ManagedIndices/__snapshots__/ManagedIndices.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--large"
         >
           Policy managed indexes
@@ -75,7 +75,7 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
       <div
         class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/public/pages/Notifications/containers/Notifications/Notifications.tsx
+++ b/public/pages/Notifications/containers/Notifications/Notifications.tsx
@@ -235,7 +235,7 @@ const Notifications = (props: NotificationsProps) => {
         </EuiPanel>
       ) : (
         <EuiPanel>
-          <EuiText>
+          <EuiText size="s">
             <h2>Defaults for index operations</h2>
           </EuiText>
           {submitClicked && allErrors.length ? (

--- a/public/pages/Notifications/containers/Notifications/__snapshots__/Notifications.test.tsx.snap
+++ b/public/pages/Notifications/containers/Notifications/__snapshots__/Notifications.test.tsx.snap
@@ -146,7 +146,7 @@ exports[`<Notifications /> spec renders 1`] = `
     class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
   >
     <div
-      class="euiText euiText--medium"
+      class="euiText euiText--small"
     >
       <h2>
         Defaults for index operations

--- a/public/pages/Policies/containers/Policies/__snapshots__/Policies.test.tsx.snap
+++ b/public/pages/Policies/containers/Policies/__snapshots__/Policies.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`<IndexPolicies /> spec renders the component 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--large"
         >
           State management policies
@@ -25,7 +25,7 @@ exports[`<IndexPolicies /> spec renders the component 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
       <div
         class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/public/pages/PolicyDetails/components/PolicySettings/__snapshots__/PolicySettings.test.tsx.snap
+++ b/public/pages/PolicyDetails/components/PolicySettings/__snapshots__/PolicySettings.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<PolicySettings /> spec renders the component 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h3
+      <h1
         class="euiTitle euiTitle--small"
       >
         Policy settings
@@ -22,7 +22,7 @@ exports[`<PolicySettings /> spec renders the component 1`] = `
            
            
         </span>
-      </h3>
+      </h1>
     </div>
   </div>
   <hr

--- a/public/pages/Reindex/components/CreateIndexFlyout/__snapshots__/CreateIndexFlyout.test.tsx.snap
+++ b/public/pages/Reindex/components/CreateIndexFlyout/__snapshots__/CreateIndexFlyout.test.tsx.snap
@@ -61,7 +61,7 @@ Object {
                     <div
                       class="euiFlexItem"
                     >
-                      <h3
+                      <h1
                         class="euiTitle euiTitle--small"
                       >
                         Define index
@@ -71,7 +71,7 @@ Object {
                            
                            
                         </span>
-                      </h3>
+                      </h1>
                     </div>
                   </div>
                   <hr
@@ -243,7 +243,7 @@ Object {
                     <div
                       class="euiFlexItem"
                     >
-                      <h3
+                      <h1
                         class="euiTitle euiTitle--small"
                       >
                         Index settings
@@ -253,7 +253,7 @@ Object {
                            
                            
                         </span>
-                      </h3>
+                      </h1>
                     </div>
                   </div>
                   <hr

--- a/public/pages/Reindex/container/Reindex/__snapshots__/Reindex.test.tsx.snap
+++ b/public/pages/Reindex/container/Reindex/__snapshots__/Reindex.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`<Reindex /> spec renders the component 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--small"
         >
           Configure source index
@@ -65,7 +65,7 @@ exports[`<Reindex /> spec renders the component 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr
@@ -242,7 +242,7 @@ exports[`<Reindex /> spec renders the component 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--small"
         >
           Configure destination index
@@ -252,7 +252,7 @@ exports[`<Reindex /> spec renders the component 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr

--- a/public/pages/Repositories/containers/Repositories/Repositories.tsx
+++ b/public/pages/Repositories/containers/Repositories/Repositories.tsx
@@ -207,7 +207,6 @@ export class Repositories extends MDSEnabledComponent<RepositoriesProps, Reposit
     const popoverActionItems = [
       <EuiContextMenuItem
         key="Edit"
-        icon="empty"
         disabled={selectedItems.length != 1}
         data-test-subj="editButton"
         onClick={() => {
@@ -219,7 +218,6 @@ export class Repositories extends MDSEnabledComponent<RepositoriesProps, Reposit
       </EuiContextMenuItem>,
       <EuiContextMenuItem
         key="Delete"
-        icon="empty"
         disabled={!selectedItems.length}
         data-test-subj="deleteButton"
         onClick={() => {
@@ -295,6 +293,7 @@ export class Repositories extends MDSEnabledComponent<RepositoriesProps, Reposit
         compressed: useNewUX ? true : false,
         increamental: true,
       },
+      compressed: true,
       filters: [
         {
           type: "field_value_selection",

--- a/public/pages/Rollover/containers/Rollover/Rollover.tsx
+++ b/public/pages/Rollover/containers/Rollover/Rollover.tsx
@@ -228,8 +228,7 @@ export default function Rollover(props: RolloverProps) {
     {
       renderComponent: (
         <EuiText size="s" color="subdued">
-          Manually merge shards of indexes or backing indexes of data streams. You can also use force merge to clear up deleted documents
-          within indexes.
+          Rollover creates a new writing index for a data stream or index alias.
         </EuiText>
       ),
     },

--- a/public/pages/Rollover/containers/Rollover/__snapshots__/Rollover.test.tsx.snap
+++ b/public/pages/Rollover/containers/Rollover/__snapshots__/Rollover.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`container <Rollover /> spec render the component 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--small"
         >
           Configure source
@@ -46,7 +46,7 @@ exports[`container <Rollover /> spec render the component 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr

--- a/public/pages/RollupDetails/components/AggregationAndMetricsSettings/AggregationAndMetricsSettings.tsx
+++ b/public/pages/RollupDetails/components/AggregationAndMetricsSettings/AggregationAndMetricsSettings.tsx
@@ -26,7 +26,9 @@ import {
   AGGREGATION_AND_METRIC_SETTINGS,
   BaseAggregationAndMetricsState,
   BaseAggregationColumns,
-  BaseMetricsColumns, sequenceTableComponents, sourceFieldComponents
+  BaseMetricsColumns,
+  sequenceTableComponents,
+  sourceFieldComponents,
 } from "../../../Commons/BaseAggregationAndMetricSettings";
 
 interface AggregationAndMetricsSettingsProps {
@@ -41,8 +43,7 @@ interface AggregationAndMetricsSettingsProps {
   onChangeMetricsShown: (from: number, size: number) => void;
 }
 
-interface AggregationAndMetricsSettingsState extends BaseAggregationAndMetricsState {
-}
+interface AggregationAndMetricsSettingsState extends BaseAggregationAndMetricsState {}
 
 const aggregationColumns: Readonly<EuiTableFieldDataColumnType<DimensionItem>>[] = BaseAggregationColumns;
 
@@ -130,14 +131,10 @@ export default class AggregationAndMetricsSettings extends Component<
       interval = intervalValue[0] + " " + parseTimeunit(intervalUnit[0]);
     }
     return (
-      <ContentPanel
-        bodyStyles={{ padding: "initial" }}
-        title={AGGREGATION_AND_METRIC_SETTINGS}
-        titleSize="m"
-      >
+      <ContentPanel bodyStyles={{ padding: "initial" }} title={AGGREGATION_AND_METRIC_SETTINGS} titleSize="s">
         <div style={{ paddingLeft: "10px" }}>
           <EuiSpacer size="s" />
-          <EuiText>
+          <EuiText size="s">
             <h3>Additional metrics</h3>
           </EuiText>
           <EuiFlexGrid columns={3}>
@@ -163,34 +160,31 @@ export default class AggregationAndMetricsSettings extends Component<
           <EuiSpacer size="s" />
           <EuiFlexGroup gutterSize="xs">
             <EuiFlexItem grow={false}>
-              <EuiText>
+              <EuiText size="s">
                 <h3>Additional aggregations</h3>
               </EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiText color="subdued" textAlign="left">
+              <EuiText color="subdued" textAlign="left" size="s">
                 <h3>{`(${selectedDimensionField.length})`}</h3>
               </EuiText>
             </EuiFlexItem>
           </EuiFlexGroup>
 
-          {
-            sequenceTableComponents(selectedDimensionField, dimensionsShown, aggregationColumns,
-              dimensionPagination, dimensionSorting, this.onDimensionTableChange)
-          }
+          {sequenceTableComponents(
+            selectedDimensionField,
+            dimensionsShown,
+            aggregationColumns,
+            dimensionPagination,
+            dimensionSorting,
+            this.onDimensionTableChange
+          )}
 
-          <EuiSpacer size="m" />
+          <EuiSpacer size="s" />
 
-          <EuiSpacer />
+          {additionalMetricsComponent(selectedMetrics)}
 
-          {
-            additionalMetricsComponent(selectedMetrics)
-          }
-
-          {
-            sourceFieldComponents(selectedMetrics, metricsShown, metricsColumns, pagination,
-              sorting, this.onTableChange)
-          }
+          {sourceFieldComponents(selectedMetrics, metricsShown, metricsColumns, pagination, sorting, this.onTableChange)}
           <EuiSpacer size="s" />
         </div>
       </ContentPanel>

--- a/public/pages/RollupDetails/components/GeneralInformation/GeneralInformation.tsx
+++ b/public/pages/RollupDetails/components/GeneralInformation/GeneralInformation.tsx
@@ -51,7 +51,7 @@ export default class GeneralInformation extends Component<GeneralInformationProp
         actions={<ModalConsumer>{() => <ContentPanelActions actions={useActions} />}</ModalConsumer>}
         bodyStyles={{ padding: "initial" }}
         title="General information"
-        titleSize="m"
+        titleSize="s"
       >
         <div style={{ paddingLeft: "10px" }}>
           <EuiSpacer size="s" />

--- a/public/pages/RollupDetails/components/RollupStatus/RollupStatus.tsx
+++ b/public/pages/RollupDetails/components/RollupStatus/RollupStatus.tsx
@@ -15,7 +15,7 @@ interface RollupStatusProps {
 }
 
 const RollupStatus = ({ metadata }: RollupStatusProps) => (
-  <ContentPanel bodyStyles={{ padding: "initial" }} title="Rollup status" titleSize="m">
+  <ContentPanel bodyStyles={{ padding: "initial" }} title="Rollup status" titleSize="s">
     <div style={{ paddingLeft: "10px" }}>
       <EuiSpacer size="s" />
       <EuiFlexGrid columns={4}>

--- a/public/pages/Rollups/containers/Rollups/Rollups.tsx
+++ b/public/pages/Rollups/containers/Rollups/Rollups.tsx
@@ -379,7 +379,7 @@ export class Rollups extends MDSEnabledComponent<RollupsProps, RollupsState> {
           this.showDeleteModal();
         }}
       >
-        <EuiTextColor color="danger">Delete</EuiTextColor>
+        <EuiTextColor>Delete</EuiTextColor>
       </EuiContextMenuItem>,
     ];
 
@@ -481,11 +481,13 @@ export class Rollups extends MDSEnabledComponent<RollupsProps, RollupsState> {
       },
     ];
 
+    const searchbar_padding = { padding: "0px 0px 16px 0px" };
+
     return useNewUX ? (
       <>
         <HeaderControl setMountPoint={setAppRightControls} controls={controlControlsData} />
         <ContentPanel>
-          <EuiFlexGroup gutterSize="s" alignItems="center">
+          <EuiFlexGroup gutterSize="s" alignItems="center" style={searchbar_padding}>
             <EuiFlexItem grow={true}>
               <EuiCompressedFieldSearch
                 autoFocus
@@ -513,11 +515,11 @@ export class Rollups extends MDSEnabledComponent<RollupsProps, RollupsState> {
                 button={actionButton}
                 isOpen={isPopoverOpen}
                 closePopover={this.closePopover}
-                panelPaddingSize="none"
+                panelPaddingSize="s"
                 anchorPosition="downLeft"
                 data-test-subj="actionPopover"
               >
-                <EuiContextMenuPanel items={newActionItems} />
+                <EuiContextMenuPanel items={newActionItems} size="s" />
               </EuiPopover>
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/public/pages/ShrinkIndex/container/ShrinkIndex/__snapshots__/ShrinkIndex.test.tsx.snap
+++ b/public/pages/ShrinkIndex/container/ShrinkIndex/__snapshots__/ShrinkIndex.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
         <div
           class="euiFlexItem"
         >
-          <h3
+          <h1
             class="euiTitle euiTitle--small"
           >
             Source index details
@@ -65,7 +65,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
                
                
             </span>
-          </h3>
+          </h1>
         </div>
       </div>
       <hr
@@ -173,7 +173,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
         <div
           class="euiFlexItem"
         >
-          <h3
+          <h1
             class="euiTitle euiTitle--small"
           >
             Configure target index
@@ -183,7 +183,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
                
                
             </span>
-          </h3>
+          </h1>
         </div>
       </div>
       <hr
@@ -698,7 +698,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
                 <div
                   class="euiFlexItem"
                 >
-                  <h3
+                  <h1
                     class="euiTitle euiTitle--small"
                   >
                     Advanced settings
@@ -708,7 +708,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
                        
                        
                     </span>
-                  </h3>
+                  </h1>
                 </div>
               </div>
             </span>

--- a/public/pages/SnapshotPolicies/containers/SnapshotPolicies/SnapshotPolicies.tsx
+++ b/public/pages/SnapshotPolicies/containers/SnapshotPolicies/SnapshotPolicies.tsx
@@ -387,7 +387,6 @@ export class SnapshotPolicies extends MDSEnabledComponent<SnapshotPoliciesProps,
     const popoverActionItems = [
       <EuiContextMenuItem
         key="Edit"
-        icon="empty"
         disabled={selectedItems.length != 1}
         data-test-subj="editButton"
         onClick={() => {
@@ -399,7 +398,6 @@ export class SnapshotPolicies extends MDSEnabledComponent<SnapshotPoliciesProps,
       </EuiContextMenuItem>,
       <EuiContextMenuItem
         key="Delete"
-        icon="empty"
         disabled={!selectedItems.length}
         data-test-subj="deleteButton"
         onClick={() => {
@@ -407,7 +405,7 @@ export class SnapshotPolicies extends MDSEnabledComponent<SnapshotPoliciesProps,
           this.showDeleteModal();
         }}
       >
-        <EuiTextColor color="danger">Delete</EuiTextColor>
+        <EuiTextColor>Delete</EuiTextColor>
       </EuiContextMenuItem>,
     ];
 
@@ -450,7 +448,7 @@ export class SnapshotPolicies extends MDSEnabledComponent<SnapshotPoliciesProps,
           this.showDeleteModal();
         }}
       >
-        <EuiTextColor color="danger">Delete</EuiTextColor>
+        <EuiTextColor>Delete</EuiTextColor>
       </EuiContextMenuItem>,
     ];
     const actionsButton = (
@@ -460,7 +458,6 @@ export class SnapshotPolicies extends MDSEnabledComponent<SnapshotPoliciesProps,
         disabled={!selectedItems.length}
         onClick={this.onActionButtonClick}
         data-test-subj="actionButton"
-        size="s"
       >
         Actions
       </EuiButton>
@@ -480,11 +477,11 @@ export class SnapshotPolicies extends MDSEnabledComponent<SnapshotPoliciesProps,
         button={actionsButton}
         isOpen={isPopoverOpen}
         closePopover={this.closePopover}
-        panelPaddingSize="none"
+        panelPaddingSize="s"
         anchorPosition="downLeft"
         data-test-subj="actionPopover"
       >
-        <EuiContextMenuPanel items={popoverActionItems} />
+        <EuiContextMenuPanel items={popoverActionItems} size="s" />
       </EuiPopover>,
       <EuiButton onClick={this.onClickCreate} fill={true}>
         Create policy
@@ -506,7 +503,7 @@ export class SnapshotPolicies extends MDSEnabledComponent<SnapshotPoliciesProps,
       <EuiEmptyPrompt
         style={{ maxWidth: "45em" }}
         body={
-          <EuiText>
+          <EuiText size="s">
             <p>{getMessagePrompt(loadingPolicies)}</p>
           </EuiText>
         }
@@ -543,6 +540,8 @@ export class SnapshotPolicies extends MDSEnabledComponent<SnapshotPoliciesProps,
         controlType: "button",
       },
     ];
+
+    const searchbar_padding = { padding: "0px 0px 16px 0px" };
 
     const CommonTable = () => {
       return (
@@ -587,7 +586,7 @@ export class SnapshotPolicies extends MDSEnabledComponent<SnapshotPoliciesProps,
         <HeaderControl setMountPoint={setAppRightControls} controls={controlControlsData} />
         <HeaderControl setMountPoint={setAppDescriptionControls} controls={descriptionData} />
         <ContentPanel>
-          <EuiFlexGroup gutterSize="s" alignItems="center">
+          <EuiFlexGroup gutterSize="s" alignItems="center" style={searchbar_padding}>
             <EuiFlexItem grow={true}>
               <EuiCompressedFieldSearch
                 autoFocus
@@ -608,8 +607,9 @@ export class SnapshotPolicies extends MDSEnabledComponent<SnapshotPoliciesProps,
                 isOpen={isPopoverOpen}
                 closePopover={this.closePopover}
                 anchorPosition="downRight"
+                panelPaddingSize="s"
               >
-                <EuiContextMenuPanel items={popoverActionItemsNew} />
+                <EuiContextMenuPanel items={popoverActionItemsNew} size="s" />
               </EuiPopover>
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/public/pages/SnapshotPolicyDetails/containers/SnapshotPolicyDetails/SnapshotPolicyDetails.tsx
+++ b/public/pages/SnapshotPolicyDetails/containers/SnapshotPolicyDetails/SnapshotPolicyDetails.tsx
@@ -446,11 +446,11 @@ export class SnapshotPolicyDetails extends MDSEnabledComponent<SnapshotPolicyDet
           </>
         )}
 
-        <ContentPanel title="Policy settings" titleSize="m">
+        <ContentPanel title="Policy settings" titleSize="s">
           <EuiFlexGrid columns={3}>
             {policySettingItems.map((item) => (
               <EuiFlexItem key={`${item.term}`}>
-                <EuiText size="xs">
+                <EuiText size="s">
                   <dt>{item.term}</dt>
                   <dd>{item.value}</dd>
                 </EuiText>
@@ -465,7 +465,7 @@ export class SnapshotPolicyDetails extends MDSEnabledComponent<SnapshotPolicyDet
             <EuiFlexGrid columns={3}>
               {advancedSettingItems.map((item) => (
                 <EuiFlexItem key={`${item.term}`}>
-                  <EuiText size="xs">
+                  <EuiText size="s">
                     <dt>{item.term}</dt>
                     <dd>{item.value}</dd>
                   </EuiText>
@@ -477,11 +477,11 @@ export class SnapshotPolicyDetails extends MDSEnabledComponent<SnapshotPolicyDet
 
         <EuiSpacer />
 
-        <ContentPanel title="Snapshot schedule" titleSize="m">
+        <ContentPanel title="Snapshot schedule" titleSize="s">
           <EuiFlexGrid columns={3}>
             {snapshotScheduleItems.map((item) => (
               <EuiFlexItem key={`${item.term}`}>
-                <EuiText size="xs">
+                <EuiText size="s">
                   <dt>{item.term}</dt>
                   <dd>{item.value}</dd>
                 </EuiText>
@@ -492,11 +492,11 @@ export class SnapshotPolicyDetails extends MDSEnabledComponent<SnapshotPolicyDet
 
         <EuiSpacer />
 
-        <ContentPanel title="Snapshot retention period" titleSize="m">
+        <ContentPanel title="Snapshot retention period" titleSize="s">
           <EuiFlexGrid columns={3}>
             {retentionItems.map((item) => (
               <EuiFlexItem key={`${item.term}`}>
-                <EuiText size="xs">
+                <EuiText size="s">
                   <dt>{item.term}</dt>
                   <dd>{item.value}</dd>
                 </EuiText>
@@ -508,7 +508,7 @@ export class SnapshotPolicyDetails extends MDSEnabledComponent<SnapshotPolicyDet
             <EuiFlexGrid columns={3}>
               {deletionScheduleItems.map((item) => (
                 <EuiFlexItem key={`${item.term}`}>
-                  <EuiText size="xs">
+                  <EuiText size="s">
                     <dt>{item.term}</dt>
                     <dd>{item.value}</dd>
                   </EuiText>
@@ -520,11 +520,11 @@ export class SnapshotPolicyDetails extends MDSEnabledComponent<SnapshotPolicyDet
 
         <EuiSpacer />
 
-        <ContentPanel title="Notifications" titleSize="m">
+        <ContentPanel title="Notifications" titleSize="s">
           <EuiFlexGrid columns={2}>
             {notificationItems.map((item) => (
               <EuiFlexItem key={`${item.term}`}>
-                <EuiText size="xs">
+                <EuiText size="s">
                   <dt>{item.term}</dt>
                   <dd>{item.value}</dd>
                 </EuiText>
@@ -537,7 +537,7 @@ export class SnapshotPolicyDetails extends MDSEnabledComponent<SnapshotPolicyDet
 
         <ContentPanel
           title="Last creation/deletion"
-          titleSize="m"
+          titleSize="s"
           actions={
             <EuiButton iconType="refresh" onClick={() => this.getPolicy(policyId)} data-test-subj="refreshButton">
               Refresh

--- a/public/pages/Snapshots/components/CreateSnapshotFlyout/CreateSnapshotFlyout.tsx
+++ b/public/pages/Snapshots/components/CreateSnapshotFlyout/CreateSnapshotFlyout.tsx
@@ -14,6 +14,8 @@ import {
   EuiFormRow,
   EuiSpacer,
   EuiTitle,
+  EuiText,
+  EuiFormHelpText,
 } from "@elastic/eui";
 import _ from "lodash";
 
@@ -216,7 +218,9 @@ export class CreateSnapshotFlyout extends MDSEnabledComponent<CreateSnapshotProp
       <EuiFlyout ownFocus={false} onClose={onCloseFlyout} maxWidth={600} size="m" hideCloseButton>
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="m">
-            <h2 id="flyoutTitle"> Create snapshot</h2>
+            <EuiText size="s">
+              <h2 id="flyoutTitle"> Create snapshot</h2>
+            </EuiText>
           </EuiTitle>
         </EuiFlyoutHeader>
 
@@ -229,8 +233,10 @@ export class CreateSnapshotFlyout extends MDSEnabledComponent<CreateSnapshotProp
                 this.setState({ snapshotId: e.target.value });
               }}
               data-test-subj="snapshotNameInput"
+              placeholder="Enter snapshot name"
             />
           </EuiFormRow>
+          <EuiFormHelpText>A valid snapshot name can not contain upper case characters. </EuiFormHelpText>
 
           <EuiSpacer size="m" />
 

--- a/public/pages/Snapshots/containers/Snapshots/Snapshots.tsx
+++ b/public/pages/Snapshots/containers/Snapshots/Snapshots.tsx
@@ -7,7 +7,6 @@ import React, { Component, useContext } from "react";
 import _ from "lodash";
 import { RouteComponentProps } from "react-router-dom";
 import {
-  EuiButton,
   EuiInMemoryTable,
   EuiLink,
   EuiTableFieldDataColumnType,
@@ -21,6 +20,7 @@ import {
   EuiContextMenuPanel,
   EuiContextMenuItem,
   EuiButtonIcon,
+  EuiButton,
 } from "@elastic/eui";
 import { FieldValueSelectionFilterConfigType } from "@elastic/eui/src/components/search_bar/filters/field_value_selection_filter";
 import { CoreServicesContext } from "../../../../components/core_services";
@@ -440,7 +440,6 @@ export class Snapshots extends MDSEnabledComponent<SnapshotsProps, SnapshotsStat
     const popoverActionItems = [
       <EuiContextMenuItem
         key="Delete"
-        icon="empty"
         disabled={!selectedItems.length}
         onClick={() => {
           this.closePopover();
@@ -465,8 +464,15 @@ export class Snapshots extends MDSEnabledComponent<SnapshotsProps, SnapshotsStat
     const renderToolsRight = () => {
       return [
         <EuiButtonIcon iconType="refresh" onClick={this.getSnapshots} aria-label="refresh" size="s" display="base" />,
-        <EuiPopover id="action" button={actionsButton} isOpen={isPopoverOpen} closePopover={this.closePopover} anchorPosition="downRight">
-          <EuiContextMenuPanel items={popoverActionItems} />
+        <EuiPopover
+          id="action"
+          button={actionsButton}
+          isOpen={isPopoverOpen}
+          closePopover={this.closePopover}
+          anchorPosition="downRight"
+          panelPaddingSize="s"
+        >
+          <EuiContextMenuPanel size="s" items={popoverActionItems} />
         </EuiPopover>,
       ];
     };
@@ -491,6 +497,7 @@ export class Snapshots extends MDSEnabledComponent<SnapshotsProps, SnapshotsStat
         incremental: true,
         compressed: useNewUX ? true : false,
       },
+      compressed: true,
       filters: [
         {
           type: "field_value_selection",
@@ -581,7 +588,7 @@ export class Snapshots extends MDSEnabledComponent<SnapshotsProps, SnapshotsStat
           </>
         ) : null}
         <EuiPageHeader>
-          <EuiTabs size="m" ref={this.tabsRef}>
+          <EuiTabs size="s" ref={this.tabsRef}>
             <EuiTab isSelected={true} onClick={this.onClickTab}>
               {SnapshotTabName}
             </EuiTab>

--- a/public/pages/Templates/containers/DeleteTemplatesModal/__snapshots__/DeleteTemplateModal.test.tsx.snap
+++ b/public/pages/Templates/containers/DeleteTemplatesModal/__snapshots__/DeleteTemplateModal.test.tsx.snap
@@ -61,7 +61,7 @@ HTMLCollection [
                   class="euiSpacer euiSpacer--l"
                 />
                 <div
-                  class="euiText euiText--medium"
+                  class="euiText euiText--small"
                 >
                   <div
                     class="euiTextColor euiTextColor--subdued"

--- a/public/pages/Transforms/containers/Transforms/__snapshots__/EditTransform.test.tsx.snap
+++ b/public/pages/Transforms/containers/Transforms/__snapshots__/EditTransform.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`<EditTransform /> spec renders the component 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--medium"
         >
           Job name and description
@@ -33,7 +33,7 @@ exports[`<EditTransform /> spec renders the component 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr
@@ -159,7 +159,7 @@ exports[`<EditTransform /> spec renders the component 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--medium"
         >
           Indices
@@ -169,7 +169,7 @@ exports[`<EditTransform /> spec renders the component 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr
@@ -338,7 +338,7 @@ exports[`<EditTransform /> spec renders the component 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3
+        <h1
           class="euiTitle euiTitle--medium"
         >
           Schedule
@@ -348,7 +348,7 @@ exports[`<EditTransform /> spec renders the component 1`] = `
              
              
           </span>
-        </h3>
+        </h1>
       </div>
     </div>
     <hr

--- a/public/pages/VisualCreatePolicy/components/PolicyInfo/__snapshots__/PolicyInfo.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/PolicyInfo/__snapshots__/PolicyInfo.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<PolicyInfo /> spec renders the component 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h3
+      <h1
         class="euiTitle euiTitle--small"
       >
         Policy info
@@ -22,7 +22,7 @@ exports[`<PolicyInfo /> spec renders the component 1`] = `
            
            
         </span>
-      </h3>
+      </h1>
     </div>
   </div>
   <hr

--- a/public/pages/VisualCreatePolicy/components/States/__snapshots__/States.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/States/__snapshots__/States.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<States /> spec renders the component 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h3
+      <h1
         class="euiTitle euiTitle--small"
       >
         States (2)
@@ -22,7 +22,7 @@ exports[`<States /> spec renders the component 1`] = `
            
            
         </span>
-      </h3>
+      </h1>
       <div
         class="euiText euiText--small"
         style="padding: 5px 0px;"


### PR DESCRIPTION
### Description
Incorporate feel and look good guide changes for snapshots pages, datastreams, rollups and notification settings.

Note: Merge this PR after this PR from @AMoo-Miki is merged. https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1103

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
