### PR TITLE
Fix snapshot restore: do not rename option should not add prefix

### DIFF
--- a/public/pages/Snapshots/components/RestoreSnapshotFlyout/RestoreSnapshotFlyout.tsx
+++ b/public/pages/Snapshots/components/RestoreSnapshotFlyout/RestoreSnapshotFlyout.tsx
@@ -332,9 +332,12 @@ export class RestoreSnapshotFlyout extends MDSEnabledComponent<RestoreSnapshotPr
       let renamePattern = this.state.renamePattern;
       let renameReplacement = this.state.renameReplacement;
 
-      if (e.target.id !== "rename_indices") {
+      if (e.target.id === "add_prefix") {
         renamePattern = "(.+)";
         renameReplacement = "restored_$1";
+      } else if (e.target.id === "do_not_rename") {
+        renamePattern = "(.+)";
+        renameReplacement = "$1";
       }
 
       this.setState({


### PR DESCRIPTION
### Description
Fixed a bug in the snapshot restoration functionality where the "Do not rename" option was incorrectly adding a "restored_" prefix to index names during restoration.

### Issues Resolved
#850
#1003

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
