### PR TITLE
[Look & Feel] Consistency and Density Changes for Snapshot Management

### DIFF
--- a/public/pages/CreateSnapshotPolicy/components/SnapshotIndicesRepoInput/SnapshotIndicesRepoInput.tsx
+++ b/public/pages/CreateSnapshotPolicy/components/SnapshotIndicesRepoInput/SnapshotIndicesRepoInput.tsx
@@ -94,7 +94,7 @@ const SnapshotIndicesRepoInput = ({
 
         {showFlyout != null && (
           <EuiFlexItem grow={false}>
-            <EuiSmallButton onClick={openFlyout}>Create repository</EuiSmallButton>
+            <EuiSmallButton onClick={openFlyout} iconType="plus">Create repository</EuiSmallButton>
           </EuiFlexItem>
         )}
       </EuiFlexGroup>

--- a/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
+++ b/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
@@ -698,7 +698,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
               <EuiAccordion id="additional_delete_conditions" buttonContent="Additional settings">
                 <EuiSpacer size="m" />
 
-                <EuiText>Number of snapshots retained</EuiText>
+                <EuiText size="s">Number of snapshots retained</EuiText>
                 <EuiSpacer size="s" />
 
                 <EuiFlexGroup alignItems="flexStart">
@@ -726,7 +726,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
 
                 <EuiSpacer size="m" />
 
-                <EuiText>Deletion frequency</EuiText>
+                <EuiText size="s">Deletion frequency</EuiText>
                 <span style={{ color: "grey", fontWeight: 200, fontSize: "12px" }}>
                   Configure when to check retention conditions and delete snapshots.
                 </span>

--- a/public/pages/Reindex/components/CreateIndexFlyout/__snapshots__/CreateIndexFlyout.test.tsx.snap
+++ b/public/pages/Reindex/components/CreateIndexFlyout/__snapshots__/CreateIndexFlyout.test.tsx.snap
@@ -860,6 +860,7 @@ Object {
                   <span
                     class="euiButtonContent euiButton__content"
                   >
+                    EuiIconMock
                     <span
                       class="euiButton__text"
                     >

--- a/public/pages/Repositories/components/CreateRepositoryFlyout/CreateRepositoryFlyout.tsx
+++ b/public/pages/Repositories/components/CreateRepositoryFlyout/CreateRepositoryFlyout.tsx
@@ -231,13 +231,15 @@ export class CreateRepositoryFlyout extends MDSEnabledComponent<CreateRepository
       configuration = (
         <>
           <EuiCallOut title="Install and configure custom repository types">
-            <p>
-              To use a custom repository, such as Amazon S3, Azure Blob Storage or similar, install and configure the respective repository
-              plugin on OpenSearch and then define the repository configuration below.{" "}
-              <EuiLink href={REPOSITORY_DOCUMENTATION_URL} target="_blank" rel="noopener noreferrer">
-                Learn more
-              </EuiLink>
-            </p>
+            <EuiText size="s">
+              <p>
+                To use a custom repository, such as Amazon S3, Azure Blob Storage or similar, install and configure the respective repository
+                plugin on OpenSearch and then define the repository configuration below.{" "}
+                <EuiLink href={REPOSITORY_DOCUMENTATION_URL} target="_blank" rel="noopener noreferrer">
+                  Learn more
+                </EuiLink>
+              </p>
+            </EuiText>
           </EuiCallOut>
 
           <EuiSpacer size="s" />
@@ -272,7 +274,7 @@ export class CreateRepositoryFlyout extends MDSEnabledComponent<CreateRepository
     return (
       <EuiFlyout ownFocus={false} onClose={onCloseFlyout} maxWidth={600} size="m" hideCloseButton>
         <EuiFlyoutHeader hasBorder>
-          <EuiTitle size="m">
+          <EuiTitle size="s">
             <h2 id="flyoutTitle">{!!editRepo ? "Edit" : "Create"} repository</h2>
           </EuiTitle>
         </EuiFlyoutHeader>

--- a/public/pages/Repositories/containers/Repositories/Repositories.tsx
+++ b/public/pages/Repositories/containers/Repositories/Repositories.tsx
@@ -248,7 +248,7 @@ export class Repositories extends MDSEnabledComponent<RepositoriesProps, Reposit
       <EuiSmallButton disabled={!selectedItems.length} onClick={this.showDeleteModal} data-test-subj="deleteButton" color="danger">
         Delete
       </EuiSmallButton>,
-      <EuiSmallButton onClick={this.onClickCreate} fill={true}>
+      <EuiSmallButton onClick={this.onClickCreate} fill={true} iconType="plus">
         Create repository
       </EuiSmallButton>,
     ];
@@ -341,7 +341,13 @@ export class Repositories extends MDSEnabledComponent<RepositoriesProps, Reposit
 
     const { HeaderControl } = getNavigationUI();
     const { setAppRightControls, setAppDescriptionControls } = getApplication();
-    const useTitle = useNewUX ? undefined : "Repositories";
+    const useTitle = useNewUX 
+      ? undefined 
+      : (
+        <EuiText size="s">
+          <h1>Repositories</h1>
+        </EuiText>
+      );  
     const useActions = useNewUX ? undefined : actions;
     const useSubTitleText = useNewUX ? undefined : subTitleText;
 

--- a/public/pages/SnapshotPolicies/containers/SnapshotPolicies/SnapshotPolicies.tsx
+++ b/public/pages/SnapshotPolicies/containers/SnapshotPolicies/SnapshotPolicies.tsx
@@ -483,7 +483,7 @@ export class SnapshotPolicies extends MDSEnabledComponent<SnapshotPoliciesProps,
       >
         <EuiContextMenuPanel items={popoverActionItems} size="s" />
       </EuiPopover>,
-      <EuiSmallButton onClick={this.onClickCreate} fill={true}>
+      <EuiSmallButton onClick={this.onClickCreate} fill={true} iconType="plus">
         Create policy
       </EuiSmallButton>,
     ];
@@ -508,7 +508,7 @@ export class SnapshotPolicies extends MDSEnabledComponent<SnapshotPoliciesProps,
           </EuiText>
         }
         actions={
-          <EuiSmallButton onClick={this.onClickCreate} fill={true}>
+          <EuiSmallButton onClick={this.onClickCreate} fill={true} iconType="plus">
             Create policy
           </EuiSmallButton>
         }
@@ -569,7 +569,15 @@ export class SnapshotPolicies extends MDSEnabledComponent<SnapshotPoliciesProps,
 
     return !this.state.useNewUx ? (
       <>
-        <ContentPanel title="Snapshot policies" actions={actions} subTitleText={subTitleText}>
+        <ContentPanel 
+          title={
+            <EuiText size="s">
+              <h1>Snapshot policies</h1>
+            </EuiText>
+          }  
+          actions={actions} 
+          subTitleText={subTitleText}
+        >
           <EuiSearchBar
             box={{
               placeholder: "Search snapshot policies",

--- a/public/pages/Snapshots/containers/Snapshots/Snapshots.tsx
+++ b/public/pages/Snapshots/containers/Snapshots/Snapshots.tsx
@@ -574,7 +574,13 @@ export class Snapshots extends MDSEnabledComponent<SnapshotsProps, SnapshotsStat
 
     const { HeaderControl } = getNavigationUI();
     const { setAppRightControls, setAppDescriptionControls } = getApplication();
-    const showTitle = useNewUX ? undefined : "Snapshots";
+    const showTitle = useNewUX 
+      ? undefined 
+      : (
+        <EuiText size="s">
+          <h1>Snapshots</h1>
+        </EuiText>
+      );
     const SnapshotTabName = useNewUX ? "Index snapshots" : "Snapshots";
     const useActions = useNewUX ? undefined : actions;
     const useSubTitle = useNewUX ? undefined : subTitleText;

--- a/public/pages/VisualCreatePolicy/components/FlyoutFooter/FlyoutFooter.tsx
+++ b/public/pages/VisualCreatePolicy/components/FlyoutFooter/FlyoutFooter.tsx
@@ -36,7 +36,7 @@ const FlyoutFooter = ({
       </EuiSmallButtonEmpty>
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
-      <EuiSmallButton disabled={disabledAction} onClick={onClickAction} fill data-test-subj="flyout-footer-action-button">
+      <EuiSmallButton disabled={disabledAction} onClick={onClickAction} fill data-test-subj="flyout-footer-action-button" iconType={"Add" ? "plusInCircle" : "plus"}>
         {text ? text : restore ? "Restore snapshot" : !save ? `${edit ? "Edit" : "Add"} ${action}` : save ? "Save" : "Create"}
       </EuiSmallButton>
     </EuiFlexItem>

--- a/public/pages/VisualCreatePolicy/components/FlyoutFooter/__snapshots__/FlyoutFooter.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/FlyoutFooter/__snapshots__/FlyoutFooter.test.tsx.snap
@@ -34,6 +34,7 @@ exports[`<FlyoutFooter /> spec renders the component 1`] = `
       <span
         class="euiButtonContent euiButton__content"
       >
+        EuiIconMock
         <span
           class="euiButton__text"
         >


### PR DESCRIPTION
## Description

**Note that this PR only contains partial changes, and the other changes are made in https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1157**

This PR makes consistency and density improvements, including:

1. Using small font size as normal paragraph font size through 
2. Using semantic headers (H1s on main pages, H2s on modals/flyouts) wrapped under
3. Using Plus icons for create use cases and PlusInCricle icon for add use cases.

## Screenshots

### Standard Paragraph Text Size
|     Before        |       After        |
| ------------- | ------------- |
| <img width="300" alt="Screenshot 2024-08-28 at 8 13 50 PM" src="https://github.com/user-attachments/assets/257cd0f5-3ebf-441a-bd80-375daf5b3af1">  | <img width="300" alt="Screenshot 2024-08-28 at 8 14 29 PM" src="https://github.com/user-attachments/assets/febcbef1-0a87-419b-8603-6c3512fb094e"> |
| <img width="300" alt="Screenshot 2024-08-28 at 8 14 53 PM" src="https://github.com/user-attachments/assets/6857b218-5e92-4352-82ad-2275609efbac"> | <img width="300" alt="Screenshot 2024-08-28 at 8 15 16 PM" src="https://github.com/user-attachments/assets/1e9e9a3a-5c5a-4353-b19e-d50c9a2707a0"> |
| <img width="1129" alt="Screenshot 2024-08-28 at 8 15 46 PM" src="https://github.com/user-attachments/assets/8f715362-d125-4bd8-a3f1-4d27c6134a5f"> | <img width="1128" alt="Screenshot 2024-08-28 at 8 16 04 PM" src="https://github.com/user-attachments/assets/2ddeb66a-eeb2-476b-b253-a9b8c4295903"> | 

### Semantic Headers
|     Before        |       After        |
| ------------- | ------------- |
| <img width="1196" alt="Screenshot 2024-08-28 at 8 18 03 PM" src="https://github.com/user-attachments/assets/78848c0a-1c8d-4ce4-88a4-817831b9ad58"> | <img width="1202" alt="Screenshot 2024-08-28 at 8 18 14 PM" src="https://github.com/user-attachments/assets/bcef60d6-c901-4ffd-9b37-8e61d23a8fe3"> |
| <img width="1401" alt="Screenshot 2024-08-28 at 8 18 44 PM" src="https://github.com/user-attachments/assets/7a07c98b-ddf8-46a3-8d8c-cae251727619"> | <img width="1396" alt="Screenshot 2024-08-28 at 8 18 56 PM" src="https://github.com/user-attachments/assets/5399d24c-a821-45ac-ae1c-68c7cedc82a9"> |
| <img width="1399" alt="Screenshot 2024-08-28 at 8 19 24 PM" src="https://github.com/user-attachments/assets/2c64ad68-7e76-4a23-9f18-66fa87fd8f01"> | <img width="1400" alt="Screenshot 2024-08-28 at 8 19 39 PM" src="https://github.com/user-attachments/assets/70862c61-ddb8-4128-beb5-316c70b66147"> |
| <img width="1396" alt="Screenshot 2024-08-28 at 8 20 03 PM" src="https://github.com/user-attachments/assets/5c1f6ba5-92a5-4a54-941c-9e74dcb7fc3a"> | <img width="1399" alt="Screenshot 2024-08-28 at 8 20 14 PM" src="https://github.com/user-attachments/assets/ebe6d860-19f3-424e-bacc-da9ac6051ee7"> | 

### Plus Icon and PlusInCircle Icon
|     Before        |       After        |
| ------------- | ------------- |
| <img width="1397" alt="Screenshot 2024-08-28 at 8 21 03 PM" src="https://github.com/user-attachments/assets/7857c941-2014-4763-872e-2cda2fa0f742"> | <img width="1392" alt="Screenshot 2024-08-28 at 8 21 26 PM" src="https://github.com/user-attachments/assets/bf2f52db-3746-4840-a89d-e90c73b6b3c6"> |
| <img width="1303" alt="Screenshot 2024-08-28 at 8 21 46 PM" src="https://github.com/user-attachments/assets/d0633a33-c9a9-4ebb-b4d4-d151db43a409"> | <img width="1319" alt="Screenshot 2024-08-28 at 8 22 00 PM" src="https://github.com/user-attachments/assets/877b69cf-4877-4591-ad46-83caa4fce5b9"> | 
| <img width="1401" alt="Screenshot 2024-08-28 at 8 22 33 PM" src="https://github.com/user-attachments/assets/27578a87-2d6c-434b-ae23-ee8147de42b8"> | <img width="1397" alt="Screenshot 2024-08-28 at 8 22 51 PM" src="https://github.com/user-attachments/assets/cf4ec863-88d4-48de-978d-f63755bb5a76"> | 
| <img width="665" alt="Screenshot 2024-08-28 at 8 23 05 PM" src="https://github.com/user-attachments/assets/9c67603f-5b78-4e9e-8343-c6d817540ef0"> | <img width="665" alt="Screenshot 2024-08-28 at 8 23 20 PM" src="https://github.com/user-attachments/assets/a4a1c20e-9c3b-4d86-93ef-eb4c66642398"> | 
| <img width="1400" alt="Screenshot 2024-08-28 at 8 23 41 PM" src="https://github.com/user-attachments/assets/ece17ab6-5d23-4e18-94c0-f695d607f022"> | <img width="1401" alt="Screenshot 2024-08-28 at 8 23 56 PM" src="https://github.com/user-attachments/assets/c1d5aac4-35ce-4247-906d-422ef3131f68"> | 
| <img width="1398" alt="Screenshot 2024-08-28 at 8 24 12 PM" src="https://github.com/user-attachments/assets/4fb9dba9-436b-4a9d-8c62-35fb3343603b"> | <img width="1400" alt="Screenshot 2024-08-28 at 8 24 30 PM" src="https://github.com/user-attachments/assets/ac79ad19-04a6-4ef7-b377-c52fbd97e801"> | 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
