### PR TITLE
Bug Fixes in Snapshot Policy: Schedule Editing and Index Expression Display

### DIFF
--- a/public/pages/CreateSnapshotPolicy/components/CronSchedule/CronSchedule.tsx
+++ b/public/pages/CreateSnapshotPolicy/components/CronSchedule/CronSchedule.tsx
@@ -88,12 +88,12 @@ const CronSchedule = ({
 
   function onDayOfWeekChange(dayOfWeek: string) {
     setWeek(dayOfWeek);
-    // changeCron({ dayOfWeek });
+    changeCron({ dayOfWeek });
   }
 
   function onDayOfMonthChange(dayOfMonth: number) {
     setMonth(dayOfMonth);
-    // changeCron({ dayOfMonth });
+    changeCron({ dayOfMonth });
   }
 
   function onStartTimeChange(date: moment.Moment) {
@@ -101,7 +101,7 @@ const CronSchedule = ({
     const hour = date.hour();
     setMinute(minute);
     setHour(hour);
-    // changeCron({ minute, hour });
+    changeCron({ minute, hour });
   }
 
   function onTypeChange(e: ChangeEvent<HTMLSelectElement>) {

--- a/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
+++ b/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
@@ -477,7 +477,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
     const selectedIndexOptions = [...this.state.selectedIndexOptions, newOption];
     this.setState({
       selectedIndexOptions: selectedIndexOptions,
-      policy: this.setPolicyHelper("snapshot_config.indices", selectedIndexOptions.toString()),
+      policy: this.setPolicyHelper("snapshot_config.indices", selectedIndexOptions.map((option) => option.label).join(", ")),
     });
   };
 


### PR DESCRIPTION
### Description
This pull request addresses two significant bugs in the snapshot policy functionality:

**Schedule Editing Bug:**
Fixed an issue where users were unable to modify the snapshot schedule time during policy editing.
Users can now successfully update the snapshot timing as needed.

**Index Expression Display Bug:**
Resolved a problem where entered index expressions were not displaying correctly, and no snapshots were happening for that policy with correct indices. 
The snapshot details page now properly shows the index expressions as strings, replacing the previous [Object][Object] display. Snapshot's are taking place with correct indices. 
This fix ensures that users can accurately view and verify their index selections.

Testing:

Verified that snapshot schedule times can be edited and saved correctly.
Confirmed that index expressions are now displayed properly in all relevant sections of the UI.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
