### PR TITLE
Fix blank page when trying to list SM policies when one of them does not have creation field

### DIFF
--- a/public/pages/SnapshotPolicies/containers/SnapshotPolicies/SnapshotPolicies.tsx
+++ b/public/pages/SnapshotPolicies/containers/SnapshotPolicies/SnapshotPolicies.tsx
@@ -154,6 +154,9 @@ export class SnapshotPolicies extends MDSEnabledComponent<SnapshotPoliciesProps,
         dataType: "string",
         width: "180px",
         render: (name: string, item: SMPolicy) => {
+          if (!item.creation) {
+            return "-";
+          }
           const expression = name;
           const timezone = item.creation.schedule.cron.timezone;
           return `${humanCronExpression(parseCronExpression(expression), expression, timezone)}`;

--- a/public/pages/SnapshotPolicyDetails/containers/SnapshotPolicyDetails/SnapshotPolicyDetails.tsx
+++ b/public/pages/SnapshotPolicyDetails/containers/SnapshotPolicyDetails/SnapshotPolicyDetails.tsx
@@ -299,16 +299,21 @@ export class SnapshotPolicyDetails extends MDSEnabledComponent<SnapshotPolicyDet
       // { term: "Time zone of timestamp", value: `${_.get(policy, "snapshot_config.date_format_timezone")}` },
     ];
 
-    const createCronExpression = policy.creation.schedule.cron.expression;
-    const { minute, hour, dayOfWeek, dayOfMonth, frequencyType } = parseCronExpression(createCronExpression);
-    const humanCron = humanCronExpression(
-      { minute, hour, dayOfWeek, dayOfMonth, frequencyType },
-      createCronExpression,
-      policy.creation.schedule.cron.timezone
-    );
+    let frequencyType = "-";
+    let humanCron;
+    if (policy.creation != null) {
+      const createCronExpression = policy.creation.schedule.cron.expression;
+      const { minute, hour, dayOfWeek, dayOfMonth, frequencyType } = parseCronExpression(createCronExpression);
+      humanCron = humanCronExpression(
+        { minute, hour, dayOfWeek, dayOfMonth, frequencyType },
+        createCronExpression,
+        policy.creation.schedule.cron.timezone
+      );
+    }
+
     const snapshotScheduleItems = [
       { term: "Frequency", value: _.capitalize(frequencyType) },
-      { term: "Cron schedule", value: humanCron },
+      { term: "Cron schedule", value: humanCron ?? "-" },
       { term: "Next snapshot time", value: renderTimestampMillis(metadata?.creation?.trigger.time) },
     ];
 

--- a/public/pages/SnapshotPolicyDetails/containers/SnapshotPolicyDetails/SnapshotPolicyDetails.tsx
+++ b/public/pages/SnapshotPolicyDetails/containers/SnapshotPolicyDetails/SnapshotPolicyDetails.tsx
@@ -299,11 +299,12 @@ export class SnapshotPolicyDetails extends MDSEnabledComponent<SnapshotPolicyDet
       // { term: "Time zone of timestamp", value: `${_.get(policy, "snapshot_config.date_format_timezone")}` },
     ];
 
-    let frequencyType = "-";
+    let frequency;
     let humanCron;
     if (policy.creation != null) {
       const createCronExpression = policy.creation.schedule.cron.expression;
       const { minute, hour, dayOfWeek, dayOfMonth, frequencyType } = parseCronExpression(createCronExpression);
+      frequency = _.capitalize(frequencyType);
       humanCron = humanCronExpression(
         { minute, hour, dayOfWeek, dayOfMonth, frequencyType },
         createCronExpression,
@@ -312,7 +313,7 @@ export class SnapshotPolicyDetails extends MDSEnabledComponent<SnapshotPolicyDet
     }
 
     const snapshotScheduleItems = [
-      { term: "Frequency", value: _.capitalize(frequencyType) },
+      { term: "Frequency", value: frequency ?? "-" },
       { term: "Cron schedule", value: humanCron ?? "-" },
       { term: "Next snapshot time", value: renderTimestampMillis(metadata?.creation?.trigger.time) },
     ];


### PR DESCRIPTION
### Description
It's impossible to list Snapshot Policies if one of the policies does not have creation field defined. This https://github.com/opensearch-project/index-management/pull/1452 made the creation field optional in SMPolicy, allowing deletion-only policies.
This PR makes it possible to view policy list even when one of policies does not have creation field.

### Issues Resolved
https://github.com/opensearch-project/index-management-dashboards-plugin/issues/1405

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
