### PR TITLE
Replace EuiButton to EuiSmallButton in repositories page

### DIFF
--- a/public/pages/Repositories/containers/Repositories/Repositories.tsx
+++ b/public/pages/Repositories/containers/Repositories/Repositories.tsx
@@ -268,7 +268,7 @@ export class Repositories extends MDSEnabledComponent<RepositoriesProps, Reposit
 
     const renderToolsLeft = () => {
       return [
-        <EuiButton
+        <EuiSmallButton
           iconType="trash"
           iconSide="left"
           iconSize="s"
@@ -277,11 +277,10 @@ export class Repositories extends MDSEnabledComponent<RepositoriesProps, Reposit
           data-test-subj="deleteButton"
           aria-label="delete"
           color="danger"
-          size="s"
           minWidth={75}
         >
           Delete
-        </EuiButton>,
+        </EuiSmallButton>,
       ];
     };
 


### PR DESCRIPTION
### Description
In the current implementation with this https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1103 change. We replaced all instances of EuiButtons to EuiSmallButton where explicitly size is not set. With this change we have removed the EuiButton import from the pages and that caused an issue for Snapshot Repositores page to render. In this PR i've changed the EuiButton instance to EuiSmallButton. 

### Issues Resolved


### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
