### PR TITLE
bug-fix: Restore snapshot shouldn't restore index alias always

### DIFF
--- a/public/pages/Snapshots/components/RestoreSnapshotFlyout/RestoreSnapshotFlyout.tsx
+++ b/public/pages/Snapshots/components/RestoreSnapshotFlyout/RestoreSnapshotFlyout.tsx
@@ -289,10 +289,21 @@ export class RestoreSnapshotFlyout extends MDSEnabledComponent<RestoreSnapshotPr
   };
 
   onToggle = (e: ChangeEvent<HTMLInputElement>) => {
-    const { restore_specific_indices, restore_all_indices, customize_index_settings, ignore_index_settings } = RESTORE_OPTIONS;
+    const {
+      restore_specific_indices,
+      restore_all_indices,
+      customize_index_settings,
+      ignore_index_settings,
+      restore_aliases,
+    } = RESTORE_OPTIONS;
 
     if (e.target.id === restore_specific_indices) {
       this.setState({ restoreSpecific: true, snapshot: _.set(this.state.snapshot!, e.target.id, e.target.checked) });
+      return;
+    }
+
+    if (e.target.id === restore_aliases) {
+      this.setState({ snapshot: _.set(this.state.snapshot!, e.target.id, e.target.checked) });
       return;
     }
 
@@ -482,7 +493,7 @@ export class RestoreSnapshotFlyout extends MDSEnabledComponent<RestoreSnapshotPr
 
                 <SnapshotRestoreAdvancedOptions
                   getIndexSettings={this.getIndexSettings}
-                  restoreAliases={String(_.get(snapshot, restore_aliases, true)) == "true"}
+                  restoreAliases={String(_.get(snapshot, restore_aliases, false)) == "true"}
                   onRestoreAliasesToggle={this.onToggle}
                   restoreClusterState={String(_.get(snapshot, include_global_state, false)) == "true"}
                   onRestoreClusterStateToggle={this.onToggle}


### PR DESCRIPTION
### Description
Previously restoring a snapshot always tries to restore index alias even if the restore alias is unchecked from the dashboard.
This bug is now being fixed with this PR as we set the checkbox for restore alias as false default option and add a toggle check when users chooses to select alias restore option.  

### Issues Resolved


### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
