### PR TITLE
Fit and Finish UX changes

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -82,13 +82,13 @@ jobs:
           wait-on: 'http://localhost:5601'
           browser: chrome
       # Screenshots are only captured on failure, will change this once we do visual regression tests
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots
           path: OpenSearch-Dashboards/plugins/index-management-dashboards-plugin/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: cypress-videos

--- a/public/pages/CreateIndexTemplate/containers/CreateIndexTemplate/__snapshots__/CreateIndexTemplate.test.tsx.snap
+++ b/public/pages/CreateIndexTemplate/containers/CreateIndexTemplate/__snapshots__/CreateIndexTemplate.test.tsx.snap
@@ -211,7 +211,7 @@ exports[`<CreateIndexTemplate /> spec render template pages 1`] = `
       </button>
     </div>
     <div
-      class="euiSpacer euiSpacer--l"
+      class="euiSpacer euiSpacer--m"
     />
     <div
       class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"

--- a/public/pages/CreateIndexTemplate/containers/TemplateDetail/TemplateDetail.tsx
+++ b/public/pages/CreateIndexTemplate/containers/TemplateDetail/TemplateDetail.tsx
@@ -387,7 +387,7 @@ const TemplateDetail = (props: TemplateDetailProps, ref: Ref<FieldInstance>) => 
               </EuiTab>
             ))}
           </EuiTabs>
-          <EuiSpacer />
+          <EuiSpacer size="m" />
         </>
       ) : null}
       {subCompontentProps.readonly ? null : (

--- a/public/pages/IndexDetail/containers/IndexDetail/IndexDetail.tsx
+++ b/public/pages/IndexDetail/containers/IndexDetail/IndexDetail.tsx
@@ -150,7 +150,7 @@ export default function IndexDetail(props: IndexDetailModalProps) {
         mode: IndicesUpdateMode.settings,
         content: (
           <>
-            <EuiSpacer />
+            <EuiSpacer size="m" />
             <EuiPanel>
               <EuiText size="s">
                 <h2>Index settings</h2>
@@ -168,7 +168,7 @@ export default function IndexDetail(props: IndexDetailModalProps) {
         mode: IndicesUpdateMode.mappings,
         content: (
           <>
-            <EuiSpacer />
+            <EuiSpacer size="m" />
             <EuiPanel>
               <EuiText size="s">
                 <h2>Index mappings</h2>
@@ -206,7 +206,7 @@ export default function IndexDetail(props: IndexDetailModalProps) {
         mode: IndicesUpdateMode.alias,
         content: (
           <>
-            <EuiSpacer />
+            <EuiSpacer size="m" />
             <EuiPanel>
               <EuiText size="s">
                 <h2>Index alias</h2>

--- a/public/pages/Indices/components/IndexControls/IndexControls.tsx
+++ b/public/pages/Indices/components/IndexControls/IndexControls.tsx
@@ -15,6 +15,7 @@ import {
   EuiSearchBar,
   EuiCompressedSwitch,
   EuiButtonEmpty,
+  EuiToolTip,
 } from "@elastic/eui";
 import { DataStream, ManagedCatIndex } from "../../../../../server/models/interfaces";
 import IndicesActions from "../../containers/IndicesActions";
@@ -96,7 +97,9 @@ export default class IndexControls extends Component<IndexControlsProps, IndexCo
             />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon iconType="refresh" data-test-subj="refreshButton" display="base" size="s" />
+            <EuiToolTip content="Refresh">
+              <EuiButtonIcon iconType="refresh" data-test-subj="refreshButton" display="base" size="s" onClick={onRefresh} />
+            </EuiToolTip>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <IndicesActions

--- a/public/pages/Indices/components/NotificationModal/NotificationModal.tsx
+++ b/public/pages/Indices/components/NotificationModal/NotificationModal.tsx
@@ -197,24 +197,22 @@ const Notifications = ({ onClose, visible }: NotificationsProps) => {
       </EuiModalHeader>
       <EuiModalBody>
         {noPermission ? (
-          <EuiPanel>
-            <EuiEmptyPrompt
-              iconType="alert"
-              iconColor="danger"
-              title={
-                <EuiText size="s">
-                  {" "}
-                  <h2>Error loading Notification settings</h2>{" "}
-                </EuiText>
-              }
-              body={
-                <EuiText size="s">
-                  {" "}
-                  <p>You do not have permissions to view Notification settings. Contact your administrator to request permissions.</p>
-                </EuiText>
-              }
-            />
-          </EuiPanel>
+          <EuiEmptyPrompt
+            iconType="alert"
+            iconColor="danger"
+            title={
+              <EuiText size="s">
+                {" "}
+                <h2>Error loading Notification settings</h2>{" "}
+              </EuiText>
+            }
+            body={
+              <EuiText size="s">
+                {" "}
+                <p>You do not have permissions to view Notification settings. Contact your administrator to request permissions.</p>
+              </EuiText>
+            }
+          />
         ) : (
           <>
             {submitClicked && allErrors.length ? (

--- a/public/pages/Indices/components/NotificationModal/UnsavedChangesButton.tsx
+++ b/public/pages/Indices/components/NotificationModal/UnsavedChangesButton.tsx
@@ -1,9 +1,7 @@
 // FILE: UnsavedChangesButtons.tsx
 
 import React, { useCallback, useRef, useState } from "react";
-import { EuiSmallButton, EuiSmallButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiText } from "@elastic/eui";
-import classNames from "classnames";
-
+import { EuiSmallButton, EuiSmallButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiText, EuiPanel } from "@elastic/eui";
 interface UnsavedChangesButtonsProps {
   unsavedCount: number;
   formErrorsCount?: number;
@@ -37,7 +35,7 @@ const UnsavedChangesButtons: React.FC<UnsavedChangesButtonsProps> = ({
 
   const renderCancel = useCallback(
     () => (
-      <EuiSmallButtonEmpty onClick={onClickCancel} iconType="cross" target="_blank">
+      <EuiSmallButtonEmpty onClick={onClickCancel} target="_blank">
         Cancel
       </EuiSmallButtonEmpty>
     ),
@@ -51,7 +49,6 @@ const UnsavedChangesButtons: React.FC<UnsavedChangesButtonsProps> = ({
         onClick={onClick}
         isLoading={loading}
         disabled={loading}
-        iconType="check"
         color="primary"
         fill
       >
@@ -62,27 +59,28 @@ const UnsavedChangesButtons: React.FC<UnsavedChangesButtonsProps> = ({
   );
 
   return (
-    <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
-      <>
+    <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" style={{ padding: "0px 16px" }}>
+      <EuiFlexGroup gutterSize="s" alignItems="center">
         {formErrorsCount ? (
           <EuiFlexItem grow={false}>
             <EuiText color="danger" size="s">
-              {" "}
-              {formErrorsCount} form errors{" "}
+              {formErrorsCount} form errors
             </EuiText>
           </EuiFlexItem>
         ) : null}
         {unsavedCount && !formErrorsCount ? (
           <EuiFlexItem grow={false}>
             <EuiText color="warning" size="s">
-              {" "}
-              {unsavedCount} unsaved changes{" "}
+              {unsavedCount} unsaved changes
             </EuiText>
           </EuiFlexItem>
         ) : null}
-      </>
-      <EuiFlexItem grow={false}>{renderCancel()}</EuiFlexItem>
-      <EuiFlexItem grow={false}>{renderConfirm()}</EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiFlexGroup gutterSize="s" alignItems="center" justifyContent="flexEnd">
+        <EuiFlexItem grow={false}>{renderCancel()}</EuiFlexItem>
+        <EuiFlexItem grow={false}>{renderConfirm()}</EuiFlexItem>
+      </EuiFlexGroup>
     </EuiFlexGroup>
   );
 };

--- a/public/pages/Indices/containers/Indices/Indices.tsx
+++ b/public/pages/Indices/containers/Indices/Indices.tsx
@@ -300,7 +300,6 @@ export class Indices extends MDSEnabledComponent<IndicesProps, IndicesState> {
               run: this.toggleNotificationModal,
               testId: "notificationSettingsButton",
               controlType: "button",
-              color: "secondary",
             } as TopNavControlButtonData,
             {
               id: "Create index",

--- a/public/pages/ManagedIndices/components/ManagedIndexControls/ManagedIndexControls.tsx
+++ b/public/pages/ManagedIndices/components/ManagedIndexControls/ManagedIndexControls.tsx
@@ -14,6 +14,7 @@ import {
   EuiButtonIcon,
   EuiButtonEmpty,
   EuiSpacer,
+  EuiToolTip,
 } from "@elastic/eui";
 import { DataStream } from "../../../../../server/models/interfaces";
 import { getUISettings } from "../../../../services/Services";
@@ -43,7 +44,7 @@ export default class ManagedIndexControls extends Component<ManagedIndexControls
   };
 
   render() {
-    const { search, onSearchChange, showDataStreams, toggleShowDataStreams, Actions } = this.props;
+    const { search, onSearchChange, showDataStreams, toggleShowDataStreams, Actions, onRefresh } = this.props;
 
     const schema = {
       strict: true,
@@ -94,7 +95,9 @@ export default class ManagedIndexControls extends Component<ManagedIndexControls
             />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon iconType="refresh" data-test-subj="refreshButton" display="base" size="s" />
+            <EuiToolTip content="Refresh">
+              <EuiButtonIcon iconType="refresh" data-test-subj="refreshButton" display="base" size="s" onClick={onRefresh} />
+            </EuiToolTip>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>{Actions}</EuiFlexItem>
           <EuiFlexItem grow={false}>

--- a/public/pages/ManagedIndices/containers/ManagedIndices/ManagedIndices.tsx
+++ b/public/pages/ManagedIndices/containers/ManagedIndices/ManagedIndices.tsx
@@ -121,7 +121,6 @@ export class ManagedIndices extends MDSEnabledComponent<ManagedIndicesProps, Man
         sortable: true,
         truncateText: true,
         textOnly: true,
-        width: "150px",
         render: (index: string) => <span title={index}>{index}</span>,
       },
       {
@@ -130,7 +129,6 @@ export class ManagedIndices extends MDSEnabledComponent<ManagedIndicesProps, Man
         sortable: true,
         truncateText: true,
         textOnly: true,
-        width: "120px",
         render: (dataStream) => dataStream || DEFAULT_EMPTY_DATA,
       },
       {
@@ -139,7 +137,6 @@ export class ManagedIndices extends MDSEnabledComponent<ManagedIndicesProps, Man
         sortable: true,
         truncateText: true,
         textOnly: true,
-        width: "140px",
         render: this.renderPolicyId,
       },
       {
@@ -147,7 +144,6 @@ export class ManagedIndices extends MDSEnabledComponent<ManagedIndicesProps, Man
         name: "State",
         sortable: false,
         truncateText: false,
-        width: "150px",
         // @ts-ignore
         render: (state: string) => state || DEFAULT_EMPTY_DATA,
       },
@@ -156,7 +152,6 @@ export class ManagedIndices extends MDSEnabledComponent<ManagedIndicesProps, Man
         name: "Action",
         sortable: false,
         truncateText: false,
-        width: "150px",
         // @ts-ignore
         render: (action: string) => (
           <span style={{ textTransform: "capitalize" }}>{(action || DEFAULT_EMPTY_DATA).split("_").join(" ")}</span>
@@ -168,7 +163,6 @@ export class ManagedIndices extends MDSEnabledComponent<ManagedIndicesProps, Man
         sortable: false,
         truncateText: true,
         textOnly: true,
-        width: "150px",
         render: (info: object) => (
           <ModalConsumer>
             {({ onShow }) => (
@@ -184,7 +178,6 @@ export class ManagedIndices extends MDSEnabledComponent<ManagedIndicesProps, Man
         name: "Job Status",
         sortable: false,
         truncateText: false,
-        width: "150px",
         render: (index: string, item: ManagedIndexItem) => {
           const { managedIndexMetaData } = item;
           if (!managedIndexMetaData) return "Initializing";

--- a/public/pages/ManagedIndices/containers/ManagedIndices/__snapshots__/ManagedIndices.test.tsx.snap
+++ b/public/pages/ManagedIndices/containers/ManagedIndices/__snapshots__/ManagedIndices.test.tsx.snap
@@ -348,7 +348,6 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
                   data-test-subj="tableHeaderCell_index_0"
                   role="columnheader"
                   scope="col"
-                  style="width: 150px;"
                 >
                   <button
                     class="euiTableHeaderButton euiTableHeaderButton-isSorted"
@@ -375,7 +374,6 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
                   data-test-subj="tableHeaderCell_policyId_1"
                   role="columnheader"
                   scope="col"
-                  style="width: 140px;"
                 >
                   <button
                     class="euiTableHeaderButton"
@@ -399,7 +397,6 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
                   data-test-subj="tableHeaderCell_managedIndexMetaData.state.name_2"
                   role="columnheader"
                   scope="col"
-                  style="width: 150px;"
                 >
                   <span
                     class="euiTableCellContent"
@@ -417,7 +414,6 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
                   data-test-subj="tableHeaderCell_managedIndexMetaData.action.name_3"
                   role="columnheader"
                   scope="col"
-                  style="width: 150px;"
                 >
                   <span
                     class="euiTableCellContent"
@@ -435,7 +431,6 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
                   data-test-subj="tableHeaderCell_managedIndexMetaData.info_4"
                   role="columnheader"
                   scope="col"
-                  style="width: 150px;"
                 >
                   <span
                     class="euiTableCellContent"
@@ -453,7 +448,6 @@ exports[`<ManagedIndices /> spec renders the component 1`] = `
                   data-test-subj="tableHeaderCell_index_5"
                   role="columnheader"
                   scope="col"
-                  style="width: 150px;"
                 >
                   <span
                     class="euiTableCellContent"

--- a/public/pages/Notifications/containers/Notifications/Notifications.tsx
+++ b/public/pages/Notifications/containers/Notifications/Notifications.tsx
@@ -190,6 +190,7 @@ const Notifications = (props: NotificationsProps) => {
       controlType: "button",
       display: "base",
       iconType: "popout",
+      iconSide: "right",
       fill: true,
     } as TopNavControlButtonData,
   ];

--- a/public/pages/Policies/containers/Policies/Policies.tsx
+++ b/public/pages/Policies/containers/Policies/Policies.tsx
@@ -111,7 +111,6 @@ export class Policies extends MDSEnabledComponent<PoliciesProps, PoliciesState> 
         sortable: true,
         truncateText: true,
         textOnly: true,
-        width: "150px",
         render: (name: string, item: PolicyItem) => (
           <EuiLink onClick={() => this.props.history.push(`${ROUTES.POLICY_DETAILS}?id=${name}`)} data-test-subj={`policyLink_${name}`}>
             {name}
@@ -124,7 +123,6 @@ export class Policies extends MDSEnabledComponent<PoliciesProps, PoliciesState> 
         sortable: true,
         truncateText: true,
         textOnly: true,
-        width: "150px",
       },
       {
         field: "policy.last_updated_time",
@@ -133,7 +131,6 @@ export class Policies extends MDSEnabledComponent<PoliciesProps, PoliciesState> 
         truncateText: false,
         render: renderTime,
         dataType: "date",
-        width: "150px",
       },
     ];
   }

--- a/public/pages/Policies/containers/Policies/__snapshots__/Policies.test.tsx.snap
+++ b/public/pages/Policies/containers/Policies/__snapshots__/Policies.test.tsx.snap
@@ -254,7 +254,6 @@ exports[`<IndexPolicies /> spec renders the component 1`] = `
                   data-test-subj="tableHeaderCell_id_0"
                   role="columnheader"
                   scope="col"
-                  style="width: 150px;"
                 >
                   <button
                     class="euiTableHeaderButton euiTableHeaderButton-isSorted"
@@ -281,7 +280,6 @@ exports[`<IndexPolicies /> spec renders the component 1`] = `
                   data-test-subj="tableHeaderCell_policy.description_1"
                   role="columnheader"
                   scope="col"
-                  style="width: 150px;"
                 >
                   <button
                     class="euiTableHeaderButton"
@@ -307,7 +305,6 @@ exports[`<IndexPolicies /> spec renders the component 1`] = `
                   data-test-subj="tableHeaderCell_policy.last_updated_time_2"
                   role="columnheader"
                   scope="col"
-                  style="width: 150px;"
                 >
                   <button
                     class="euiTableHeaderButton"

--- a/public/pages/Repositories/containers/Repositories/Repositories.tsx
+++ b/public/pages/Repositories/containers/Repositories/Repositories.tsx
@@ -13,6 +13,7 @@ import {
   EuiTextColor,
   EuiButtonIcon,
   EuiPanel,
+  EuiToolTip,
 } from "@elastic/eui";
 import { getErrorMessage } from "../../../../utils/helpers";
 import React, { Component, useContext } from "react";
@@ -257,14 +258,18 @@ export class Repositories extends MDSEnabledComponent<RepositoriesProps, Reposit
 
     const renderToolsRight = () => {
       return [
-        <EuiButtonIcon
-          iconType="refresh"
-          onClick={this.getRepos}
-          data-test-subj="refreshButton"
-          aria-label="refresh"
-          size="s"
-          display="base"
-        />,
+        <>
+          <EuiToolTip content="Refresh">
+            <EuiButtonIcon
+              iconType="refresh"
+              onClick={this.getRepos}
+              data-test-subj="refreshButton"
+              aria-label="refresh"
+              size="s"
+              display="base"
+            />
+          </EuiToolTip>
+        </>,
       ];
     };
 
@@ -369,13 +374,11 @@ export class Repositories extends MDSEnabledComponent<RepositoriesProps, Reposit
 
     const { HeaderControl } = getNavigationUI();
     const { setAppRightControls, setAppDescriptionControls } = getApplication();
-    const useTitle = useNewUX 
-      ? undefined 
-      : (
-        <EuiText size="s">
-          <h1>Repositories</h1>
-        </EuiText>
-      );  
+    const useTitle = useNewUX ? undefined : (
+      <EuiText size="s">
+        <h1>Repositories</h1>
+      </EuiText>
+    );
     const useActions = useNewUX ? undefined : actions;
     const useSubTitleText = useNewUX ? undefined : subTitleText;
 

--- a/public/pages/Rollups/containers/Rollups/Rollups.tsx
+++ b/public/pages/Rollups/containers/Rollups/Rollups.tsx
@@ -36,6 +36,7 @@ import {
   EuiButtonIcon,
   EuiSpacer,
   EuiText,
+  EuiToolTip,
 } from "@elastic/eui";
 import { RollupService } from "../../../../services";
 import RollupEmptyPrompt from "../../components/RollupEmptyPrompt";
@@ -506,14 +507,16 @@ export class Rollups extends MDSEnabledComponent<RollupsProps, RollupsState> {
               />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon
-                iconType="refresh"
-                onClick={this.getRollups}
-                aria-label="refresh"
-                size="s"
-                display="base"
-                data-test-subj="refreshButton"
-              />
+              <EuiToolTip content="Refresh">
+                <EuiButtonIcon
+                  iconType="refresh"
+                  onClick={this.getRollups}
+                  aria-label="refresh"
+                  size="s"
+                  display="base"
+                  data-test-subj="refreshButton"
+                />
+              </EuiToolTip>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiPopover

--- a/public/pages/SnapshotPolicies/containers/SnapshotPolicies/SnapshotPolicies.tsx
+++ b/public/pages/SnapshotPolicies/containers/SnapshotPolicies/SnapshotPolicies.tsx
@@ -33,6 +33,7 @@ import {
   EuiCompressedFieldSearch,
   EuiPanel,
   EuiSpacer,
+  EuiToolTip,
 } from "@elastic/eui";
 import { BREADCRUMBS, PLUGIN_NAME, ROUTES, SNAPSHOT_MANAGEMENT_DOCUMENTATION_URL } from "../../../../utils/constants";
 import { getMessagePrompt, getSMPoliciesQueryParamsFromURL, renderTimestampMillis } from "../../helpers";
@@ -574,13 +575,13 @@ export class SnapshotPolicies extends MDSEnabledComponent<SnapshotPoliciesProps,
 
     return !this.state.useNewUx ? (
       <>
-        <ContentPanel 
+        <ContentPanel
           title={
             <EuiText size="s">
               <h1>Snapshot policies</h1>
             </EuiText>
-          }  
-          actions={actions} 
+          }
+          actions={actions}
           subTitleText={subTitleText}
         >
           <EuiCompressedFieldSearch placeholder="Search snapshot policies" incremental={false} fullWidth onChange={this.onSearchChange} />
@@ -605,7 +606,9 @@ export class SnapshotPolicies extends MDSEnabledComponent<SnapshotPoliciesProps,
               />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon iconType="refresh" onClick={this.getPolicies} aria-label="refresh" size="s" display="base" />
+              <EuiToolTip content="Refresh">
+                <EuiButtonIcon iconType="refresh" onClick={this.getPolicies} aria-label="refresh" size="s" display="base" />
+              </EuiToolTip>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiPopover

--- a/public/pages/Snapshots/components/RestoreActivitiesPanel/RestoreActivitiesPanel.tsx
+++ b/public/pages/Snapshots/components/RestoreActivitiesPanel/RestoreActivitiesPanel.tsx
@@ -17,6 +17,7 @@ import {
   EuiText,
   EuiFlexItem,
   EuiHorizontalRule,
+  EuiToolTip,
 } from "@elastic/eui";
 import _ from "lodash";
 import React, { useEffect, useContext, useState, useMemo } from "react";
@@ -218,7 +219,13 @@ export const RestoreActivitiesPanel = ({
   );
 
   const renderToolsRight = () => {
-    return [<EuiButtonIcon iconType="refresh" onClick={getRestoreStatus} aria-label="refresh" size="s" display="base" />];
+    return [
+      <>
+        <EuiToolTip content="Refresh">
+          <EuiButtonIcon iconType="refresh" onClick={getRestoreStatus} aria-label="refresh" size="s" display="base" />
+        </EuiToolTip>
+      </>,
+    ];
   };
 
   const currentStage = stage.slice(0, stage.indexOf(" "));

--- a/public/pages/Snapshots/containers/Snapshots/Snapshots.tsx
+++ b/public/pages/Snapshots/containers/Snapshots/Snapshots.tsx
@@ -23,6 +23,7 @@ import {
   EuiButtonIcon,
   EuiButton,
   EuiPanel,
+  EuiToolTip,
 } from "@elastic/eui";
 import { FieldValueSelectionFilterConfigType } from "@elastic/eui/src/components/search_bar/filters/field_value_selection_filter";
 import { CoreServicesContext } from "../../../../components/core_services";
@@ -466,7 +467,11 @@ export class Snapshots extends MDSEnabledComponent<SnapshotsProps, SnapshotsStat
 
     const renderToolsRight = () => {
       return [
-        <EuiButtonIcon iconType="refresh" onClick={this.getSnapshots} aria-label="refresh" size="s" display="base" />,
+        <>
+          <EuiToolTip content="Refresh">
+            <EuiButtonIcon iconType="refresh" onClick={this.getSnapshots} aria-label="refresh" size="s" display="base" />
+          </EuiToolTip>
+        </>,
         <EuiPopover
           id="action"
           button={actionsButton}

--- a/public/pages/Transforms/components/TransformEmptyPrompt/TransformEmptyPrompt.tsx
+++ b/public/pages/Transforms/components/TransformEmptyPrompt/TransformEmptyPrompt.tsx
@@ -43,7 +43,12 @@ const getActions: React.SFC<TransformEmptyPromptProps> = ({ filterIsApplied, loa
   }
 
   return (
-    <EuiSmallButton href={`${PLUGIN_NAME}#${ROUTES.CREATE_TRANSFORM}`} data-test-subj="emptyPromptCreateTransformButton" iconType="plus">
+    <EuiSmallButton
+      href={`${PLUGIN_NAME}#${ROUTES.CREATE_TRANSFORM}`}
+      data-test-subj="emptyPromptCreateTransformButton"
+      iconType="plus"
+      fill
+    >
       Create transform
     </EuiSmallButton>
   );

--- a/public/pages/Transforms/containers/Transforms/Transforms.tsx
+++ b/public/pages/Transforms/containers/Transforms/Transforms.tsx
@@ -27,6 +27,8 @@ import {
   EuiTableSelectionType,
   EuiTableSortingType,
   EuiSpacer,
+  EuiToolTip,
+  EuiButtonIcon,
 } from "@elastic/eui";
 import queryString from "query-string";
 import { RouteComponentProps } from "react-router-dom";
@@ -297,6 +299,18 @@ export class Transforms extends MDSEnabledComponent<TransformProps, TransformSta
                   />
                 </EuiFlexItem>
               )}
+              <EuiFlexItem grow={false}>
+                <EuiToolTip content="Refresh">
+                  <EuiButtonIcon
+                    iconType="refresh"
+                    onClick={this.getTransforms}
+                    aria-label="refresh"
+                    size="s"
+                    display="base"
+                    data-test-subj="refreshButton"
+                  />
+                </EuiToolTip>
+              </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiPopover
                   id="action"


### PR DESCRIPTION
### Description
Fixed some Fit and Finish UX changes along with couple of other fixes: 

- Added refresh button in transform jobs page
- Fixed refresh button in indexes and policy managed indices page

Notifications Modal:
<img width="855" alt="image" src="https://github.com/user-attachments/assets/e499326e-3d71-478d-b378-4f896c4fcdad">

Refresh Button toolkit:
<img width="1444" alt="image" src="https://github.com/user-attachments/assets/db28ad27-6396-4166-a5d6-78af7f522434">

Removed extra spacing between checkbox and policy column
<img width="1455" alt="image" src="https://github.com/user-attachments/assets/e2f304a9-77e1-44fd-8367-8747d2158039">

Spacing between the tabs and content set to medium
<img width="1435" alt="image" src="https://github.com/user-attachments/assets/cca4ddbd-1683-41af-af10-f6b62d505d59">

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
