### PR TITLE
bug fix: Snapshot restore always restores index alias

### DIFF
--- a/public/pages/Snapshots/components/RestoreSnapshotFlyout/RestoreSnapshotFlyout.tsx
+++ b/public/pages/Snapshots/components/RestoreSnapshotFlyout/RestoreSnapshotFlyout.tsx
@@ -146,7 +146,7 @@ export class RestoreSnapshotFlyout extends MDSEnabledComponent<RestoreSnapshotPr
       include_global_state: snapshot?.include_global_state,
       rename_pattern: pattern,
       rename_replacement: renameIndices === add_prefix ? `${prefix}$1` : renameReplacement,
-      include_aliases: snapshot?.restore_aliases ? snapshot.restore_aliases : true,
+      include_aliases: snapshot?.restore_aliases !== undefined ? snapshot.restore_aliases : true,
       partial: snapshot?.partial || false,
     };
     let repoError = "";
@@ -493,7 +493,7 @@ export class RestoreSnapshotFlyout extends MDSEnabledComponent<RestoreSnapshotPr
 
                 <SnapshotRestoreAdvancedOptions
                   getIndexSettings={this.getIndexSettings}
-                  restoreAliases={String(_.get(snapshot, restore_aliases, false)) == "true"}
+                  restoreAliases={String(_.get(snapshot, restore_aliases, true)) == "true"}
                   onRestoreAliasesToggle={this.onToggle}
                   restoreClusterState={String(_.get(snapshot, include_global_state, false)) == "true"}
                   onRestoreClusterStateToggle={this.onToggle}


### PR DESCRIPTION
### Description
This PR is follow up PR https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1193  for fixing the bug in snapshot restore page. Currently snapshot restore always restores index alias. 

In this PR we set default value to `true` for include_aliases parameter as mentioned in the documentation: https://opensearch.org/docs/latest/api-reference/snapshots/restore-snapshot/#request-body-fields which we changed in the previous PR by mistake. 

### Issues Resolved


### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
