### PR TITLE
Remove unecessary OPENSEARCH_VERSION from cypress test run

### DIFF
--- a/.github/actions/run-cypress-tests/action.yaml
+++ b/.github/actions/run-cypress-tests/action.yaml
@@ -25,7 +25,7 @@ runs:
       if: ${{ inputs.with-security == 'false' }}
       run: |
         cd index-management
-        ./gradlew run -Dopensearch.version=${{ env.OPENSEARCH_VERSION }} &
+        ./gradlew run &
         sleep 300
       # timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do sleep 5; done'
     - name: Run opensearch with plugin
@@ -33,7 +33,7 @@ runs:
       if: ${{ inputs.with-security == 'true' }}
       run: |
         cd index-management
-        ./gradlew run -Dopensearch.version=${{ env.OPENSEARCH_VERSION }} -Dsecurity=true -Dhttps=true &
+        ./gradlew run -Dsecurity=true -Dhttps=true &
         sleep 300
       # timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do sleep 5; done'
     - name: Checkout Index Management Dashboards plugin

--- a/.github/workflows/cypress-with-security-workflow.yml
+++ b/.github/workflows/cypress-with-security-workflow.yml
@@ -8,7 +8,6 @@ on:
       - "*"
 env:
   OPENSEARCH_DASHBOARDS_VERSION: 'main'
-  OPENSEARCH_VERSION: '3.0.0-SNAPSHOT'
 jobs:
   tests:
     name: Run Cypress E2E tests with security

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -8,7 +8,6 @@ on:
       - "*"
 env:
   OPENSEARCH_DASHBOARDS_VERSION: 'main'
-  OPENSEARCH_VERSION: '3.0.0-SNAPSHOT'
 jobs:
   tests:
     name: Run Cypress E2E tests


### PR DESCRIPTION
### Description

This PR is a small follow-up to https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1202 to simplify the action and remove an unnecessary env variable. Instead of getting the version from this variable, it will get it from the branch-specific build.gradle file and spin up a `<Version>-SNAPSHOT` version of a node for testing. 

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
