### PR TITLE
Updated active maintainers.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @amsiglan @AWSHurneyt @bowenlan-amzn @getsaurabh02 @praveensameneni @xluo-aws @gaobinlong @Hailong-am @SuZhou-Joe @lezzago @sbcd90 @eirsep @r1walz @vikasvb90
+*   @bowenlan-amzn @Hailong-am @RamakrishnaChilaka @vikasvb90 @SuZhou-Joe

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,26 +4,26 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer            | GitHub ID                                             | Affiliation |
-|-----------------------| ----------------------------------------------------- | ----------- |
-| Bowen Lan             | [bowenlan-amzn](https://github.com/bowenlan-amzn)     | Amazon      |
-| Saurabh Singh         | [getsaurabh02](https://github.com/getsaurabh02)       | Amazon      |
-| Praveen Sameneni      | [praveensameneni](https://github.com/praveensameneni) | Amazon      |
-| Xuesong Luo           | [xluo-aws](https://github.com/xluo-aws)               | Amazon      |
-| Hailong Cui           | [Hailong-am](https://github.com/Hailong-am)           | Amazon      |
-| Binlong Gao           | [gaobinlong](https://github.com/gaobinlong)           | Amazon      |
-| Zhou Su               | [SuZhou-Joe](https://github.com/SuZhou-Joe)           | Amazon      |
-| Amardeepsingh Siglani | [amsiglan](https://github.com/amsiglan)               | Amazon      |
-| Thomas Hurney         | [AWSHurneyt](https://github.com/AWSHurneyt)           | Amazon      |
-| Ashish Agrawal        | [lezzago](https://github.com/lezzago)                 | Amazon      |
-| Subhobrata DEY        | [sbcd90](https://github.com/sbcd90)                   | Amazon      |
-| Surya Sashank Nistala | [eirsep](https://github.com/eirsep)                   | Amazon      |
-| Rohit Ashiwal         | [r1walz](https://github.com/r1walz)                   | Amazon      |
-| Vikas Bansal          | [vikasvb90](https://github.com/vikasvb90)             | Amazon      |
-| Ramakrishna Chilaka   | [RamakrishnaChilaka](https://github.com/RamakrishnaChilaka)             | Amazon      |
+| Maintainer            | GitHub ID                                                    | Affiliation |
+|-----------------------| ------------------------------------------------------------ | ----------- |
+| Bowen Lan             | [bowenlan-amzn](https://github.com/bowenlan-amzn)            | Amazon      |
+| Hailong Cui           | [Hailong-am](https://github.com/Hailong-am)                  | Amazon      |
+| Ramakrishna Chilaka   | [RamakrishnaChilaka](https://github.com/RamakrishnaChilaka)  | Amazon      |
+| Vikas Bansal          | [vikasvb90](https://github.com/vikasvb90)                    | Amazon      |
+| Zhou Su               | [SuZhou-Joe](https://github.com/SuZhou-Joe)                  | Amazon      |
 
 ## Emeritus
 
-| Maintainer    | GitHub ID                                     | Affiliation |
-| ------------- | --------------------------------------------- | ----------- |
-| Angie Zhang   | [Angie-Zhang](https://github.com/Angie-Zhang) | Amazon      |
+| Maintainer            | GitHub ID                                             | Affiliation |
+| --------------------- | ----------------------------------------------------- | ----------- |
+| Amardeepsingh Siglani | [amsiglan](https://github.com/amsiglan)               | Amazon      |
+| Angie Zhang           | [Angie-Zhang](https://github.com/Angie-Zhang)         | Amazon      |
+| Ashish Agrawal        | [lezzago](https://github.com/lezzago)                 | Amazon      |
+| Binlong Gao           | [gaobinlong](https://github.com/gaobinlong)           | Amazon      |
+| Praveen Sameneni      | [praveensameneni](https://github.com/praveensameneni) | Amazon      |
+| Rohit Ashiwal         | [r1walz](https://github.com/r1walz)                   | Amazon      |
+| Saurabh Singh         | [getsaurabh02](https://github.com/getsaurabh02)       | Amazon      |
+| Subhobrata DEY        | [sbcd90](https://github.com/sbcd90)                   | Amazon      |
+| Surya Sashank Nistala | [eirsep](https://github.com/eirsep)                   | Amazon      |
+| Thomas Hurney         | [AWSHurneyt](https://github.com/AWSHurneyt)           | Amazon      |
+| Xuesong Luo           | [xluo-aws](https://github.com/xluo-aws)               | Amazon      |


### PR DESCRIPTION
### Description

In https://github.com/opensearch-project/index-management/issues/1230 I asked ISM maintainers whether they are actively maintaining the plugin. Many also said they are not maintaining the dashboards plugin. Moved them to emeritus.

If any of the remaining folks @bowenlan-amzn @Hailong-am @RamakrishnaChilaka @vikasvb90 @SuZhou-Joe need to move please lmk!

It also looks like the addition of @RamakrishnaChilaka didn't include an update to CODEOWNERS and permissions were not adjusted. I can take care of it after this is merged.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
