### PR TITLE
Use cat snapshot to get the number of snapshot for a repo (#1242)

### DIFF
--- a/server/models/interfaces.ts
+++ b/server/models/interfaces.ts
@@ -409,6 +409,22 @@ export interface GetSnapshotResponse {
   snapshots: GetSnapshot[];
 }
 
+export interface CatSnapshotsResponse {
+  snapshots: CatSnapshots[];
+}
+
+export interface CatSnapshots {
+  id: string;
+  status: string;
+  start_epoch: number;
+  end_epoch: number;
+  duration: number;
+  indices: number;
+  successful_shards: number;
+  failed_shards: number;
+  total_shards: number;
+}
+
 export interface CreateSnapshotResponse {
   snapshot: GetSnapshot;
 }


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/index-management-dashboards-plugin/commit/c459af0d6c6a01d54c25fc8a915d927a34d0f6af from https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1242.

### Issues Resolved
Resolves https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1244

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
