### PR TITLE
Fix CreateSnapshotPolicy handling of indices array format

### DIFF
--- a/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.test.tsx
+++ b/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.test.tsx
@@ -1,0 +1,199 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render, waitFor } from "@testing-library/react";
+import { MemoryRouter as Router, Redirect, Route, Switch, RouteComponentProps } from "react-router-dom";
+import { CoreStart } from "opensearch-dashboards/public";
+import CreateSnapshotPolicy from "./CreateSnapshotPolicy";
+import { browserServicesMock, coreServicesMock } from "../../../../../test/mocks";
+import { ROUTES } from "../../../../utils/constants";
+import { ServicesConsumer, ServicesContext } from "../../../../services";
+import { ModalProvider, ModalRoot } from "../../../../components/Modal";
+import { CoreServicesConsumer, CoreServicesContext } from "../../../../components/core_services";
+import { getApplication, getNavigationUI, getUISettings } from "../../../../services/Services";
+import { BrowserServices } from "../../../../models/interfaces";
+
+jest.mock("../../../../services/Services", () => ({
+  ...jest.requireActual("../../../../services/Services"),
+  getUISettings: jest.fn(),
+  getApplication: jest.fn(),
+  getNavigationUI: jest.fn(),
+}));
+
+beforeEach(() => {
+  (getUISettings as jest.Mock).mockReturnValue({
+    get: jest.fn().mockReturnValue(false),
+  });
+  (getApplication as jest.Mock).mockReturnValue({});
+  (getNavigationUI as jest.Mock).mockReturnValue({});
+});
+
+function renderCreateSnapshotPolicyWithRouter(initialEntries = ["/"], isEdit = false) {
+  return {
+    ...render(
+      <Router initialEntries={initialEntries}>
+        <CoreServicesContext.Provider value={coreServicesMock}>
+          <ServicesContext.Provider value={browserServicesMock}>
+            <ServicesConsumer>
+              {(services: BrowserServices | null) =>
+                services && (
+                  <CoreServicesConsumer>
+                    {(core: CoreStart | null) =>
+                      core && (
+                        <ModalProvider>
+                          <ModalRoot services={services} />
+                          <Switch>
+                            <Route
+                              path={ROUTES.CREATE_SNAPSHOT_POLICY}
+                              render={(props: RouteComponentProps) => (
+                                <CreateSnapshotPolicy 
+                                  {...props} 
+                                  isEdit={isEdit} 
+                                  snapshotManagementService={services.snapshotManagementService}
+                                  indexService={services.indexService}
+                                  notificationService={services.notificationService}
+                                />
+                              )}
+                            />
+                            <Route
+                              path="/edit-snapshot-policy"
+                              render={(props: RouteComponentProps) => (
+                                <CreateSnapshotPolicy 
+                                  {...props} 
+                                  isEdit={true} 
+                                  snapshotManagementService={services.snapshotManagementService}
+                                  indexService={services.indexService}
+                                  notificationService={services.notificationService}
+                                />
+                              )}
+                            />
+                            <Route path={ROUTES.SNAPSHOT_POLICIES} render={() => <div>Testing Snapshot Policies</div>} />
+                            <Redirect from="/" to={ROUTES.CREATE_SNAPSHOT_POLICY} />
+                          </Switch>
+                        </ModalProvider>
+                      )
+                    }
+                  </CoreServicesConsumer>
+                )
+              }
+            </ServicesConsumer>
+          </ServicesContext.Provider>
+        </CoreServicesContext.Provider>
+      </Router>
+    ),
+  };
+}
+
+describe("<CreateSnapshotPolicy /> spec", () => {
+  it("renders the component", async () => {
+    const { container } = renderCreateSnapshotPolicyWithRouter();
+    await waitFor(() => {});
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("sets breadcrumbs when mounting", async () => {
+    renderCreateSnapshotPolicyWithRouter();
+    expect(coreServicesMock.chrome.setBreadcrumbs).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles indices as array format when editing policy", async () => {
+    // Mock the getPolicy response with indices as array
+    browserServicesMock.snapshotManagementService.getPolicy = jest.fn().mockResolvedValue({
+      ok: true,
+      response: {
+        id: "test-policy",
+        seqNo: 0,
+        primaryTerm: 1,
+        policy: {
+          name: "test-policy",
+          description: "Test policy",
+          snapshot_config: {
+            indices: ["index1", "index2", "index3"],
+            repository: "test-repo"
+          },
+          creation: {
+            schedule: {
+              cron: {
+                expression: "0 0 * * *",
+                timezone: "UTC"
+              }
+            }
+          },
+          enabled: true
+        }
+      }
+    });
+
+    const { getByText } = renderCreateSnapshotPolicyWithRouter(["/edit-snapshot-policy?id=test-policy"], true);
+    
+    await waitFor(() => {
+      // Wait for the policy to load without error
+      expect(browserServicesMock.snapshotManagementService.getPolicy).toHaveBeenCalledWith("test-policy");
+      // No error toasts should be shown
+      expect(coreServicesMock.notifications.toasts.addDanger).not.toHaveBeenCalled();
+    });
+  });
+
+  it("handles indices as string format when editing policy", async () => {
+    // Mock the getPolicy response with indices as string 
+    browserServicesMock.snapshotManagementService.getPolicy = jest.fn().mockResolvedValue({
+      ok: true,
+      response: {
+        id: "test-policy",
+        seqNo: 0,
+        primaryTerm: 1,
+        policy: {
+          name: "test-policy",
+          description: "Test policy", 
+          snapshot_config: {
+            indices: "index1,index2,index3",
+            repository: "test-repo"
+          },
+          creation: {
+            schedule: {
+              cron: {
+                expression: "0 0 * * *",
+                timezone: "UTC"
+              }
+            }
+          },
+          enabled: true
+        }
+      }
+    });
+
+    const { getByText } = renderCreateSnapshotPolicyWithRouter(["/edit-snapshot-policy?id=test-policy"], true);
+    
+    await waitFor(() => {
+      expect(browserServicesMock.snapshotManagementService.getPolicy).toHaveBeenCalledWith("test-policy");
+      expect(coreServicesMock.notifications.toasts.addDanger).not.toHaveBeenCalled();
+    });
+  });
+
+  it("handles policy loading error gracefully", async () => {
+    browserServicesMock.snapshotManagementService.getPolicy = jest.fn().mockResolvedValue({
+      ok: false,
+      error: "Policy not found"
+    });
+
+    const { getByText } = renderCreateSnapshotPolicyWithRouter(["/edit-snapshot-policy?id=test-policy"], true);
+    
+    await waitFor(() => getByText("Testing Snapshot Policies"));
+    expect(coreServicesMock.notifications.toasts.addDanger).toHaveBeenCalledWith(
+      "Could not load the policy: Policy not found"
+    );
+  });
+
+  it("handles policy loading exception gracefully", async () => {
+    browserServicesMock.snapshotManagementService.getPolicy = jest.fn().mockRejectedValue(new Error("Network error"));
+
+    const { getByText } = renderCreateSnapshotPolicyWithRouter(["/edit-snapshot-policy?id=test-policy"], true);
+    
+    await waitFor(() => getByText("Testing Snapshot Policies"));
+    expect(coreServicesMock.notifications.toasts.addDanger).toHaveBeenCalledWith("Could not load the policy");
+  });
+});

--- a/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
+++ b/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
@@ -234,14 +234,23 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
       const { snapshotManagementService } = this.props;
       const response = await snapshotManagementService.getPolicy(policyId);
 
-      if (response.ok) {
+      if (response.ok && response.response && response.response.policy) {
         // Populate policy into state
         const policy = response.response.policy;
         const indices = _.get(policy, "snapshot_config.indices", "");
-        const selectedIndexOptions = indices
-          .split(",")
-          .filter((index: string) => !!index)
-          .map((label: string) => ({ label }));
+        
+        // Handle both array and string format for indices
+        let selectedIndexOptions: { label: string }[] = [];
+        if (Array.isArray(indices)) {
+          selectedIndexOptions = indices
+            .filter((index: string) => !!index)
+            .map((label: string) => ({ label }));
+        } else if (typeof indices === 'string') {
+          selectedIndexOptions = indices
+            .split(",")
+            .filter((index: string) => !!index)
+            .map((label: string) => ({ label }));
+        }
         const selectedRepoValue = _.get(policy, "snapshot_config.repository", "");
 
         const { frequencyType: creationScheduleFrequencyType } = parseCronExpression(_.get(policy, "creation.schedule.cron.expression"));


### PR DESCRIPTION
The CreateSnapshotPolicy component was failing when the API returned indices as an array instead of a string, causing TypeError: indices.split is not a function. The API permits both a string and array, I was using the array. Another fix could be to make the API more restrictive but that might impact users who have done the same and actually I like the array better than a delimited string.

So, frontend fix with Claude Code to permit this. Tests succeed locally.

Changes:
- Updated getPolicy method to handle both array and string formats for indices
- Added comprehensive unit tests to prevent regression
- Maintains backward compatibility with existing string format

Fixes issue where editing snapshot policies would fail with TypeError when indices were returned as an array from the API.

### Description
Fixed the loading error

### Issues Resolved
https://github.com/opensearch-project/index-management-dashboards-plugin/issues/946

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
