### PR TITLE
fix: Handle deletion-only SM policies in the UI

### DIFF
--- a/models/interfaces.ts
+++ b/models/interfaces.ts
@@ -210,7 +210,7 @@ export interface SMWorkflowMetadata {
 export interface SMPolicy {
   name: string;
   description: string;
-  creation: SMCreation;
+  creation?: SMCreation;
   deletion?: SMDeletion;
   snapshot_config: SMSnapshotConfig;
   enabled: boolean;

--- a/public/pages/CreateSnapshotPolicy/components/CronSchedule/CronSchedule.tsx
+++ b/public/pages/CreateSnapshotPolicy/components/CronSchedule/CronSchedule.tsx
@@ -35,6 +35,7 @@ interface CronScheduleProps {
   onChangeTimezone?: (timezone: string) => void;
   timezoneError?: string;
   frequencyTitle?: string;
+  disabled?: boolean;
 }
 
 const CronSchedule = ({
@@ -47,6 +48,7 @@ const CronSchedule = ({
   onChangeTimezone,
   timezoneError,
   frequencyTitle = "Schedule frequency",
+  disabled = false,
 }: CronScheduleProps) => {
   const { minute: initMin, hour: initHour, dayOfWeek: initWeek, dayOfMonth: initMonth } = parseCronExpression(cronExpression);
 
@@ -79,6 +81,9 @@ const CronSchedule = ({
   }, [minute, hour, dayOfWeek, dayOfMonth]);
 
   const changeCron = (input?: any) => {
+    if (disabled) {
+      return;
+    }
     let cronParts = { hour, minute, dayOfWeek, dayOfMonth, frequencyType };
     cronParts = { ...cronParts, ...input };
     const expression = buildCronExpression(cronParts, cronExpression);
@@ -113,7 +118,14 @@ const CronSchedule = ({
 
   const dayOfWeekCheckbox = (day: string, checkedDay: string) => (
     <EuiFlexItem key={day} grow={false} style={{ marginRight: "0px" }}>
-      <EuiCheckbox id={day} label={day} checked={checkedDay === day} onChange={(e) => onDayOfWeekChange(day)} compressed />
+      <EuiCheckbox
+        id={day}
+        label={day}
+        checked={checkedDay === day}
+        onChange={(e) => onDayOfWeekChange(day)}
+        compressed
+        disabled={disabled}
+      />
     </EuiFlexItem>
   );
 
@@ -127,6 +139,7 @@ const CronSchedule = ({
       onChange={onStartTimeChange}
       dateFormat="HH:mm"
       timeFormat="HH:mm"
+      disabled={disabled}
     />
   );
   if (frequencyType === "hourly") {
@@ -144,7 +157,7 @@ const CronSchedule = ({
         <CustomLabel title="On the" />
         <EuiFlexGroup gutterSize="m">
           <EuiFlexItem>
-            <EuiCompressedSelect options={[{ value: "day", text: "Day" }]} defaultValue="Day" />
+            <EuiCompressedSelect options={[{ value: "day", text: "Day" }]} defaultValue="Day" disabled={disabled} />
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiCompressedFieldNumber
@@ -154,6 +167,7 @@ const CronSchedule = ({
               }}
               min={1}
               max={31}
+              disabled={disabled}
             />
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -180,6 +194,7 @@ const CronSchedule = ({
         options={CRON_SCHEDULE_FREQUENCY_TYPE}
         value={frequencyType}
         onChange={onTypeChange}
+        disabled={disabled}
       />
 
       <EuiSpacer size="m" />
@@ -195,6 +210,7 @@ const CronSchedule = ({
                   onChange={(e) => {
                     onCronExpressionChange(e.target.value);
                   }}
+                  disabled={disabled}
                 />
               </EuiCompressedFormRow>
             </>
@@ -225,6 +241,7 @@ const CronSchedule = ({
                     onChangeTimezone(_.first(options)?.label ?? "");
                   }
                 }}
+                isDisabled={disabled}
               />
             </EuiCompressedFormRow>
           </EuiFlexItem>

--- a/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
+++ b/public/pages/CreateSnapshotPolicy/containers/CreateSnapshotPolicy/CreateSnapshotPolicy.tsx
@@ -89,6 +89,7 @@ interface CreateSMPolicyState extends DataSourceMenuProperties {
   creationScheduleFrequencyType: string;
   deletionScheduleFrequencyType: string;
 
+  deletionOnlyPolicy: boolean; // edit-only: the loaded policy has no creation workflow
   deleteConditionEnabled: boolean;
   deletionScheduleEnabled: boolean; // whether to use the same schedule as creation
 
@@ -135,6 +136,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
       creationScheduleFrequencyType: "daily",
       deletionScheduleFrequencyType: "daily",
 
+      deletionOnlyPolicy: false,
       deleteConditionEnabled: false,
       deletionScheduleEnabled: false,
 
@@ -207,6 +209,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
       creationScheduleFrequencyType: "daily",
       deletionScheduleFrequencyType: "daily",
 
+      deletionOnlyPolicy: false,
       deleteConditionEnabled: false,
       deletionScheduleEnabled: false,
 
@@ -256,6 +259,10 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
           if (creationScheduleExpression !== deletionScheduleExpression) deletionScheduleEnabled = true;
         }
 
+        // A deletion-only policy has no creation workflow. Track it so the form does not require
+        // a creation schedule and does not silently re-add one when editing other fields.
+        const deletionOnlyPolicy = _.get(policy, "creation") == null;
+
         const maxAge = policy.deletion?.condition?.max_age;
         let maxAgeNum = 1;
         let maxAgeUnit = "d";
@@ -273,6 +280,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
           selectedRepoValue,
           creationScheduleFrequencyType,
           deletionScheduleFrequencyType,
+          deletionOnlyPolicy,
           deleteConditionEnabled,
           deletionScheduleEnabled,
           maxAgeNum,
@@ -399,17 +407,21 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
   onClickSubmit = async () => {
     this.setState({ isSubmitting: true });
     const { isEdit } = this.props;
-    const { policyId, policy } = this.state;
+    const { policyId, policy, deletionOnlyPolicy } = this.state;
 
     try {
       if (!policyId.trim()) {
         this.setState({ policyIdError: ERROR_PROMPT.NAME });
       } else if (!_.get(policy, "snapshot_config.repository")) {
         this.setState({ repoError: ERROR_PROMPT.REPO });
-      } else if (!_.get(policy, "creation.schedule.cron.timezone")) {
+      } else if (!deletionOnlyPolicy && !_.get(policy, "creation.schedule.cron.timezone")) {
         this.setState({ timezoneError: ERROR_PROMPT.TIMEZONE });
       } else {
-        const policyFromState = this.buildPolicyFromState(policy);
+        // Operate on a deep clone so the transformations below (which delete the creation or
+        // deletion blocks) never mutate the component state. Otherwise a failed submit can leave
+        // state.policy corrupted - e.g. dropping the deletion schedule's time zone and causing a
+        // backend "zone" NullPointerException on the next submit.
+        const policyFromState = this.buildPolicyFromState(_.cloneDeep(policy));
         // console.log(`sm dev policy from state ${JSON.stringify(policyFromState)}`);
         if (isEdit) await this.updatePolicy(policyId, policyFromState);
         else await this.createPolicy(policyId, policyFromState);
@@ -423,7 +435,13 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
   };
 
   buildPolicyFromState = (policy: SMPolicy): SMPolicy => {
-    const { deletionScheduleEnabled, maxAgeNum, maxAgeUnit, deleteConditionEnabled } = this.state;
+    const { deletionScheduleEnabled, maxAgeNum, maxAgeUnit, deleteConditionEnabled, deletionOnlyPolicy } = this.state;
+
+    // Deletion-only policies have no creation workflow. Drop any creation block so that editing
+    // other fields never converts the policy into a creation + deletion policy.
+    if (deletionOnlyPolicy) {
+      delete policy.creation;
+    }
 
     if (deleteConditionEnabled) {
       _.set(policy, "deletion.condition.max_age", maxAgeNum + maxAgeUnit);
@@ -432,7 +450,11 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
     }
 
     if (deletionScheduleEnabled) {
-      _.set(policy, "deletion.schedule.cron.timezone", _.get(policy, "creation.schedule.cron.timezone"));
+      // For a deletion-only policy there is no creation schedule to inherit the time zone from,
+      // so preserve the existing deletion schedule time zone instead of overwriting it.
+      if (!deletionOnlyPolicy) {
+        _.set(policy, "deletion.schedule.cron.timezone", _.get(policy, "creation.schedule.cron.timezone"));
+      }
     } else {
       delete policy.deletion?.schedule;
     }
@@ -519,6 +541,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
       maxAgeUnit,
       creationScheduleFrequencyType,
       deletionScheduleFrequencyType,
+      deletionOnlyPolicy,
       deleteConditionEnabled,
       deletionScheduleEnabled,
       advancedSettingsOpen,
@@ -679,6 +702,7 @@ export class CreateSnapshotPolicy extends MDSEnabledComponent<CreateSMPolicyProp
             onCronExpressionChange={(expression: string) => {
               this.setState({ policy: this.setPolicyHelper("creation.schedule.cron.expression", expression) });
             }}
+            disabled={deletionOnlyPolicy}
           />
         </EuiPanel>
 

--- a/public/pages/SnapshotPolicies/containers/SnapshotPolicies/SnapshotPolicies.tsx
+++ b/public/pages/SnapshotPolicies/containers/SnapshotPolicies/SnapshotPolicies.tsx
@@ -154,6 +154,9 @@ export class SnapshotPolicies extends MDSEnabledComponent<SnapshotPoliciesProps,
         dataType: "string",
         width: "180px",
         render: (name: string, item: SMPolicy) => {
+          if (!item.creation) {
+            return "-";
+          }
           const expression = name;
           const timezone = item.creation.schedule.cron.timezone;
           return `${humanCronExpression(parseCronExpression(expression), expression, timezone)}`;

--- a/public/pages/SnapshotPolicyDetails/containers/SnapshotPolicyDetails/SnapshotPolicyDetails.tsx
+++ b/public/pages/SnapshotPolicyDetails/containers/SnapshotPolicyDetails/SnapshotPolicyDetails.tsx
@@ -299,16 +299,21 @@ export class SnapshotPolicyDetails extends MDSEnabledComponent<SnapshotPolicyDet
       // { term: "Time zone of timestamp", value: `${_.get(policy, "snapshot_config.date_format_timezone")}` },
     ];
 
-    const createCronExpression = policy.creation.schedule.cron.expression;
-    const { minute, hour, dayOfWeek, dayOfMonth, frequencyType } = parseCronExpression(createCronExpression);
-    const humanCron = humanCronExpression(
-      { minute, hour, dayOfWeek, dayOfMonth, frequencyType },
-      createCronExpression,
-      policy.creation.schedule.cron.timezone
-    );
+    let frequency;
+    let humanCron;
+    if (policy.creation != null) {
+      const createCronExpression = policy.creation.schedule.cron.expression;
+      const { minute, hour, dayOfWeek, dayOfMonth, frequencyType } = parseCronExpression(createCronExpression);
+      frequency = _.capitalize(frequencyType);
+      humanCron = humanCronExpression(
+        { minute, hour, dayOfWeek, dayOfMonth, frequencyType },
+        createCronExpression,
+        policy.creation.schedule.cron.timezone
+      );
+    }
     const snapshotScheduleItems = [
-      { term: "Frequency", value: _.capitalize(frequencyType) },
-      { term: "Cron schedule", value: humanCron },
+      { term: "Frequency", value: frequency ?? "-" },
+      { term: "Cron schedule", value: humanCron ?? "-" },
       { term: "Next snapshot time", value: renderTimestampMillis(metadata?.creation?.trigger.time) },
     ];
 


### PR DESCRIPTION
PR opensearch-project/index-management#1452 makes the snapshot management creation workflow optional, allowing deletion-only policies. The dashboard assumed every policy had a creation block, which crashed the policy view pages and broke editing such policies.

- Make SMPolicy.creation optional
- Guard creation access on the policy list and details pages so a deletion-only policy renders instead of throwing "Cannot read properties of undefined (reading 'schedule')"
- Disable the snapshot (creation) schedule controls when editing a deletion-only policy and skip the creation time-zone validation
- Preserve the existing deletion schedule time zone on save instead of deriving it from the missing creation schedule
- Build the request body from a deep clone so a failed submit never mutates the in-memory policy (which previously dropped the deletion time zone and caused a backend 'zone' NullPointerException)

Out of scope, tracked as follow-ups: creating or re-enabling creation for deletion-only policies via the UI, snapshot_pattern support, and guarding the 'Retain all snapshots' option for deletion-only policies.

### Description
[Describe what this change achieves]

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
