### PR TITLE
Revert "Updating the maintainers and codeowners list"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-*   @bowenlan-amzn @Hailong-am @RamakrishnaChilaka @vikasvb90 @SuZhou-Joe @tandonks @shiv0408 @soosinha
+# This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
+*   @opensearch-project/index-management

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,32 +1,9 @@
-## Overview
+## Maintainers
+| Maintainer | GitHub ID | Affiliation |
+| --------------- | --------- | ----------- |
+| Annie Lee | [leeyun-amzn](https://github.com/leeyun-amzn) | Amazon |
+| Bowen Lan | [bowenlan-amzn](https://github.com/bowenlan-amzn) | Amazon |
+| Drew Baugher | [dbbaughe](https://github.com/dbbaughe) | Amazon |
+| Ravi | [thalurur](https://github.com/thalurur) | Amazon |
 
-This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
-
-## Current Maintainers
-
-| Maintainer            | GitHub ID                                                    | Affiliation |
-|-----------------------| ------------------------------------------------------------ | ----------- |
-| Bowen Lan             | [bowenlan-amzn](https://github.com/bowenlan-amzn)            | Amazon      |
-| Hailong Cui           | [Hailong-am](https://github.com/Hailong-am)                  | Amazon      |
-| Ramakrishna Chilaka   | [RamakrishnaChilaka](https://github.com/RamakrishnaChilaka)  | Amazon      |
-| Vikas Bansal          | [vikasvb90](https://github.com/vikasvb90)                    | Amazon      |
-| Zhou Su               | [SuZhou-Joe](https://github.com/SuZhou-Joe)                  | Amazon      |
-| Kshitij Tandon        | [tandonks](https://github.com/tandonks)                      | Amazon      |
-| Shivansh Arora        | [shiv0408](https://github.com/shiv0408)                      | Amazon      |
-| Sooraj Sinha          | [soosinha](https://github.com/soosinha)                      | Amazon      |
-
-## Emeritus
-
-| Maintainer            | GitHub ID                                             | Affiliation |
-| --------------------- | ----------------------------------------------------- | ----------- |
-| Amardeepsingh Siglani | [amsiglan](https://github.com/amsiglan)               | Amazon      |
-| Angie Zhang           | [Angie-Zhang](https://github.com/Angie-Zhang)         | Amazon      |
-| Ashish Agrawal        | [lezzago](https://github.com/lezzago)                 | Amazon      |
-| Binlong Gao           | [gaobinlong](https://github.com/gaobinlong)           | Amazon      |
-| Praveen Sameneni      | [praveensameneni](https://github.com/praveensameneni) | Amazon      |
-| Rohit Ashiwal         | [r1walz](https://github.com/r1walz)                   | Amazon      |
-| Saurabh Singh         | [getsaurabh02](https://github.com/getsaurabh02)       | Amazon      |
-| Subhobrata DEY        | [sbcd90](https://github.com/sbcd90)                   | Amazon      |
-| Surya Sashank Nistala | [eirsep](https://github.com/eirsep)                   | Amazon      |
-| Thomas Hurney         | [AWSHurneyt](https://github.com/AWSHurneyt)           | Amazon      |
-| Xuesong Luo           | [xluo-aws](https://github.com/xluo-aws)               | Amazon      |
+[This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
This reverts commit 2cc34049feecf39cb20c1fc88985cfd70cf98614.

### Description
Reverting last commit to add maintainers

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
