### PR TITLE
Replace delete-merged-branch action with GitHub script

### DIFF
--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   delete-branch:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     if: startsWith(github.event.pull_request.head.ref,'backport/') || startsWith(github.event.pull_request.head.ref,'release-chores/')
     steps:
       - name: Delete merged branch


### PR DESCRIPTION
This PR replaces the SvanBoxel/delete-merged-branch action with a custom GitHub script using actions/github-script@v7. This provides a more direct approach using the GitHub API to delete branches after they are merged.