### PR TITLE
ci: Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/actions/run-cypress-tests/action.yaml
+++ b/.github/actions/run-cypress-tests/action.yaml
@@ -10,13 +10,13 @@ runs:
   using: "composite"
   steps:
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
       with:
         # TODO: Parse this from index management plugin
         java-version: 21
         distribution: 'temurin'
     - name: Checkout index management
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       with:
         path: index-management
         repository: opensearch-project/index-management
@@ -38,23 +38,23 @@ runs:
         sleep 300
       # timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do sleep 5; done'
     - name: Checkout Index Management Dashboards plugin
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       with:
         path: index-management-dashboards-plugin
     - name: Checkout Security Dashboards plugin
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       with:
         repository: opensearch-project/security-dashboards-plugin
         path: security-dashboards-plugin
         ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
     - name: Checkout OpenSearch-Dashboards
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       with:
         repository: opensearch-project/OpenSearch-Dashboards
         path: OpenSearch-Dashboards
         ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
     - name: Setup Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
       with:
         node-version-file: './OpenSearch-Dashboards/.nvmrc'
         registry-url: 'https://registry.npmjs.org'
@@ -104,7 +104,7 @@ runs:
         mv index-management-dashboards-plugin OpenSearch-Dashboards/plugins
         mv security-dashboards-plugin OpenSearch-Dashboards/plugins
     - name: Bootstrap the OpenSearch Dashboard
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2
       with:
         timeout_minutes: 20
         max_attempts: 2
@@ -124,7 +124,7 @@ runs:
       # timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
     # for now just chrome, use matrix to do all browsers later
     - name: Cypress tests
-      uses: cypress-io/github-action@v5
+      uses: cypress-io/github-action@248bde77443c376edc45906ede03a1aba9da0462 # v5
       if: ${{ inputs.with-security == 'false' }}
       with:
         working-directory: OpenSearch-Dashboards/plugins/index-management-dashboards-plugin
@@ -132,7 +132,7 @@ runs:
         wait-on: 'http://localhost:5601'
         browser: chrome
     - name: Cypress tests
-      uses: cypress-io/github-action@v5
+      uses: cypress-io/github-action@248bde77443c376edc45906ede03a1aba9da0462 # v5
       if: ${{ inputs.with-security == 'true' }}
       with:
         working-directory: OpenSearch-Dashboards/plugins/index-management-dashboards-plugin
@@ -140,13 +140,13 @@ runs:
         wait-on: 'http://localhost:5601'
         browser: chrome
     # Screenshots are only captured on failure, will change this once we do visual regression tests
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: failure()
       with:
         name: cypress-screenshots
         path: OpenSearch-Dashboards/plugins/index-management-dashboards-plugin/cypress/screenshots
     # Test run video was always captured, so this action uses "always()" condition
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: always()
       with:
         name: cypress-videos

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -26,14 +26,14 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v2.1.0
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
 
       - name: Backport
-        uses: VachaShah/backport@v2.2.0
+        uses: VachaShah/backport@142d3b8a8c70dc54db515e653e5ed3c3fac64100 # v2.2.0
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
           head_template: backport/backport-<%= number %>-to-<%= base %>

--- a/.github/workflows/create-documentation-issue.yml
+++ b/.github/workflows/create-documentation-issue.yml
@@ -14,14 +14,14 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v1.5.0
+        uses: tibdex/github-app-token@1901dc7d52169e70c27a8da37aef0d423e2867a2 # v1.5.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         
       - name: Edit the issue template
         run: |
@@ -29,7 +29,7 @@ jobs:
           
       - name: Create Issue From File
         id: create-issue
-        uses: peter-evans/create-issue-from-file@v4
+        uses: peter-evans/create-issue-from-file@433e51abf769039ee20ba1293a088ca19d573b7f # v4
         with:
           title: Add documentation related to new feature
           content-filepath: ./.github/ISSUE_TEMPLATE/documentation-issue.md

--- a/.github/workflows/cypress-with-security-workflow.yml
+++ b/.github/workflows/cypress-with-security-workflow.yml
@@ -19,7 +19,7 @@ jobs:
       TERM: xterm
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - id: run-cypress-tests
         uses: ./.github/actions/run-cypress-tests
         with:

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -21,7 +21,7 @@ jobs:
       TERM: xterm
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - id: run-cypress-tests
         uses: ./.github/actions/run-cypress-tests
         with:

--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -10,6 +10,6 @@ jobs:
     if: startsWith(github.event.pull_request.head.ref,'backport/') || startsWith(github.event.pull_request.head.ref,'release-chores/')
     steps:
       - name: Delete merged branch
-        uses: SvanBoxel/delete-merged-branch@main
+        uses: SvanBoxel/delete-merged-branch@2b5b058e3db41a3328fd9a6a58fd4c2545a14353 # main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/draft-release-notes-workflow.yml
+++ b/.github/workflows/draft-release-notes-workflow.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update draft release notes
-        uses: release-drafter/release-drafter@v5
+        uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5
         with:
           config-name: draft-release-notes-config.yml
           name: Version (set here)

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -9,10 +9,10 @@ jobs:
   linkchecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: lychee Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@master
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # master
         with:
           args: --accept=200,403,429 --exclude=localhost "**/*.html" "**/*.md" "**/*.txt" "**/*.json"
         env:

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -10,7 +10,7 @@ env:
   OPENSEARCH_DASHBOARDS_VERSION: 'main'
 jobs:
   Get-CI-Image-Tag:
-    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@58f2e5108a5164e37af78f5d8de5d825825023a9 # main
     with:
       product: opensearch-dashboards
 
@@ -28,13 +28,13 @@ jobs:
     steps:
       # Enable longer filenames for windows
       - name: Checkout OpenSearch-Dashboards
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
           path: OpenSearch-Dashboards
       - name: Checkout Index Management Dashboards plugin
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           path: OpenSearch-Dashboards/plugins/index-management-dashboards-plugin
       - name: Bootstrap / Run tests
@@ -46,7 +46,7 @@ jobs:
                                whoami && yarn osd bootstrap && yarn run test:jest --coverage"
 
       - name: Uploads coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192 # v1
 
   tests-windows-macos:
     name: Run unit tests
@@ -60,13 +60,13 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         run: git config --system core.longpaths true
       - name: Checkout OpenSearch-Dashboards
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
           path: OpenSearch-Dashboards
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: './OpenSearch-Dashboards/.nvmrc'
           registry-url: 'https://registry.npmjs.org'
@@ -80,7 +80,7 @@ jobs:
       - run: node -v
       - run: yarn -v
       - name: Checkout Index Management Dashboards plugin
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           path: OpenSearch-Dashboards/plugins/index-management-dashboards-plugin
       - name: Bootstrap plugin/OpenSearch-Dashboards

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -29,7 +29,7 @@ jobs:
         shell: bash
 
       - name: Run Opensearch
-        uses: derek-ho/start-opensearch@e9060d3df24b30cdbfac62d749fec3367dade572 # v6
+        uses: opensearch-project/opensearch-build/.github/actions/start-opensearch@643b632712710159088d5f0798de7e91c1f2b8f7
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           security-enabled: false
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run Dashboard
         id: setup-dashboards
-        uses: derek-ho/setup-opensearch-dashboards@f64b331c58fe5b0a6533e76da1b46cb9d11bcaef # v1
+        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@643b632712710159088d5f0798de7e91c1f2b8f7
         with:
           plugin_name: index-management-dashboards-plugin
           built_plugin_name: index-management-dashboards

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Set env
         run: |
@@ -29,7 +29,7 @@ jobs:
         shell: bash
 
       - name: Run Opensearch
-        uses: derek-ho/start-opensearch@v6
+        uses: derek-ho/start-opensearch@e9060d3df24b30cdbfac62d749fec3367dade572 # v6
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           security-enabled: false
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run Dashboard
         id: setup-dashboards
-        uses: derek-ho/setup-opensearch-dashboards@v1
+        uses: derek-ho/setup-opensearch-dashboards@f64b331c58fe5b0a6533e76da1b46cb9d11bcaef # v1
         with:
           plugin_name: index-management-dashboards-plugin
           built_plugin_name: index-management-dashboards

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "**/glob-parent": "^5.1.2",
     "**/braces": "^3.0.3",
     "**/elliptic": "^6.5.4",
-    "@babel/runtime": "^7.26.10",
+    "@babel/runtime": "^7.29.7",
     "@babel/helpers": "^7.26.10",
     "pbkdf2": "^3.1.3",
     "form-data": "4.0.4",
@@ -68,7 +68,7 @@
     "husky": "^3.0.0",
     "lint-staged": "^10.2.0",
     "ts-loader": "^6.2.1",
-    "@babel/runtime": "^7.26.10",
+    "@babel/runtime": "^7.29.7",
     "@babel/helpers": "^7.26.10"
   },
   "engines": {


### PR DESCRIPTION
The repository now enforces the GitHub policy requiring all Actions to be pinned to a full-length commit SHA. Workflows referencing actions by tag (e.g. actions/checkout@v3) fail at the prepare-actions step, which blocks CI on every pull request.

Pin every action - and the get-ci-image-tag reusable workflow - to its current commit SHA, keeping the previous tag as a trailing comment for readability and future updates.

Changes done in other plugins/repos: https://github.com/opensearch-project/dashboards-assistant/pull/699

### Description
[Describe what this change achieves]

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
