### PR TITLE
Update rollup jobs and transform jobs title with total numbers of jobs

### DIFF
--- a/public/pages/Reindex/components/CreateIndexFlyout/__snapshots__/CreateIndexFlyout.test.tsx.snap
+++ b/public/pages/Reindex/components/CreateIndexFlyout/__snapshots__/CreateIndexFlyout.test.tsx.snap
@@ -853,7 +853,6 @@ Object {
                   <span
                     class="euiButtonContent euiButton__content"
                   >
-                    EuiIconMock
                     <span
                       class="euiButton__text"
                     >

--- a/public/pages/Rollups/containers/Rollups/Rollups.tsx
+++ b/public/pages/Rollups/containers/Rollups/Rollups.tsx
@@ -100,10 +100,19 @@ export class Rollups extends MDSEnabledComponent<RollupsProps, RollupsState> {
     this.getRollups = _.debounce(this.getRollups, 500, { leading: true });
   }
 
+  async updateBreadCrumbs() {
+    if (this.state.useNewUX) {
+      this.context.chrome.setBreadcrumbs([
+        { text: BREADCRUMBS.ROLLUPS.text.concat(` (${this.state.rollups.length})`), href: BREADCRUMBS.ROLLUPS.href },
+      ]);
+    }
+  }
+
   async componentDidMount() {
     const breadCrumbs = this.state.useNewUX ? [BREADCRUMBS.ROLLUPS] : [BREADCRUMBS.INDEX_MANAGEMENT, BREADCRUMBS.ROLLUPS];
     this.context.chrome.setBreadcrumbs(breadCrumbs);
     await this.getRollups();
+    this.updateBreadCrumbs();
   }
 
   async componentDidUpdate(prevProps: RollupsProps, prevState: RollupsState) {
@@ -112,6 +121,7 @@ export class Rollups extends MDSEnabledComponent<RollupsProps, RollupsState> {
     if (!_.isEqual(prevQuery, currQuery)) {
       await this.getRollups();
     }
+    this.updateBreadCrumbs();
   }
 
   static getQueryObjectFromState({

--- a/public/pages/Transforms/containers/Transforms/Transforms.tsx
+++ b/public/pages/Transforms/containers/Transforms/Transforms.tsx
@@ -100,10 +100,19 @@ export class Transforms extends MDSEnabledComponent<TransformProps, TransformSta
     this.getTransforms = _.debounce(this.getTransforms, 500, { leading: true });
   }
 
+  async updateBreadCrumbs() {
+    if (this.state.useUpdatedUX) {
+      this.context.chrome.setBreadcrumbs([
+        { text: BREADCRUMBS.TRANSFORMS.text.concat(` (${this.state.transforms.length})`), href: BREADCRUMBS.TRANSFORMS.href },
+      ]);
+    }
+  }
+
   async componentDidMount() {
     const breadCrumbs = this.state.useUpdatedUX ? [BREADCRUMBS.TRANSFORMS] : [BREADCRUMBS.INDEX_MANAGEMENT, BREADCRUMBS.TRANSFORMS];
     this.context.chrome.setBreadcrumbs(breadCrumbs);
     await this.getTransforms();
+    this.updateBreadCrumbs();
   }
 
   async componentDidUpdate(prevProps: TransformProps, prevState: TransformState) {
@@ -112,6 +121,7 @@ export class Transforms extends MDSEnabledComponent<TransformProps, TransformSta
     if (!_.isEqual(prevQuery, currQuery)) {
       await this.getTransforms();
     }
+    this.updateBreadCrumbs();
   }
 
   render() {

--- a/public/pages/VisualCreatePolicy/components/FlyoutFooter/FlyoutFooter.tsx
+++ b/public/pages/VisualCreatePolicy/components/FlyoutFooter/FlyoutFooter.tsx
@@ -25,13 +25,7 @@ const FlyoutFooter = ({ edit, action, disabledAction = false, onClickCancel, onC
       </EuiSmallButtonEmpty>
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
-      <EuiSmallButton
-        disabled={disabledAction}
-        onClick={onClickAction}
-        fill
-        data-test-subj="flyout-footer-action-button"
-        iconType={"Add" ? "plusInCircle" : "plus"}
-      >
+      <EuiSmallButton disabled={disabledAction} onClick={onClickAction} fill data-test-subj="flyout-footer-action-button">
         {text ? text : restore ? "Restore snapshot" : !save ? `${edit ? "Edit" : "Add"} ${action}` : save ? "Save" : "Create"}
       </EuiSmallButton>
     </EuiFlexItem>

--- a/public/pages/VisualCreatePolicy/components/FlyoutFooter/__snapshots__/FlyoutFooter.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/FlyoutFooter/__snapshots__/FlyoutFooter.test.tsx.snap
@@ -34,7 +34,6 @@ exports[`<FlyoutFooter /> spec renders the component 1`] = `
       <span
         class="euiButtonContent euiButton__content"
       >
-        EuiIconMock
         <span
           class="euiButton__text"
         >


### PR DESCRIPTION
### Description
This PR achieves 3 things. 
1. Show number of rollup jobs in the title of rollup jobs
2. Show number of transform jobs in the title of transform jobs
3. Removes plus in circle icon in snapshot pages buttons introduced by https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1148 as this is not required according to guidelines.

## Before
Rollup Jobs
![image](https://github.com/user-attachments/assets/b5ee9c2c-8cb5-4596-85a8-aebb9aa8f0de)

Transform Jobs
![image](https://github.com/user-attachments/assets/c920165b-d7ac-451c-a620-b22789a83c24)



## After
Rollup Jobs
![image](https://github.com/user-attachments/assets/eac552e5-1e61-4044-8fff-eff65f48f63f)

Transform Jobs
![image](https://github.com/user-attachments/assets/d0847b2b-aa24-4560-aa12-572755d44e74)


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
