### PR TITLE
Fixing CVE-2026-2739

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "cipher-base": "^1.0.7",
     "sha.js": "^2.4.12",
     "qs": "^6.14.1",
-    "lodash": "^4.17.23"
+    "lodash": "^4.17.23",
+    "bn.js": "^4.12.3"
   },
   "devDependencies": {
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",


### PR DESCRIPTION
### Description
https://advisories.opensearch.org/advisories/CVE-2026-2739

### Issues Resolved
It will fix this - https://advisories.opensearch.org/advisories/CVE-2026-2739

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
