### PR TITLE
[Look&Feel] Consistency and density improvements

### DIFF
--- a/public/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/public/components/ConfirmationModal/ConfirmationModal.tsx
@@ -13,6 +13,7 @@ import {
   EuiModalHeaderTitle,
   EuiOverlayMask,
   EuiButtonEmpty,
+  EuiText,
   // @ts-ignore
 } from "@elastic/eui";
 
@@ -41,7 +42,11 @@ const ConfirmationModal: React.SFC<ConfirmationModalProps> = ({
       // @ts-ignore */}
       <EuiModal onCancel={onClose} onClose={onClose} maxWidth={1000} {...modalProps}>
         <EuiModalHeader>
-          <EuiModalHeaderTitle>{title}</EuiModalHeaderTitle>
+          <EuiModalHeaderTitle>
+            <EuiText size="s">
+              <h2>{title}</h2>
+            </EuiText>
+          </EuiModalHeaderTitle>
         </EuiModalHeader>
 
         <EuiModalBody>{bodyMessage}</EuiModalBody>

--- a/public/components/CreatePolicyModal/CreatePolicyModal.tsx
+++ b/public/components/CreatePolicyModal/CreatePolicyModal.tsx
@@ -35,7 +35,11 @@ const CreatePolicyModal: React.SFC<CreatePolicyModalProps> = ({ isEdit = false, 
       // @ts-ignore */}
       <EuiModal onCancel={onClose} onClose={onClose} maxWidth={600}>
         <EuiModalHeader>
-          <EuiModalHeaderTitle>Configuration method</EuiModalHeaderTitle>
+          <EuiModalHeaderTitle>
+            <EuiText size="s">
+              <h2>Configuration method</h2>
+            </EuiText>
+          </EuiModalHeaderTitle>
         </EuiModalHeader>
 
         <EuiModalBody>

--- a/public/components/JSONModal/JSONModal.tsx
+++ b/public/components/JSONModal/JSONModal.tsx
@@ -13,6 +13,7 @@ import {
   EuiOverlayMask,
   EuiCodeBlock,
   EuiButtonEmpty,
+  EuiText,
 } from "@elastic/eui";
 
 interface JSONModalProps {
@@ -26,7 +27,11 @@ const JSONModal: React.SFC<JSONModalProps> = ({ title, json, onClose }) => {
     <EuiOverlayMask>
       <EuiModal onClose={onClose}>
         <EuiModalHeader>
-          <EuiModalHeaderTitle>{title}</EuiModalHeaderTitle>
+          <EuiModalHeaderTitle>
+            <EuiText size="s">
+              <h2>{title}</h2>
+            </EuiText>
+          </EuiModalHeaderTitle>
         </EuiModalHeader>
 
         <EuiModalBody>

--- a/public/containers/ClearCacheModal/ClearCacheModal.tsx
+++ b/public/containers/ClearCacheModal/ClearCacheModal.tsx
@@ -177,12 +177,14 @@ export default function ClearCacheModal(props: ClearCacheModalProps) {
       <div style={{ lineHeight: 1.5 }}>
         {unBlockedItems.length > 0 && (
           <>
-            <p>{hint}</p>
-            <ul style={{ listStyleType: "disc", listStylePosition: "inside" }}>
-              {unBlockedItems.map((item) => (
-                <li key={item}>{item}</li>
-              ))}
-            </ul>
+            <EuiText size="s">
+              {hint}
+              <ul style={{ listStyleType: "disc", listStylePosition: "inside" }}>
+                {unBlockedItems.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </EuiText>
             <EuiSpacer />
           </>
         )}
@@ -201,7 +203,7 @@ export default function ClearCacheModal(props: ClearCacheModalProps) {
   const noSpecificIndexesChildren: React.ReactChild = (
     <>
       <div style={{ lineHeight: 1.5 }}>
-        <p>Cache will be cleared for all open indexes.</p>
+        <EuiText size="s">Cache will be cleared for all open indexes.</EuiText>
         <EuiSpacer />
       </div>
     </>
@@ -217,9 +219,7 @@ export default function ClearCacheModal(props: ClearCacheModalProps) {
         </EuiModalHeaderTitle>
       </EuiModalHeader>
 
-      <EuiModalBody>
-        <EuiText size="s">{!!selectedItems && selectedItems.length > 0 ? specificIndexesChildren : noSpecificIndexesChildren}</EuiText>
-      </EuiModalBody>
+      <EuiModalBody>{!!selectedItems && selectedItems.length > 0 ? specificIndexesChildren : noSpecificIndexesChildren}</EuiModalBody>
 
       <EuiModalFooter>
         <EuiButtonEmpty data-test-subj="ClearCacheCancelButton" onClick={onClose}>

--- a/public/containers/ClearCacheModal/ClearCacheModal.tsx
+++ b/public/containers/ClearCacheModal/ClearCacheModal.tsx
@@ -21,6 +21,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiSpacer,
+  EuiText,
 } from "@elastic/eui";
 
 export interface ClearCacheModalProps {
@@ -209,10 +210,16 @@ export default function ClearCacheModal(props: ClearCacheModalProps) {
   return (
     <EuiModal onClose={onClose}>
       <EuiModalHeader>
-        <EuiModalHeaderTitle>Clear cache for {type}</EuiModalHeaderTitle>
+        <EuiModalHeaderTitle>
+          <EuiText size="s">
+            <h2>Clear cache for {type}</h2>
+          </EuiText>
+        </EuiModalHeaderTitle>
       </EuiModalHeader>
 
-      <EuiModalBody>{!!selectedItems && selectedItems.length > 0 ? specificIndexesChildren : noSpecificIndexesChildren}</EuiModalBody>
+      <EuiModalBody>
+        <EuiText size="s">{!!selectedItems && selectedItems.length > 0 ? specificIndexesChildren : noSpecificIndexesChildren}</EuiText>
+      </EuiModalBody>
 
       <EuiModalFooter>
         <EuiButtonEmpty data-test-subj="ClearCacheCancelButton" onClick={onClose}>

--- a/public/containers/FlushIndexModal/FlushIndexModal.tsx
+++ b/public/containers/FlushIndexModal/FlushIndexModal.tsx
@@ -167,20 +167,18 @@ export default function FlushIndexModal(props: FlushIndexModalProps) {
 
       <EuiModalBody>
         <div style={{ lineHeight: 1.5 }}>
-          <EuiText size="s">
-            {/* we will not display this part if not flushAll and there is no flushable items */}
-            {flushAll && <p>{flushAllMessage}</p>}
-            {!!unBlockedItems.length && (
-              <>
-                {`The following ${flushTarget} will be flushed:`}
-                <ul style={{ listStyleType: "disc", listStylePosition: "inside" }}>
-                  {unBlockedItems.map((item) => (
-                    <li key={item}>{item}</li>
-                  ))}
-                </ul>
-              </>
-            )}
-          </EuiText>
+          {/* we will not display this part if not flushAll and there is no flushable items */}
+          {flushAll && <EuiText size="s">{flushAllMessage}</EuiText>}
+          {!!unBlockedItems.length && (
+            <EuiText size="s">
+              {`The following ${flushTarget} will be flushed:`}
+              <ul style={{ listStyleType: "disc", listStylePosition: "inside" }}>
+                {unBlockedItems.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </EuiText>
+          )}
           <EuiSpacer />
           <EuiCallOut data-test-subj="flushBlockedCallout" color="warning" size="s" hidden={!blockedItems.length}>
             <p>{blockedItemsMessageTemplate(flushTarget)}</p>

--- a/public/containers/FlushIndexModal/FlushIndexModal.tsx
+++ b/public/containers/FlushIndexModal/FlushIndexModal.tsx
@@ -14,6 +14,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiSpacer,
+  EuiText,
 } from "@elastic/eui";
 import { CoreStart } from "opensearch-dashboards/public";
 import { CoreServicesContext } from "../../components/core_services";
@@ -157,23 +158,29 @@ export default function FlushIndexModal(props: FlushIndexModalProps) {
   return (
     <EuiModal onClose={onClose}>
       <EuiModalHeader>
-        <EuiModalHeaderTitle data-test-subj="flushModalTitle">Flush {flushTarget}</EuiModalHeaderTitle>
+        <EuiModalHeaderTitle data-test-subj="flushModalTitle">
+          <EuiText size="s">
+            <h2>Flush {flushTarget}</h2>
+          </EuiText>
+        </EuiModalHeaderTitle>
       </EuiModalHeader>
 
       <EuiModalBody>
         <div style={{ lineHeight: 1.5 }}>
-          {/* we will not display this part if not flushAll and there is no flushable items */}
-          {flushAll && <p>{flushAllMessage}</p>}
-          {!!unBlockedItems.length && (
-            <>
-              <p>{`The following ${flushTarget} will be flushed:`}</p>
-              <ul style={{ listStyleType: "disc", listStylePosition: "inside" }}>
-                {unBlockedItems.map((item) => (
-                  <li key={item}>{item}</li>
-                ))}
-              </ul>
-            </>
-          )}
+          <EuiText size="s">
+            {/* we will not display this part if not flushAll and there is no flushable items */}
+            {flushAll && <p>{flushAllMessage}</p>}
+            {!!unBlockedItems.length && (
+              <>
+                {`The following ${flushTarget} will be flushed:`}
+                <ul style={{ listStyleType: "disc", listStylePosition: "inside" }}>
+                  {unBlockedItems.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </>
+            )}
+          </EuiText>
           <EuiSpacer />
           <EuiCallOut data-test-subj="flushBlockedCallout" color="warning" size="s" hidden={!blockedItems.length}>
             <p>{blockedItemsMessageTemplate(flushTarget)}</p>

--- a/public/containers/RefreshAction/index.tsx
+++ b/public/containers/RefreshAction/index.tsx
@@ -14,6 +14,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiSpacer,
+  EuiText,
 } from "@elastic/eui";
 import { CoreStart } from "opensearch-dashboards/public";
 import { ServicesContext } from "../../services";
@@ -167,19 +168,23 @@ export default function RefreshActionModal<T>(props: RefreshActionModalProps) {
   return (
     <EuiModal onClose={onClose}>
       <EuiModalHeader>
-        <EuiModalHeaderTitle>Refresh {type}</EuiModalHeaderTitle>
+        <EuiModalHeaderTitle>
+          <EuiText size="s">
+            <h2>Refresh {type}</h2>
+          </EuiText>
+        </EuiModalHeaderTitle>
       </EuiModalHeader>
 
       <EuiModalBody>
         <div style={{ lineHeight: 1.5 }}>
           {selectedItems.length === 0 && blockedItems.length === 0 && (
             <>
-              <p>All open indexes will be refreshed.</p>
+              <EuiText size="s">All open indexes will be refreshed.</EuiText>
             </>
           )}
           {!!unBlockedItems.length && (
-            <>
-              <p>{unblockedWording} will be refreshed.</p>
+            <EuiText size="s">
+              {unblockedWording} will be refreshed.
               <ul style={{ listStyleType: "disc", listStylePosition: "inside" }}>
                 {unBlockedItems.map((item) => (
                   <li key={item} data-test-subj={`UnblockedItem-${item}`}>
@@ -187,7 +192,7 @@ export default function RefreshActionModal<T>(props: RefreshActionModalProps) {
                   </li>
                 ))}
               </ul>
-            </>
+            </EuiText>
           )}
           <EuiSpacer />
           {!!blockedItems.length && (

--- a/public/pages/ChangePolicy/containers/ChangePolicy/ChangePolicy.tsx
+++ b/public/pages/ChangePolicy/containers/ChangePolicy/ChangePolicy.tsx
@@ -5,7 +5,7 @@
 
 import React, { Component, useContext } from "react";
 import { RouteComponentProps } from "react-router-dom";
-import { EuiSpacer, EuiTitle, EuiButton, EuiFlexGroup, EuiFlexItem, EuiButtonEmpty } from "@elastic/eui";
+import { EuiSpacer, EuiText, EuiButton, EuiFlexGroup, EuiFlexItem, EuiButtonEmpty } from "@elastic/eui";
 import { IndexService, ManagedIndexService } from "../../../../services";
 import ChangeManagedIndices from "../../components/ChangeManagedIndices";
 import NewPolicy from "../../components/NewPolicy";
@@ -156,9 +156,9 @@ export class ChangePolicy extends Component<ChangePolicyProps, ChangePolicyState
 
     return (
       <div style={{ padding: "0px 25px" }}>
-        <EuiTitle size="l">
+        <EuiText size="s">
           <h1>Change policy</h1>
-        </EuiTitle>
+        </EuiText>
 
         <EuiSpacer />
 

--- a/public/pages/CreateIndex/containers/CreateIndex/CreateIndex.tsx
+++ b/public/pages/CreateIndex/containers/CreateIndex/CreateIndex.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { Component, useContext } from "react";
-import { EuiSpacer, EuiTitle } from "@elastic/eui";
+import { EuiSpacer, EuiText } from "@elastic/eui";
 import { RouteComponentProps } from "react-router-dom";
 import IndexForm from "../IndexForm";
 import { BREADCRUMBS, IndicesUpdateMode, ROUTES } from "../../../../utils/constants";
@@ -47,9 +47,9 @@ export class CreateIndex extends Component<CreateIndexProps> {
 
     return (
       <div style={{ padding: "0px 50px" }}>
-        <EuiTitle size="l">
+        <EuiText size="s">
           <h1>{isEdit ? "Edit" : "Create"} index</h1>
-        </EuiTitle>
+        </EuiText>
         <EuiSpacer />
         <IndexForm
           index={this.index}

--- a/public/pages/CreatePolicy/containers/CreatePolicy/CreatePolicy.tsx
+++ b/public/pages/CreatePolicy/containers/CreatePolicy/CreatePolicy.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, Component, Fragment, useContext } from "react";
-import { EuiSpacer, EuiTitle, EuiFlexGroup, EuiFlexItem, EuiButton, EuiButtonEmpty, EuiCallOut, EuiLink, EuiIcon } from "@elastic/eui";
+import { EuiSpacer, EuiFlexGroup, EuiFlexItem, EuiButton, EuiButtonEmpty, EuiCallOut, EuiLink, EuiIcon, EuiText } from "@elastic/eui";
 import queryString from "query-string";
 import { RouteComponentProps } from "react-router-dom";
 import { DEFAULT_POLICY } from "../../utils/constants";
@@ -235,9 +235,9 @@ export class CreatePolicy extends Component<CreatePolicyProps, CreatePolicyState
 
     return (
       <div style={{ padding: "25px 50px" }}>
-        <EuiTitle size="l">
+        <EuiText size="s">
           <h1>{isEdit ? "Edit" : "Create"} policy</h1>
-        </EuiTitle>
+        </EuiText>
         <EuiSpacer />
         {this.renderEditCallOut()}
         <ConfigurePolicy policyId={policyId} policyIdError={policyIdError} isEdit={isEdit} onChange={this.onChange} />

--- a/public/pages/DataStreams/containers/DataStreams/DataStreams.tsx
+++ b/public/pages/DataStreams/containers/DataStreams/DataStreams.tsx
@@ -385,7 +385,7 @@ class DataStreams extends MDSEnabledComponent<DataStreamsProps, DataStreamsState
             ) ? (
               <EuiEmptyPrompt
                 body={
-                  <EuiText>
+                  <EuiText size="s">
                     <p>You have no data streams.</p>
                   </EuiText>
                 }
@@ -403,7 +403,7 @@ class DataStreams extends MDSEnabledComponent<DataStreamsProps, DataStreamsState
             ) : (
               <EuiEmptyPrompt
                 body={
-                  <EuiText>
+                  <EuiText size="s">
                     <p>There are no data streams matching your applied filters. Reset your filters to view your data streams.</p>
                   </EuiText>
                 }

--- a/public/pages/DataStreams/containers/DataStreamsActions/index.tsx
+++ b/public/pages/DataStreams/containers/DataStreamsActions/index.tsx
@@ -61,6 +61,7 @@ export default function DataStreamsActions(props: DataStreamsActionsProps) {
           // The EuiContextMenu has bug when testing in jest
           // the props change won't make it rerender
           key={renderKey}
+          size="s"
           panels={[
             {
               id: 0,

--- a/public/pages/ForceMerge/container/ForceMerge/ForceMerge.tsx
+++ b/public/pages/ForceMerge/container/ForceMerge/ForceMerge.tsx
@@ -3,7 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButton, EuiButtonEmpty, EuiButtonIcon, EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from "@elastic/eui";
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from "@elastic/eui";
 import React, { useContext, useEffect, useRef, useState } from "react";
 import { RouteComponentProps } from "react-router-dom";
 import { CoreStart } from "opensearch-dashboards/public";
@@ -166,9 +176,9 @@ export default function ForceMergeWrapper(props: Omit<ForceMergeProps, "services
 
   return (
     <div style={{ padding: "0px 50px" }}>
-      <EuiTitle size="l">
+      <EuiText size="s">
         <h1>Force merge</h1>
-      </EuiTitle>
+      </EuiText>
       <CustomFormRow
         fullWidth
         helpText="Manually merge shards of indexes or backing indexes of data streams. You can also use force merge to clear up deleted documents within indexes."

--- a/public/pages/IndexDetail/containers/IndexDetail/IndexDetail.tsx
+++ b/public/pages/IndexDetail/containers/IndexDetail/IndexDetail.tsx
@@ -285,6 +285,7 @@ export default function IndexDetail(props: IndexDetailModalProps) {
       <EuiSpacer />
       <EuiTabbedContent
         selectedTab={selectedTab}
+        size="s"
         onTabClick={(tab) => {
           if (ref.current?.hasUnsavedChanges?.(selectedTab.mode)) {
             Modal.show({

--- a/public/pages/Indices/components/ApplyPolicyModal/ApplyPolicyModal.tsx
+++ b/public/pages/Indices/components/ApplyPolicyModal/ApplyPolicyModal.tsx
@@ -283,11 +283,15 @@ export default class ApplyPolicyModal extends Component<ApplyPolicyModalProps, A
             // @ts-ignore */}
         <EuiModal onCancel={onClose} onClose={onClose}>
           <EuiModalHeader>
-            <EuiModalHeaderTitle>Apply policy</EuiModalHeaderTitle>
+            <EuiModalHeaderTitle>
+              <EuiText size="s">
+                <h2>Apply policy</h2>
+              </EuiText>
+            </EuiModalHeaderTitle>
           </EuiModalHeader>
 
           <EuiModalBody>
-            <EuiText size="xs" grow={false}>
+            <EuiText size="s" grow={false}>
               <p>
                 Choose the policy you want to use for the selected indices. A copy of the policy will be created and applied to the indices.
               </p>

--- a/public/pages/Indices/components/CloseIndexModal/CloseIndexModal.tsx
+++ b/public/pages/Indices/components/CloseIndexModal/CloseIndexModal.tsx
@@ -44,7 +44,11 @@ export default function CloseIndexModal(props: CloseIndexModalProps) {
   return (
     <EuiModal onClose={onClose}>
       <EuiModalHeader>
-        <EuiModalHeaderTitle>Close indexes</EuiModalHeaderTitle>
+        <EuiModalHeaderTitle>
+          <EuiText size="s">
+            <h2>Close indexes</h2>
+          </EuiText>
+        </EuiModalHeaderTitle>
       </EuiModalHeader>
 
       <EuiModalBody>
@@ -55,12 +59,14 @@ export default function CloseIndexModal(props: CloseIndexModalProps) {
           <EuiSpacer />
         </>
         <div style={{ lineHeight: 1.5 }}>
-          <p>The following index will be closed. It is not possible to index documents or to search for documents in a closed index.</p>
-          <ul style={{ listStyleType: "disc", listStylePosition: "inside" }}>
-            {selectedItems.map((item) => (
-              <li key={item}>{item}</li>
-            ))}
-          </ul>
+          <EuiText size="s">
+            The following index will be closed. It is not possible to index documents or to search for documents in a closed index.
+            <ul style={{ listStyleType: "disc", listStylePosition: "inside" }}>
+              {selectedItems.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </EuiText>
           <EuiSpacer />
           <EuiText color="subdued">
             To confirm your action, type <b style={{ color: "#000" }}>close</b>.

--- a/public/pages/Indices/components/DeleteIndexModal/DeleteIndexModal.tsx
+++ b/public/pages/Indices/components/DeleteIndexModal/DeleteIndexModal.tsx
@@ -44,7 +44,11 @@ export default function DeleteIndexModal(props: DeleteIndexModalProps) {
   return (
     <EuiModal onClose={onClose}>
       <EuiModalHeader>
-        <EuiModalHeaderTitle>Delete indexes</EuiModalHeaderTitle>
+        <EuiModalHeaderTitle>
+          <EuiText size="s">
+            <h2>Delete indexes</h2>
+          </EuiText>
+        </EuiModalHeaderTitle>
       </EuiModalHeader>
 
       <EuiModalBody>
@@ -57,14 +61,16 @@ export default function DeleteIndexModal(props: DeleteIndexModalProps) {
           </>
         ) : null}
         <div style={{ lineHeight: 1.5 }}>
-          <p>The following index will be permanently deleted. This action cannot be undone.</p>
-          <ul style={{ listStyleType: "disc", listStylePosition: "inside" }}>
-            {selectedItems.map((item) => (
-              <li key={item}>{item}</li>
-            ))}
-          </ul>
+          <EuiText size="s">
+            The following index will be permanently deleted. This action cannot be undone.
+            <ul style={{ listStyleType: "disc", listStylePosition: "inside" }}>
+              {selectedItems.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </EuiText>
           <EuiSpacer />
-          <EuiText color="subdued">
+          <EuiText color="subdued" size="s">
             To confirm your action, type <b style={{ color: "#000" }}>delete</b>.
           </EuiText>
           <EuiFieldText placeholder="delete" fullWidth value={value} onChange={(e) => setValue(e.target.value)} />

--- a/public/pages/Indices/components/IndexEmptyPrompt/IndexEmptyPrompt.tsx
+++ b/public/pages/Indices/components/IndexEmptyPrompt/IndexEmptyPrompt.tsx
@@ -40,11 +40,11 @@ interface IndexEmptyPromptProps {
   resetFilters: () => void;
 }
 
-const IndexEmptyPrompt: React.SFC<IndexEmptyPromptProps> = props => (
+const IndexEmptyPrompt: React.SFC<IndexEmptyPromptProps> = (props) => (
   <EuiEmptyPrompt
     style={{ maxWidth: "45em" }}
     body={
-      <EuiText>
+      <EuiText size="s">
         <p>{getMessagePrompt(props)}</p>
       </EuiText>
     }

--- a/public/pages/Indices/components/OpenIndexModal/OpenIndexModal.tsx
+++ b/public/pages/Indices/components/OpenIndexModal/OpenIndexModal.tsx
@@ -40,17 +40,17 @@ export default function OpenIndexModal(props: OpenIndexModalProps) {
       </EuiModalHeader>
 
       <EuiModalBody>
-        <EuiText size="s">
-          <div style={{ lineHeight: 1.5 }}>
+        <div style={{ lineHeight: 1.5 }}>
+          <EuiText size="s">
             The following index will be opened.
             <ul style={{ listStyleType: "disc", listStylePosition: "inside" }}>
               {selectedItems.map((item) => (
                 <li key={item}>{item}</li>
               ))}
             </ul>
-            <EuiSpacer />
-          </div>
-        </EuiText>
+          </EuiText>
+          <EuiSpacer />
+        </div>
       </EuiModalBody>
 
       <EuiModalFooter>

--- a/public/pages/Indices/components/OpenIndexModal/OpenIndexModal.tsx
+++ b/public/pages/Indices/components/OpenIndexModal/OpenIndexModal.tsx
@@ -13,6 +13,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiSpacer,
+  EuiText,
 } from "@elastic/eui";
 
 interface OpenIndexModalProps {
@@ -31,19 +32,25 @@ export default function OpenIndexModal(props: OpenIndexModalProps) {
   return (
     <EuiModal onClose={onClose}>
       <EuiModalHeader>
-        <EuiModalHeaderTitle>Open indexes</EuiModalHeaderTitle>
+        <EuiModalHeaderTitle>
+          <EuiText size="s">
+            <h2>Open indexes</h2>
+          </EuiText>
+        </EuiModalHeaderTitle>
       </EuiModalHeader>
 
       <EuiModalBody>
-        <div style={{ lineHeight: 1.5 }}>
-          <p>The following index will be opened.</p>
-          <ul style={{ listStyleType: "disc", listStylePosition: "inside" }}>
-            {selectedItems.map((item) => (
-              <li key={item}>{item}</li>
-            ))}
-          </ul>
-          <EuiSpacer />
-        </div>
+        <EuiText size="s">
+          <div style={{ lineHeight: 1.5 }}>
+            The following index will be opened.
+            <ul style={{ listStyleType: "disc", listStylePosition: "inside" }}>
+              {selectedItems.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+            <EuiSpacer />
+          </div>
+        </EuiText>
       </EuiModalBody>
 
       <EuiModalFooter>

--- a/public/pages/Indices/containers/IndicesActions/index.tsx
+++ b/public/pages/Indices/containers/IndicesActions/index.tsx
@@ -143,6 +143,7 @@ export default function IndicesActions(props: IndicesActionsProps) {
               initialPanelId={0}
               // The EuiContextMenu has bug when testing in jest
               // the props change won't make it rerender
+              size="s"
               key={renderKey}
               panels={[
                 {

--- a/public/pages/ManagedIndices/components/ManagedIndexEmptyPrompt/ManagedIndexEmptyPrompt.tsx
+++ b/public/pages/ManagedIndices/components/ManagedIndexEmptyPrompt/ManagedIndexEmptyPrompt.tsx
@@ -59,7 +59,7 @@ const ManagedIndexEmptyPrompt: React.SFC<ManagedIndexEmptyPromptProps> = (props)
   <EuiEmptyPrompt
     style={{ maxWidth: "45em" }}
     body={
-      <EuiText>
+      <EuiText size="s">
         <p>{getMessagePrompt(props)}</p>
       </EuiText>
     }

--- a/public/pages/Policies/components/PolicyEmptyPrompt/PolicyEmptyPrompt.tsx
+++ b/public/pages/Policies/components/PolicyEmptyPrompt/PolicyEmptyPrompt.tsx
@@ -59,7 +59,7 @@ const PolicyEmptyPrompt: React.SFC<PolicyEmptyPromptProps> = (props) => (
   <EuiEmptyPrompt
     style={{ maxWidth: "45em" }}
     body={
-      <EuiText>
+      <EuiText size="s">
         <p>{getMessagePrompt(props)}</p>
       </EuiText>
     }

--- a/public/pages/PolicyDetails/components/DeleteModal/DeleteModal.tsx
+++ b/public/pages/PolicyDetails/components/DeleteModal/DeleteModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, Component, Fragment } from "react";
-import { EuiConfirmModal, EuiForm, EuiFormRow, EuiFieldText, EuiOverlayMask, EuiSpacer } from "@elastic/eui";
+import { EuiConfirmModal, EuiForm, EuiFormRow, EuiFieldText, EuiOverlayMask, EuiSpacer, EuiText } from "@elastic/eui";
 
 interface DeleteModalProps {
   policyId: string;
@@ -41,7 +41,9 @@ export default class DeleteModal extends Component<DeleteModalProps, DeleteModal
         >
           <EuiForm>
             <Fragment>
-              Delete "<strong>{policyId}</strong>" permanently? Indices will no longer be managed using this policy.
+              <EuiText size="s">
+                Delete "<strong>{policyId}</strong>" permanently? Indices will no longer be managed using this policy.
+              </EuiText>
             </Fragment>
             <EuiSpacer size="s" />
             <EuiFormRow helpText={`To confirm deletion, type "delete".`}>

--- a/public/pages/Reindex/container/Reindex/Reindex.tsx
+++ b/public/pages/Reindex/container/Reindex/Reindex.tsx
@@ -555,9 +555,9 @@ class Reindex extends Component<ReindexProps, ReindexState> {
 
     return (
       <div style={{ padding: "0px 50px" }}>
-        <EuiTitle size="l">
+        <EuiText size="s">
           <h1>Reindex</h1>
-        </EuiTitle>
+        </EuiText>
         {subTitleText}
         <EuiSpacer />
 

--- a/public/pages/SplitIndex/container/SplitIndex/SplitIndex.tsx
+++ b/public/pages/SplitIndex/container/SplitIndex/SplitIndex.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React, { Component, useContext } from "react";
-import { EuiCallOut, EuiSpacer, EuiTitle, EuiButton, EuiLink, EuiFormRow } from "@elastic/eui";
+import { EuiCallOut, EuiSpacer, EuiText, EuiButton, EuiLink, EuiFormRow } from "@elastic/eui";
 import { get } from "lodash";
 
 import { CatIndex } from "../../../../../server/models/interfaces";
@@ -221,9 +221,9 @@ export class SplitIndex extends Component<SplitIndexProps> {
     const { sourceIndex, splitIndexFlyoutVisible, reasons, shardsSelectOptions } = this.state;
     return (
       <div style={{ padding: "0px 50px" }}>
-        <EuiTitle>
+        <EuiText size="s">
           <h1>Split index</h1>
-        </EuiTitle>
+        </EuiText>
 
         <EuiFormRow
           fullWidth

--- a/public/pages/VisualCreatePolicy/components/ISMTemplates/ISMTemplates.tsx
+++ b/public/pages/VisualCreatePolicy/components/ISMTemplates/ISMTemplates.tsx
@@ -106,10 +106,12 @@ const ISMTemplates = ({ policy, onChangePolicy }: ISMTemplatesProps) => {
             style={{ maxWidth: "37em" }}
             titleSize="s"
             body={
-              <p>
-                Your policy currently has no ISM templates defined. Add ISM templates to automatically apply the policy to indices created
-                in the future.
-              </p>
+              <EuiText size="s">
+                <p>
+                  Your policy currently has no ISM templates defined. Add ISM templates to automatically apply the policy to indices created
+                  in the future.
+                </p>
+              </EuiText>
             }
             actions={addTemplateButton}
           />

--- a/public/pages/VisualCreatePolicy/components/States/State.tsx
+++ b/public/pages/VisualCreatePolicy/components/States/State.tsx
@@ -72,7 +72,7 @@ const State = ({ state, isInitialState, idx, onClickEditState, onClickDeleteStat
                       onShow(ConfirmationModal, {
                         title: "Delete state",
                         bodyMessage: (
-                          <EuiText>
+                          <EuiText size="s">
                             <span>
                               Delete "<strong>{state.name}</strong>" permanently? Deleting the state will result in deleting all
                               transitions.

--- a/public/pages/VisualCreatePolicy/components/States/State.tsx
+++ b/public/pages/VisualCreatePolicy/components/States/State.tsx
@@ -110,12 +110,14 @@ const State = ({ state, isInitialState, idx, onClickEditState, onClickDeleteStat
       </EuiFlexItem>
       <EuiFlexItem>
         {!state.actions?.length ? (
-          <EuiText>No actions. Edit state to add actions.</EuiText>
+          <EuiText size="s">No actions. Edit state to add actions.</EuiText>
         ) : (
           <EuiFlexGroup wrap>
             {state.actions.map((action, index) => (
               <EuiFlexItem grow={false} key={`${makeId()}-${index}`}>
-                <EuiPanel>{actionRepoSingleton.getUIActionFromData(action).content()}</EuiPanel>
+                <EuiPanel>
+                  <EuiText size="s">{actionRepoSingleton.getUIActionFromData(action).content()}</EuiText>
+                </EuiPanel>
               </EuiFlexItem>
             ))}
           </EuiFlexGroup>
@@ -128,7 +130,7 @@ const State = ({ state, isInitialState, idx, onClickEditState, onClickDeleteStat
       </EuiFlexItem>
       <EuiFlexItem>
         {!state.transitions?.length ? (
-          <EuiText>No transitions. Edit state to add transitions.</EuiText>
+          <EuiText size="s">No transitions. Edit state to add transitions.</EuiText>
         ) : (
           <EuiFlexGroup wrap>
             {state.transitions.map((transition, index) => (

--- a/public/pages/VisualCreatePolicy/components/States/States.tsx
+++ b/public/pages/VisualCreatePolicy/components/States/States.tsx
@@ -97,7 +97,11 @@ const States = ({ onOpenFlyout, policy, onClickEditState, onClickDeleteState, on
             <EuiEmptyPrompt
               title={<h2>No states</h2>}
               titleSize="s"
-              body={<p>Your policy currently has no states defined. Add states to manage your index lifecycle.</p>}
+              body={
+                <EuiText size="s">
+                  <p>Your policy currently has no states defined. Add states to manage your index lifecycle.</p>
+                </EuiText>
+              }
               actions={
                 <EuiButton color="primary" onClick={onOpenFlyout} data-test-subj="states-add-state-button">
                   Add state

--- a/public/pages/VisualCreatePolicy/components/Transition/TransitionContent.tsx
+++ b/public/pages/VisualCreatePolicy/components/Transition/TransitionContent.tsx
@@ -13,7 +13,7 @@ interface TransitionContentProps {
 }
 
 const TransitionContent = ({ transition }: TransitionContentProps) => (
-  <EuiText>
+  <EuiText size="s">
     <dl>
       <dt>Destination state</dt>
       <dd>{transition.state_name}</dd>

--- a/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.tsx
@@ -9,7 +9,6 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
-  EuiTitle,
   EuiFlexGroup,
   EuiFlexItem,
   EuiButtonEmpty,
@@ -334,9 +333,9 @@ export default class CreateState extends Component<CreateStateProps, CreateState
       <EuiPortal>
         <EuiFlyout hideCloseButton ownFocus={false} onClose={onCloseFlyout} maxWidth={600} size="m" aria-labelledby="flyoutTitle">
           <EuiFlyoutHeader hasBorder>
-            <EuiTitle size="m">
+            <EuiText size="s">
               <h2 id="flyoutTitle">{title}</h2>
-            </EuiTitle>
+            </EuiText>
           </EuiFlyoutHeader>
           {flyoutContent()}
         </EuiFlyout>

--- a/public/pages/VisualCreatePolicy/containers/VisualCreatePolicy/VisualCreatePolicy.tsx
+++ b/public/pages/VisualCreatePolicy/containers/VisualCreatePolicy/VisualCreatePolicy.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ChangeEvent, Component, useContext } from "react";
-import { EuiText, EuiSpacer, EuiTitle, EuiFlexGroup, EuiFlexItem, EuiButton, EuiLink, EuiIcon } from "@elastic/eui";
+import { EuiText, EuiSpacer, EuiFlexGroup, EuiFlexItem, EuiButton, EuiLink, EuiIcon } from "@elastic/eui";
 import { RouteComponentProps } from "react-router-dom";
 import queryString from "query-string";
 import { EMPTY_DEFAULT_POLICY } from "../../utils/constants";
@@ -281,9 +281,9 @@ export class VisualCreatePolicy extends Component<VisualCreatePolicyProps, Visua
     const { policyId, policyIdError, policy, showFlyout, editingState, errorNotificationJsonString } = this.state;
     return (
       <div style={{ padding: "25px 50px" }}>
-        <EuiTitle size="l">
+        <EuiText size="s">
           <h1>{isEdit ? "Edit" : "Create"} policy</h1>
-        </EuiTitle>
+        </EuiText>
         <EuiSpacer size="s" />
         <EuiText size="s">
           <p>


### PR DESCRIPTION
### Description
This PR applies the following Look & Feel density and consistency improvements:

1. Use small context menus
2. Standardize paragraph font size (15.75px next theme / 14px V7 theme)
3. Use semantic headers (H1s on main pages, H2s on modals/flyouts)
4. Using small tabs
5. Use small padding on popovers

## Screenshots
### Small Context Menus
| Scope | Before | After |
| ----- | ----- | ----- |
| Data Streams | <img width="738" alt="DataScreams Before" src="https://github.com/user-attachments/assets/f213ff20-f573-40dc-a7f7-f1f014a7f0ea"> | <img width="738" alt="DataScreams Post" src="https://github.com/user-attachments/assets/2c56869b-4309-4083-b23b-42f7a3c4d260"> |
| Indices | <img width="442" alt="Indices Before" src="https://github.com/user-attachments/assets/3c2fd7e7-59c0-4396-9beb-0321e8752558"> | <img width="442" alt="Indices Post" src="https://github.com/user-attachments/assets/a97fbcc3-2038-4c35-b04f-909becd9e5cd"> |

### Modals 
| Scope | Before (Heading) | Before (Paragraph) | After (Heading) | After (Paragraph) |
| ----- | ----- | ----- | ----- | ----- |
| Apply Policy | <img width="553" alt="ApplyPolicy 1 Before" src="https://github.com/user-attachments/assets/447f73dd-0bb9-4565-8586-55a2466549b8"> | <img width="553" alt="ApplyPolicy 2 Before" src="https://github.com/user-attachments/assets/38f62315-6117-4d87-8f43-821adea79e67"> | <img width="640" alt="ApplyPolicy 1 Post" src="https://github.com/user-attachments/assets/44d4d4e2-eadf-4159-b2c0-23aa987bdca7"> | <img width="640" alt="ApplyPolicy 2 Post" src="https://github.com/user-attachments/assets/e03b0e3c-5e91-4c35-bce3-ecb71695f887"> |
| Clear Cache | <img width="424" alt="ClearCache 1 Before" src="https://github.com/user-attachments/assets/46e8833b-9646-415c-aa19-5f540c865139"> | <img width="424" alt="ClearCache 2 Before" src="https://github.com/user-attachments/assets/6753de11-f6d0-40cb-9345-fa8a757d45d9"> | <img width="424" alt="ClearCache 1 Post" src="https://github.com/user-attachments/assets/cdc73b0e-38f9-4fa6-8e4a-d36e80c5aa88"> | <img width="424" alt="ClearCache 2 Post" src="https://github.com/user-attachments/assets/9197d0f9-17a2-4acd-8b2a-5edbc087c31e"> |
| Close Index | <img width="795" alt="CloseIndex 1 Before" src="https://github.com/user-attachments/assets/ac5c990f-50aa-44c1-881d-13945bc0d6c6"> | <img width="795" alt="CloseIndex 2 Before" src="https://github.com/user-attachments/assets/4e872495-7bf0-4754-b14d-2ab0da56a802"> | <img width="786" alt="CloseIndex 1 Post" src="https://github.com/user-attachments/assets/e5c8a7c7-ecbf-4f2b-ad0f-0a0e36f10dc0"> | <img width="786" alt="CloseIndex 2 Post" src="https://github.com/user-attachments/assets/e613d273-e74d-461f-af50-d06950378b54"> |


### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
