### PR TITLE
Fix wrong urls to documentation

### DIFF
--- a/public/components/IndexDetail/IndexDetail.tsx
+++ b/public/components/IndexDetail/IndexDetail.tsx
@@ -544,7 +544,7 @@ const IndexDetail = (
                         <p>
                           All the settings will be handled in flat structure.{" "}
                           <EuiLink
-                            href={`https://opensearch.org/docs/${docVersion}/api-reference/index-apis/get-index/#url-parameters`}
+                            href={`https://opensearch.org/docs/${docVersion}/api-reference/index-apis/get-index/#query-parameters`}
                             external
                             target="_blank"
                           >

--- a/public/containers/IndexForm/__snapshots__/IndexForm.test.tsx.snap
+++ b/public/containers/IndexForm/__snapshots__/IndexForm.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`<IndexForm /> spec render page 1`] = `
               class="euiText euiText--small"
             >
               <h3>
-                Index alias
+                Index alias 
                 <i>
                    – optional
                 </i>
@@ -220,7 +220,7 @@ exports[`<IndexForm /> spec render page 1`] = `
             style="padding-top: 0px; padding-bottom: 4px;"
           >
             <div>
-              Specify the number of primary shards for the index. Default is 1.
+              Specify the number of primary shards for the index. Default is 1. 
             </div>
             <div>
               The number of primary shards cannot be changed after the index is created.
@@ -417,6 +417,7 @@ exports[`<IndexForm /> spec render page 1`] = `
                   >
                     <p>
                       Specify a comma-delimited list of settings.
+                       
                       <a
                         class="euiLink euiLink--primary"
                         href="https://opensearch.org/docs/latest/install-and-configure/configuring-opensearch/index-settings/#index-level-index-settings"
@@ -434,6 +435,7 @@ exports[`<IndexForm /> spec render page 1`] = `
                     </p>
                     <p>
                       All the settings will be handled in flat structure.
+                       
                       <a
                         class="euiLink euiLink--primary"
                         href="https://opensearch.org/docs/undefined/api-reference/index-apis/get-index/#query-parameters"
@@ -604,6 +606,7 @@ exports[`<IndexForm /> spec render page 1`] = `
         >
           <div>
             Define how documents and their fields are stored and indexed.
+             
             <a
               class="euiLink euiLink--primary"
               href="https://opensearch.org/docs/undefined/opensearch/mappings/"

--- a/public/containers/IndexForm/__snapshots__/IndexForm.test.tsx.snap
+++ b/public/containers/IndexForm/__snapshots__/IndexForm.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`<IndexForm /> spec render page 1`] = `
               class="euiText euiText--small"
             >
               <h3>
-                Index alias 
+                Index alias
                 <i>
                    – optional
                 </i>
@@ -220,7 +220,7 @@ exports[`<IndexForm /> spec render page 1`] = `
             style="padding-top: 0px; padding-bottom: 4px;"
           >
             <div>
-              Specify the number of primary shards for the index. Default is 1. 
+              Specify the number of primary shards for the index. Default is 1.
             </div>
             <div>
               The number of primary shards cannot be changed after the index is created.
@@ -417,7 +417,7 @@ exports[`<IndexForm /> spec render page 1`] = `
                   >
                     <p>
                       Specify a comma-delimited list of settings.
-                       
+
                       <a
                         class="euiLink euiLink--primary"
                         href="https://opensearch.org/docs/latest/api-reference/index-apis/create-index#index-settings"
@@ -435,10 +435,10 @@ exports[`<IndexForm /> spec render page 1`] = `
                     </p>
                     <p>
                       All the settings will be handled in flat structure.
-                       
+
                       <a
                         class="euiLink euiLink--primary"
-                        href="https://opensearch.org/docs/undefined/api-reference/index-apis/get-index/#url-parameters"
+                        href="https://opensearch.org/docs/undefined/api-reference/index-apis/get-index/#query-parameters"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -606,7 +606,7 @@ exports[`<IndexForm /> spec render page 1`] = `
         >
           <div>
             Define how documents and their fields are stored and indexed.
-             
+
             <a
               class="euiLink euiLink--primary"
               href="https://opensearch.org/docs/undefined/opensearch/mappings/"

--- a/public/containers/IndexForm/__snapshots__/IndexForm.test.tsx.snap
+++ b/public/containers/IndexForm/__snapshots__/IndexForm.test.tsx.snap
@@ -417,10 +417,9 @@ exports[`<IndexForm /> spec render page 1`] = `
                   >
                     <p>
                       Specify a comma-delimited list of settings.
-
                       <a
                         class="euiLink euiLink--primary"
-                        href="https://opensearch.org/docs/latest/api-reference/index-apis/create-index#index-settings"
+                        href="https://opensearch.org/docs/latest/install-and-configure/configuring-opensearch/index-settings/#index-level-index-settings"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -435,7 +434,6 @@ exports[`<IndexForm /> spec render page 1`] = `
                     </p>
                     <p>
                       All the settings will be handled in flat structure.
-
                       <a
                         class="euiLink euiLink--primary"
                         href="https://opensearch.org/docs/undefined/api-reference/index-apis/get-index/#query-parameters"
@@ -606,7 +604,6 @@ exports[`<IndexForm /> spec render page 1`] = `
         >
           <div>
             Define how documents and their fields are stored and indexed.
-
             <a
               class="euiLink euiLink--primary"
               href="https://opensearch.org/docs/undefined/opensearch/mappings/"

--- a/public/pages/CreateComposableTemplate/components/IndexSettings/IndexSettings.tsx
+++ b/public/pages/CreateComposableTemplate/components/IndexSettings/IndexSettings.tsx
@@ -179,7 +179,7 @@ export default function IndexSettings(props: SubDetailProps) {
                   <p>
                     All the settings will be handled in flat structure.{" "}
                     <EuiLink
-                      href="https://opensearch.org/docs/latest/api-reference/index-apis/get-index/#url-parameters"
+                      href="https://opensearch.org/docs/latest/api-reference/index-apis/get-index/#query-parameters"
                       external
                       target="_blank"
                     >

--- a/public/pages/CreateDataStream/components/IndexSettings/IndexSettings.tsx
+++ b/public/pages/CreateDataStream/components/IndexSettings/IndexSettings.tsx
@@ -135,7 +135,7 @@ export default function IndexSettings(props: SubDetailProps) {
               <p>
                 All the settings will be handled in flat structure.{" "}
                 <EuiLink
-                  href="https://opensearch.org/docs/latest/api-reference/index-apis/get-index/#url-parameters"
+                  href="https://opensearch.org/docs/latest/api-reference/index-apis/get-index/#query-parameters"
                   external
                   target="_blank"
                 >

--- a/public/pages/CreateIndexTemplate/components/IndexSettings/IndexSettings.tsx
+++ b/public/pages/CreateIndexTemplate/components/IndexSettings/IndexSettings.tsx
@@ -178,7 +178,7 @@ export default function IndexSettings(props: SubDetailProps) {
               <p>
                 All the settings will be handled in flat structure.{" "}
                 <EuiLink
-                  href="https://opensearch.org/docs/latest/api-reference/index-apis/get-index/#url-parameters"
+                  href="https://opensearch.org/docs/latest/api-reference/index-apis/get-index/#query-parameters"
                   external
                   target="_blank"
                 >

--- a/public/pages/CreateIndexTemplate/containers/CreateIndexTemplate/__snapshots__/CreateIndexTemplate.test.tsx.snap
+++ b/public/pages/CreateIndexTemplate/containers/CreateIndexTemplate/__snapshots__/CreateIndexTemplate.test.tsx.snap
@@ -457,7 +457,6 @@ exports[`<CreateIndexTemplate /> spec render template pages 1`] = `
                     >
                       <p>
                         Specify a comma-delimited list of settings.
-                         
                         <a
                           class="euiLink euiLink--primary"
                           href="https://opensearch.org/docs/latest/api-reference/index-apis/create-index#index-settings"
@@ -475,10 +474,9 @@ exports[`<CreateIndexTemplate /> spec render template pages 1`] = `
                       </p>
                       <p>
                         All the settings will be handled in flat structure.
-                         
                         <a
                           class="euiLink euiLink--primary"
-                          href="https://opensearch.org/docs/latest/api-reference/index-apis/get-index/#url-parameters"
+                          href="https://opensearch.org/docs/latest/api-reference/index-apis/get-index/#query-parameters"
                           rel="noopener noreferrer"
                           target="_blank"
                         >
@@ -642,7 +640,6 @@ exports[`<CreateIndexTemplate /> spec render template pages 1`] = `
             >
               <div>
                 Define how documents and their fields are stored and indexed.
-                 
                 <a
                   class="euiLink euiLink--primary"
                   href="https://opensearch.org/docs/undefined/opensearch/mappings/"

--- a/public/pages/CreateIndexTemplate/containers/CreateIndexTemplate/__snapshots__/CreateIndexTemplate.test.tsx.snap
+++ b/public/pages/CreateIndexTemplate/containers/CreateIndexTemplate/__snapshots__/CreateIndexTemplate.test.tsx.snap
@@ -459,7 +459,7 @@ exports[`<CreateIndexTemplate /> spec render template pages 1`] = `
                         Specify a comma-delimited list of settings.
                         <a
                           class="euiLink euiLink--primary"
-                          href="https://opensearch.org/docs/latest/api-reference/index-apis/create-index#index-settings"
+                          href="https://opensearch.org/docs/latest/install-and-configure/configuring-opensearch/index-settings/#index-level-index-settings"
                           rel="noopener noreferrer"
                           target="_blank"
                         >

--- a/public/pages/CreateIndexTemplate/containers/CreateIndexTemplate/__snapshots__/CreateIndexTemplate.test.tsx.snap
+++ b/public/pages/CreateIndexTemplate/containers/CreateIndexTemplate/__snapshots__/CreateIndexTemplate.test.tsx.snap
@@ -457,6 +457,7 @@ exports[`<CreateIndexTemplate /> spec render template pages 1`] = `
                     >
                       <p>
                         Specify a comma-delimited list of settings.
+                         
                         <a
                           class="euiLink euiLink--primary"
                           href="https://opensearch.org/docs/latest/install-and-configure/configuring-opensearch/index-settings/#index-level-index-settings"
@@ -474,6 +475,7 @@ exports[`<CreateIndexTemplate /> spec render template pages 1`] = `
                       </p>
                       <p>
                         All the settings will be handled in flat structure.
+                         
                         <a
                           class="euiLink euiLink--primary"
                           href="https://opensearch.org/docs/latest/api-reference/index-apis/get-index/#query-parameters"
@@ -640,6 +642,7 @@ exports[`<CreateIndexTemplate /> spec render template pages 1`] = `
             >
               <div>
                 Define how documents and their fields are stored and indexed.
+                 
                 <a
                   class="euiLink euiLink--primary"
                   href="https://opensearch.org/docs/undefined/opensearch/mappings/"

--- a/public/pages/CreateIndexTemplate/containers/TemplateDetail/__snapshots__/TemplateDetail.test.tsx.snap
+++ b/public/pages/CreateIndexTemplate/containers/TemplateDetail/__snapshots__/TemplateDetail.test.tsx.snap
@@ -29,7 +29,6 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
           >
             <div>
               Index templates let you initialize new indexes with predefined mappings and settings.
-               
               <a
                 class="euiLink euiLink--primary"
                 href="https://opensearch.org/docs/latest/opensearch/index-templates"
@@ -870,7 +869,6 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
                   >
                     <p>
                       Specify a comma-delimited list of settings.
-                       
                       <a
                         class="euiLink euiLink--primary"
                         href="https://opensearch.org/docs/latest/api-reference/index-apis/create-index#index-settings"
@@ -888,10 +886,10 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
                     </p>
                     <p>
                       All the settings will be handled in flat structure.
-                       
+
                       <a
                         class="euiLink euiLink--primary"
-                        href="https://opensearch.org/docs/latest/api-reference/index-apis/get-index/#url-parameters"
+                        href="https://opensearch.org/docs/latest/api-reference/index-apis/get-index/#query-parameters"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -1052,7 +1050,6 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
           >
             <div>
               Define how documents and their fields are stored and indexed.
-               
               <a
                 class="euiLink euiLink--primary"
                 href="https://opensearch.org/docs/undefined/opensearch/mappings/"

--- a/public/pages/CreateIndexTemplate/containers/TemplateDetail/__snapshots__/TemplateDetail.test.tsx.snap
+++ b/public/pages/CreateIndexTemplate/containers/TemplateDetail/__snapshots__/TemplateDetail.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
           >
             <div>
               Index templates let you initialize new indexes with predefined mappings and settings.
+               
               <a
                 class="euiLink euiLink--primary"
                 href="https://opensearch.org/docs/latest/opensearch/index-templates"
@@ -869,6 +870,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
                   >
                     <p>
                       Specify a comma-delimited list of settings.
+                       
                       <a
                         class="euiLink euiLink--primary"
                         href="https://opensearch.org/docs/latest/install-and-configure/configuring-opensearch/index-settings/#index-level-index-settings"
@@ -886,7 +888,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
                     </p>
                     <p>
                       All the settings will be handled in flat structure.
-
+                       
                       <a
                         class="euiLink euiLink--primary"
                         href="https://opensearch.org/docs/latest/api-reference/index-apis/get-index/#query-parameters"
@@ -1050,6 +1052,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
           >
             <div>
               Define how documents and their fields are stored and indexed.
+               
               <a
                 class="euiLink euiLink--primary"
                 href="https://opensearch.org/docs/undefined/opensearch/mappings/"

--- a/public/pages/CreateIndexTemplate/containers/TemplateDetail/__snapshots__/TemplateDetail.test.tsx.snap
+++ b/public/pages/CreateIndexTemplate/containers/TemplateDetail/__snapshots__/TemplateDetail.test.tsx.snap
@@ -871,7 +871,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
                       Specify a comma-delimited list of settings.
                       <a
                         class="euiLink euiLink--primary"
-                        href="https://opensearch.org/docs/latest/api-reference/index-apis/create-index#index-settings"
+                        href="https://opensearch.org/docs/latest/install-and-configure/configuring-opensearch/index-settings/#index-level-index-settings"
                         rel="noopener noreferrer"
                         target="_blank"
                       >

--- a/public/pages/Reindex/components/CreateIndexFlyout/__snapshots__/CreateIndexFlyout.test.tsx.snap
+++ b/public/pages/Reindex/components/CreateIndexFlyout/__snapshots__/CreateIndexFlyout.test.tsx.snap
@@ -39,7 +39,7 @@ Object {
               <h2
                 id="flyoutTitle"
               >
-                 Create Index
+                 Create Index 
               </h2>
             </div>
           </div>
@@ -146,7 +146,7 @@ Object {
                             class="euiText euiText--small"
                           >
                             <h3>
-                              Index alias
+                              Index alias 
                               <i>
                                  – optional
                               </i>
@@ -271,7 +271,7 @@ Object {
                           style="padding-top: 0px; padding-bottom: 4px;"
                         >
                           <div>
-                            Specify the number of primary shards for the index. Default is 1.
+                            Specify the number of primary shards for the index. Default is 1. 
                           </div>
                           <div>
                             The number of primary shards cannot be changed after the index is created.
@@ -468,6 +468,7 @@ Object {
                                 >
                                   <p>
                                     Specify a comma-delimited list of settings.
+                                     
                                     <a
                                       class="euiLink euiLink--primary"
                                       href="https://opensearch.org/docs/latest/install-and-configure/configuring-opensearch/index-settings/#index-level-index-settings"
@@ -485,6 +486,7 @@ Object {
                                   </p>
                                   <p>
                                     All the settings will be handled in flat structure.
+                                     
                                     <a
                                       class="euiLink euiLink--primary"
                                       href="https://opensearch.org/docs/undefined/api-reference/index-apis/get-index/#query-parameters"
@@ -659,6 +661,7 @@ Object {
                       >
                         <div>
                           Define how documents and their fields are stored and indexed.
+                           
                           <a
                             class="euiLink euiLink--primary"
                             href="https://opensearch.org/docs/undefined/opensearch/mappings/"

--- a/public/pages/Reindex/components/CreateIndexFlyout/__snapshots__/CreateIndexFlyout.test.tsx.snap
+++ b/public/pages/Reindex/components/CreateIndexFlyout/__snapshots__/CreateIndexFlyout.test.tsx.snap
@@ -470,7 +470,7 @@ Object {
                                     Specify a comma-delimited list of settings.
                                     <a
                                       class="euiLink euiLink--primary"
-                                      href="https://opensearch.org/docs/latest/api-reference/index-apis/create-index#index-settings"
+                                      href="https://opensearch.org/docs/latest/install-and-configure/configuring-opensearch/index-settings/#index-level-index-settings"
                                       rel="noopener noreferrer"
                                       target="_blank"
                                     >

--- a/public/pages/Reindex/components/CreateIndexFlyout/__snapshots__/CreateIndexFlyout.test.tsx.snap
+++ b/public/pages/Reindex/components/CreateIndexFlyout/__snapshots__/CreateIndexFlyout.test.tsx.snap
@@ -39,7 +39,7 @@ Object {
               <h2
                 id="flyoutTitle"
               >
-                 Create Index 
+                 Create Index
               </h2>
             </div>
           </div>
@@ -146,7 +146,7 @@ Object {
                             class="euiText euiText--small"
                           >
                             <h3>
-                              Index alias 
+                              Index alias
                               <i>
                                  – optional
                               </i>
@@ -271,7 +271,7 @@ Object {
                           style="padding-top: 0px; padding-bottom: 4px;"
                         >
                           <div>
-                            Specify the number of primary shards for the index. Default is 1. 
+                            Specify the number of primary shards for the index. Default is 1.
                           </div>
                           <div>
                             The number of primary shards cannot be changed after the index is created.
@@ -468,7 +468,6 @@ Object {
                                 >
                                   <p>
                                     Specify a comma-delimited list of settings.
-                                     
                                     <a
                                       class="euiLink euiLink--primary"
                                       href="https://opensearch.org/docs/latest/api-reference/index-apis/create-index#index-settings"
@@ -486,10 +485,9 @@ Object {
                                   </p>
                                   <p>
                                     All the settings will be handled in flat structure.
-                                     
                                     <a
                                       class="euiLink euiLink--primary"
-                                      href="https://opensearch.org/docs/undefined/api-reference/index-apis/get-index/#url-parameters"
+                                      href="https://opensearch.org/docs/undefined/api-reference/index-apis/get-index/#query-parameters"
                                       rel="noopener noreferrer"
                                       target="_blank"
                                     >
@@ -661,7 +659,6 @@ Object {
                       >
                         <div>
                           Define how documents and their fields are stored and indexed.
-                           
                           <a
                             class="euiLink euiLink--primary"
                             href="https://opensearch.org/docs/undefined/opensearch/mappings/"

--- a/public/pages/ShrinkIndex/container/ShrinkIndex/__snapshots__/ShrinkIndex.test.tsx.snap
+++ b/public/pages/ShrinkIndex/container/ShrinkIndex/__snapshots__/ShrinkIndex.test.tsx.snap
@@ -387,7 +387,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
                 class="euiText euiText--small"
               >
                 <h3>
-                  Index alias
+                  Index alias 
                   <i>
                      – optional
                   </i>

--- a/public/pages/ShrinkIndex/container/ShrinkIndex/__snapshots__/ShrinkIndex.test.tsx.snap
+++ b/public/pages/ShrinkIndex/container/ShrinkIndex/__snapshots__/ShrinkIndex.test.tsx.snap
@@ -387,7 +387,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
                 class="euiText euiText--small"
               >
                 <h3>
-                  Index alias 
+                  Index alias
                   <i>
                      – optional
                   </i>
@@ -534,7 +534,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
                       Specify a comma-delimited list of settings. 
                       <a
                         class="euiLink euiLink--primary"
-                        href="https://opensearch.org/docs/latest/api-reference/index-apis/create-index#index-settings"
+                        href="https://opensearch.org/docs/latest/install-and-configure/configuring-opensearch/index-settings/#index-level-index-settings"
                         rel="noopener noreferrer"
                         target="_blank"
                       >

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -16,7 +16,8 @@ export const ACTIONS_DOCUMENTATION_URL = "https://opensearch.org/docs/im-plugin/
 export const STATES_DOCUMENTATION_URL = "https://opensearch.org/docs/im-plugin/ism/policies/#states";
 export const ERROR_NOTIFICATION_DOCUMENTATION_URL = "https://opensearch.org/docs/im-plugin/ism/policies/#error-notifications";
 export const TRANSITION_DOCUMENTATION_URL = "https://opensearch.org/docs/im-plugin/ism/policies/#transitions";
-export const INDEX_SETTINGS_URL = "https://opensearch.org/docs/latest/api-reference/index-apis/create-index#index-settings";
+export const INDEX_SETTINGS_URL =
+  "https://opensearch.org/docs/latest/install-and-configure/configuring-opensearch/index-settings/#index-level-index-settings";
 export const SNAPSHOT_MANAGEMENT_DOCUMENTATION_URL = "https://opensearch.org/docs/latest/opensearch/snapshots/snapshot-management/";
 export const CRON_EXPRESSION_DOCUMENTATION_URL = "https://opensearch.org/docs/latest/monitoring-plugins/alerting/cron/";
 export const RESTORE_SNAPSHOT_DOCUMENTATION_URL =


### PR DESCRIPTION
### Description
Fix wrong urls to documentation:
- index settings
- create index query params

### Issues Resolved
None

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
