### PR TITLE
Fix failing cypress tests

### DIFF
--- a/.github/workflows/cypress-with-security-workflow.yml
+++ b/.github/workflows/cypress-with-security-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - "*"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: 'main'
+  OPENSEARCH_DASHBOARDS_VERSION: '3.5'
 jobs:
   tests:
     name: Run Cypress E2E tests with security

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - "*"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: 'main'
+  OPENSEARCH_DASHBOARDS_VERSION: '3.5'
   CYPRESS_MEMORY_LIMIT: '40960'
   NODE_OPTIONS: '--max-old-space-size=40960'
 jobs:

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - "*"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: 'main'
+  OPENSEARCH_DASHBOARDS_VERSION: '3.5'
 jobs:
   Get-CI-Image-Tag:
     uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main

--- a/cypress/e2e/plugins/index-management-dashboards-plugin/managed_indices_spec.js
+++ b/cypress/e2e/plugins/index-management-dashboards-plugin/managed_indices_spec.js
@@ -29,7 +29,7 @@ describe("Managed indexes", () => {
     // Common text to wait for to confirm page loaded, give up to 60 seconds for initial load
     cy.contains("Edit rollover alias", { timeout: 60000 });
 
-    cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+    cy.dismissToast();
   });
 
   describe("can have policies removed", () => {
@@ -90,7 +90,7 @@ describe("Managed indexes", () => {
       // Wait up to 5 seconds for the managed index to execute
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(5000).reload();
-      cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+      cy.dismissToast();
 
       // Confirm managed index successfully initialized the policy
       cy.contains("Successfully initialized", { timeout: 20000 });
@@ -100,7 +100,7 @@ describe("Managed indexes", () => {
       // Wait up to 5 seconds for managed index to execute
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(5000).reload();
-      cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+      cy.dismissToast();
 
       // Confirm we have a Failed execution, wait up to 20 seconds as OSD takes a while to load
       cy.contains("Failed", { timeout: 20000 });
@@ -125,7 +125,7 @@ describe("Managed indexes", () => {
 
       // Reload the page
       cy.reload();
-      cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+      cy.dismissToast();
 
       // Confirm we see managed index attempting to retry, give 20 seconds for OSD load
       cy.contains("Pending retry of failed managed index", { timeout: 20000 });
@@ -136,7 +136,7 @@ describe("Managed indexes", () => {
       // Wait up to 5 seconds for managed index to execute
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(5000).reload();
-      cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+      cy.dismissToast();
 
       // Confirm managed index successfully rolled over
       cy.contains("Successfully rolled over", { timeout: 20000 });

--- a/cypress/e2e/plugins/index-management-dashboards-plugin/policies_spec.js
+++ b/cypress/e2e/plugins/index-management-dashboards-plugin/policies_spec.js
@@ -73,6 +73,7 @@ describe("Policies", () => {
         add: ["alias1", "alias2"],
         remove: ["alias3", "alias5", "alias6"],
       };
+      const testIndexPattern = "test-index-pattern";
 
       // Route us to create policy page
       cy.contains("Create policy").click({ force: true });
@@ -88,6 +89,12 @@ describe("Policies", () => {
 
       // Type in the policy description
       cy.get(`[data-test-subj="create-policy-description"]`).type("{selectall}{backspace}" + sampleAliasPolicy.policy.description);
+
+      // Add an ISM template
+      cy.get("button").contains("Add template").click({ force: true });
+
+      // Enter an index pattern
+      cy.get(`[data-test-subj="comboBoxInput"]`).type(testIndexPattern);
 
       // Add a state
       cy.get("button").contains("Add state").click({ force: true });


### PR DESCRIPTION
### Description
Fix for the failing cypress tests and unit tests failing to bootstrap

### Issues Resolved
Change workflows to use OPENSEARCH_DASHBOARDS_VERSION as 3.5 to prevent react-dom version conflict. Fix tests in managed_indices_spec.js and policies_spec.js. All the remaining cypress tests pass in local testing.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
