### PR TITLE
Migrate Jest test suite to Jest 30 + jsdom 26

### DIFF
--- a/public/JobHandler/callbacks/force_merge.test.tsx
+++ b/public/JobHandler/callbacks/force_merge.test.tsx
@@ -25,10 +25,10 @@ const forceMergeMetaData = {
   type: ListenType.FORCE_MERGE,
 };
 
-const core = ({
+const core = {
   ...coreServicesMock,
   http: httpClientMock,
-} as unknown) as CoreSetup;
+} as unknown as CoreSetup;
 
 describe("callbackForForceMerge spec", () => {
   it("callback when error", async () => {
@@ -57,8 +57,8 @@ describe("callbackForForceMerge spec", () => {
       core,
     });
     expect(result).toBe(true);
-    expect(core.notifications.toasts.remove).toBeCalledWith("toastId");
-    expect(core.notifications.toasts.addSuccess).toBeCalledTimes(1);
+    expect(core.notifications.toasts.remove).toHaveBeenCalledWith("toastId");
+    expect(core.notifications.toasts.addSuccess).toHaveBeenCalledTimes(1);
   });
 
   it("callback when some complete", async () => {
@@ -75,8 +75,8 @@ describe("callbackForForceMerge spec", () => {
       core,
     });
     expect(result).toBe(true);
-    expect(core.notifications.toasts.remove).toBeCalledWith("toastId");
-    expect(core.notifications.toasts.addWarning).toBeCalledTimes(1);
+    expect(core.notifications.toasts.remove).toHaveBeenCalledWith("toastId");
+    expect(core.notifications.toasts.addWarning).toHaveBeenCalledTimes(1);
   });
 
   it("callback when failed", async () => {
@@ -90,8 +90,8 @@ describe("callbackForForceMerge spec", () => {
       core,
     });
     expect(result).toBe(true);
-    expect(core.notifications.toasts.remove).toBeCalledWith("toastId");
-    expect(core.notifications.toasts.addDanger).toBeCalledTimes(1);
+    expect(core.notifications.toasts.remove).toHaveBeenCalledWith("toastId");
+    expect(core.notifications.toasts.addDanger).toHaveBeenCalledTimes(1);
   });
 
   it("callback when timeout", async () => {
@@ -99,7 +99,7 @@ describe("callbackForForceMerge spec", () => {
       core,
     });
     expect(result).toBe(true);
-    expect(core.notifications.toasts.remove).toBeCalledWith("toastId");
-    expect(core.notifications.toasts.addWarning).toBeCalledTimes(1);
+    expect(core.notifications.toasts.remove).toHaveBeenCalledWith("toastId");
+    expect(core.notifications.toasts.addWarning).toHaveBeenCalledTimes(1);
   });
 });

--- a/public/JobHandler/callbacks/open.test.tsx
+++ b/public/JobHandler/callbacks/open.test.tsx
@@ -24,10 +24,10 @@ const openMetaData = {
   type: ListenType.OPEN,
 };
 
-const core = ({
+const core = {
   ...coreServicesMock,
   http: httpClientMock,
-} as unknown) as CoreSetup;
+} as unknown as CoreSetup;
 
 describe("callbackForOpen spec", () => {
   it("callback when error", async () => {
@@ -60,8 +60,8 @@ describe("callbackForOpen spec", () => {
       core,
     });
     expect(result).toBe(true);
-    expect(core.notifications.toasts.remove).toBeCalledWith("toastId");
-    expect(core.notifications.toasts.addSuccess).toBeCalledTimes(1);
+    expect(core.notifications.toasts.remove).toHaveBeenCalledWith("toastId");
+    expect(core.notifications.toasts.addSuccess).toHaveBeenCalledTimes(1);
   });
 
   it("callback when failed", async () => {
@@ -75,8 +75,8 @@ describe("callbackForOpen spec", () => {
       core,
     });
     expect(result).toBe(true);
-    expect(core.notifications.toasts.remove).toBeCalledWith("toastId");
-    expect(core.notifications.toasts.addDanger).toBeCalledTimes(1);
+    expect(core.notifications.toasts.remove).toHaveBeenCalledWith("toastId");
+    expect(core.notifications.toasts.addDanger).toHaveBeenCalledTimes(1);
   });
 
   it("callback when timeout", async () => {
@@ -84,7 +84,7 @@ describe("callbackForOpen spec", () => {
       core,
     });
     expect(result).toBe(true);
-    expect(core.notifications.toasts.remove).toBeCalledWith("toastId");
-    expect(core.notifications.toasts.addWarning).toBeCalledTimes(1);
+    expect(core.notifications.toasts.remove).toHaveBeenCalledWith("toastId");
+    expect(core.notifications.toasts.addWarning).toHaveBeenCalledTimes(1);
   });
 });

--- a/public/JobHandler/callbacks/reindex.test.tsx
+++ b/public/JobHandler/callbacks/reindex.test.tsx
@@ -27,10 +27,10 @@ const reindexMetaData = {
   type: ListenType.REINDEX,
 };
 
-const core = ({
+const core = {
   ...coreServicesMock,
   http: httpClientMock,
-} as unknown) as CoreSetup;
+} as unknown as CoreSetup;
 
 describe("callbackForOpen spec", () => {
   it("callback when error", async () => {
@@ -59,8 +59,8 @@ describe("callbackForOpen spec", () => {
       core,
     });
     expect(result).toBe(true);
-    expect(core.notifications.toasts.remove).toBeCalledWith("toastId");
-    expect(core.notifications.toasts.addSuccess).toBeCalledTimes(1);
+    expect(core.notifications.toasts.remove).toHaveBeenCalledWith("toastId");
+    expect(core.notifications.toasts.addSuccess).toHaveBeenCalledTimes(1);
   });
 
   it("callback when failed", async () => {
@@ -81,8 +81,8 @@ describe("callbackForOpen spec", () => {
       core,
     });
     expect(result).toBe(true);
-    expect(core.notifications.toasts.remove).toBeCalledWith("toastId");
-    expect(core.notifications.toasts.addDanger).toBeCalledTimes(1);
+    expect(core.notifications.toasts.remove).toHaveBeenCalledWith("toastId");
+    expect(core.notifications.toasts.addDanger).toHaveBeenCalledTimes(1);
   });
 
   it("callback when timeout", async () => {
@@ -90,7 +90,7 @@ describe("callbackForOpen spec", () => {
       core,
     });
     expect(result).toBe(true);
-    expect(core.notifications.toasts.remove).toBeCalledWith("toastId");
-    expect(core.notifications.toasts.addWarning).toBeCalledTimes(1);
+    expect(core.notifications.toasts.remove).toHaveBeenCalledWith("toastId");
+    expect(core.notifications.toasts.addWarning).toHaveBeenCalledTimes(1);
   });
 });

--- a/public/JobHandler/callbacks/shrink.test.tsx
+++ b/public/JobHandler/callbacks/shrink.test.tsx
@@ -25,10 +25,10 @@ const shrinkMetaData = {
   type: ListenType.SHRINK,
 };
 
-const core = ({
+const core = {
   ...coreServicesMock,
   http: httpClientMock,
-} as unknown) as CoreSetup;
+} as unknown as CoreSetup;
 
 describe("callbackForOpen spec", () => {
   it("callback when error", async () => {
@@ -57,8 +57,8 @@ describe("callbackForOpen spec", () => {
       core,
     });
     expect(result).toBe(true);
-    expect(core.notifications.toasts.remove).toBeCalledWith("toastId");
-    expect(core.notifications.toasts.addSuccess).toBeCalledTimes(1);
+    expect(core.notifications.toasts.remove).toHaveBeenCalledWith("toastId");
+    expect(core.notifications.toasts.addSuccess).toHaveBeenCalledTimes(1);
   });
 
   it("callback when failed", async () => {
@@ -79,8 +79,8 @@ describe("callbackForOpen spec", () => {
       core,
     });
     expect(result).toBe(true);
-    expect(core.notifications.toasts.remove).toBeCalledWith("toastId");
-    expect(core.notifications.toasts.addDanger).toBeCalledTimes(1);
+    expect(core.notifications.toasts.remove).toHaveBeenCalledWith("toastId");
+    expect(core.notifications.toasts.addDanger).toHaveBeenCalledTimes(1);
   });
 
   it("callback when timeout", async () => {
@@ -88,7 +88,7 @@ describe("callbackForOpen spec", () => {
       core,
     });
     expect(result).toBe(true);
-    expect(core.notifications.toasts.remove).toBeCalledWith("toastId");
-    expect(core.notifications.toasts.addWarning).toBeCalledTimes(1);
+    expect(core.notifications.toasts.remove).toHaveBeenCalledWith("toastId");
+    expect(core.notifications.toasts.addWarning).toHaveBeenCalledTimes(1);
   });
 });

--- a/public/JobHandler/callbacks/split.test.tsx
+++ b/public/JobHandler/callbacks/split.test.tsx
@@ -25,10 +25,10 @@ const splitMetaData = {
   type: ListenType.SPLIT,
 };
 
-const core = ({
+const core = {
   ...coreServicesMock,
   http: httpClientMock,
-} as unknown) as CoreSetup;
+} as unknown as CoreSetup;
 
 describe("callbackForOpen spec", () => {
   it("callback when error", async () => {
@@ -57,8 +57,8 @@ describe("callbackForOpen spec", () => {
       core,
     });
     expect(result).toBe(true);
-    expect(core.notifications.toasts.remove).toBeCalledWith("toastId");
-    expect(core.notifications.toasts.addSuccess).toBeCalledTimes(1);
+    expect(core.notifications.toasts.remove).toHaveBeenCalledWith("toastId");
+    expect(core.notifications.toasts.addSuccess).toHaveBeenCalledTimes(1);
   });
 
   it("callback when failed", async () => {
@@ -79,8 +79,8 @@ describe("callbackForOpen spec", () => {
       core,
     });
     expect(result).toBe(true);
-    expect(core.notifications.toasts.remove).toBeCalledWith("toastId");
-    expect(core.notifications.toasts.addDanger).toBeCalledTimes(1);
+    expect(core.notifications.toasts.remove).toHaveBeenCalledWith("toastId");
+    expect(core.notifications.toasts.addDanger).toHaveBeenCalledTimes(1);
   });
 
   it("callback when timeout", async () => {
@@ -88,7 +88,7 @@ describe("callbackForOpen spec", () => {
       core,
     });
     expect(result).toBe(true);
-    expect(core.notifications.toasts.remove).toBeCalledWith("toastId");
-    expect(core.notifications.toasts.addWarning).toBeCalledTimes(1);
+    expect(core.notifications.toasts.remove).toHaveBeenCalledWith("toastId");
+    expect(core.notifications.toasts.addWarning).toHaveBeenCalledTimes(1);
   });
 });

--- a/public/JobHandler/components/__snapshots__/components.test.tsx.snap
+++ b/public/JobHandler/components/__snapshots__/components.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DetailLink /> spec render with cluster info 1`] = `
 <div>

--- a/public/components/AdvancedSettings/AdvancedSettings.test.tsx
+++ b/public/components/AdvancedSettings/AdvancedSettings.test.tsx
@@ -35,7 +35,7 @@ describe("<FormGenerator /> spec", () => {
     await userEvent.clear(textareaInput);
     await userEvent.paste('{ "test": "1" }');
     await userEvent.click(document.body);
-    expect(onChangeMock).toBeCalledTimes(1);
-    expect(onChangeMock).toBeCalledWith({ test: "1" });
+    expect(onChangeMock).toHaveBeenCalledTimes(1);
+    expect(onChangeMock).toHaveBeenCalledWith({ test: "1" });
   });
 });

--- a/public/components/AdvancedSettings/__snapshots__/AdvancedSettings.test.tsx.snap
+++ b/public/components/AdvancedSettings/__snapshots__/AdvancedSettings.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<FormGenerator /> spec render the component 1`] = `
 HTMLCollection [

--- a/public/components/AliasSelect/AliasSelect.test.tsx
+++ b/public/components/AliasSelect/AliasSelect.test.tsx
@@ -51,7 +51,7 @@ describe("<AliasSelect /> spec", () => {
     );
     await waitFor(
       () => {
-        expect(onOptionsChange).toBeCalledWith([
+        expect(onOptionsChange).toHaveBeenCalledWith([
           {
             label: "a",
           },
@@ -97,22 +97,22 @@ describe("<AliasSelect /> spec", () => {
     });
     await userEvent.click(document.querySelector('button[title="test"]') as Element);
     await waitFor(() => {
-      expect(onChangeMock).toBeCalledTimes(1);
-      expect(onChangeMock).toBeCalledWith({
+      expect(onChangeMock).toHaveBeenCalledTimes(1);
+      expect(onChangeMock).toHaveBeenCalledWith({
         test: {},
       });
     });
     await userEvent.type(getByTestId("comboBoxInput"), "test2{enter}");
     await waitFor(() => {
-      expect(onChangeMock).toBeCalledTimes(2);
-      expect(onChangeMock).toBeCalledWith({
+      expect(onChangeMock).toHaveBeenCalledTimes(2);
+      expect(onChangeMock).toHaveBeenCalledWith({
         test: {},
         test2: {},
       });
     });
     await userEvent.type(getByTestId("comboBoxInput"), "  {enter}");
     await waitFor(() => {
-      expect(onChangeMock).toBeCalledTimes(2);
+      expect(onChangeMock).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/public/components/AliasSelect/__snapshots__/AliasSelect.test.tsx.snap
+++ b/public/components/AliasSelect/__snapshots__/AliasSelect.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<AliasSelect /> spec renders the component and remove duplicate aliases 1`] = `
 <div
@@ -35,7 +35,7 @@ exports[`<AliasSelect /> spec renders the component and remove duplicate aliases
             value=""
           />
           <div
-            style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+            style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
           />
         </div>
       </div>
@@ -92,7 +92,7 @@ exports[`<AliasSelect /> spec renders with error 1`] = `
               value=""
             />
             <div
-              style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+              style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
             />
           </div>
         </div>

--- a/public/components/BottomBar/__snapshots__/BottomBar.test.tsx.snap
+++ b/public/components/BottomBar/__snapshots__/BottomBar.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<FormGenerator /> spec render the component 1`] = `
 HTMLCollection [

--- a/public/components/ChannelNotification/ChannelNotification.test.tsx
+++ b/public/components/ChannelNotification/ChannelNotification.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import ChannelNotification from "./ChannelNotification";
 import { fireEvent, queryByTestId } from "@testing-library/dom";

--- a/public/components/ChannelNotification/__snapshots__/ChannelNotification.test.tsx.snap
+++ b/public/components/ChannelNotification/__snapshots__/ChannelNotification.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ChannelNotification /> spec renders the component 1`] = `
 <div

--- a/public/components/ConfirmationModal/ConfirmationModal.test.tsx
+++ b/public/components/ConfirmationModal/ConfirmationModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, fireEvent } from "@testing-library/react";
 import ConfirmationModal from "./ConfirmationModal";
 

--- a/public/components/ConfirmationModal/__snapshots__/ConfirmationModal.test.tsx.snap
+++ b/public/components/ConfirmationModal/__snapshots__/ConfirmationModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ConfirmationModal /> spec renders the component 1`] = `
 <div

--- a/public/components/ContentPanel/__snapshots__/ContentPanel.test.tsx.snap
+++ b/public/components/ContentPanel/__snapshots__/ContentPanel.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ContentPanel /> spec renders the component 1`] = `
 <div

--- a/public/components/ContentPanel/__snapshots__/ContentPanelActions.test.tsx.snap
+++ b/public/components/ContentPanel/__snapshots__/ContentPanelActions.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ContentPanelActions /> spec renders the component 1`] = `
 <div

--- a/public/components/CreatePolicyModal/CreatePolicyModal.test.tsx
+++ b/public/components/CreatePolicyModal/CreatePolicyModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, fireEvent } from "@testing-library/react";
 import CreatePolicyModal from "./CreatePolicyModal";
 

--- a/public/components/CreatePolicyModal/__snapshots__/CreatePolicyModal.test.tsx.snap
+++ b/public/components/CreatePolicyModal/__snapshots__/CreatePolicyModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreatePolicyModal /> spec renders the component 1`] = `
 <div

--- a/public/components/CustomFormRow/__snapshots__/CustomFormRow.test.tsx.snap
+++ b/public/components/CustomFormRow/__snapshots__/CustomFormRow.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<FormGenerator /> spec render the component 1`] = `
 HTMLCollection [

--- a/public/components/DeleteModal/DeleteModal.test.tsx
+++ b/public/components/DeleteModal/DeleteModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import DeleteModal from "./DeleteModal";
 

--- a/public/components/DeleteModal/__snapshots__/DeleteModal.test.tsx.snap
+++ b/public/components/DeleteModal/__snapshots__/DeleteModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DeleteIndexModal /> spec renders the component 1`] = `
 HTMLCollection [

--- a/public/components/DescriptionListHoz/DescriptionListHoz.test.tsx
+++ b/public/components/DescriptionListHoz/DescriptionListHoz.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import DescriptionListHoz from "./DescriptionListHoz";
 

--- a/public/components/DescriptionListHoz/__snapshots__/DescriptionListHoz.test.tsx.snap
+++ b/public/components/DescriptionListHoz/__snapshots__/DescriptionListHoz.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DescriptionListHoz /> spec renders the component 1`] = `
 <div>

--- a/public/components/EuiToolTipWrapper/__snapshots__/EuiToolTipWrapper.test.tsx.snap
+++ b/public/components/EuiToolTipWrapper/__snapshots__/EuiToolTipWrapper.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<FormGenerator /> spec render the component 1`] = `
 HTMLCollection [

--- a/public/components/FilterGroup/__snapshots__/FilterGroup.test.tsx.snap
+++ b/public/components/FilterGroup/__snapshots__/FilterGroup.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<FilterGroup /> spec render the component 1`] = `
 HTMLCollection [

--- a/public/components/FormGenerator/FormGenerator.test.tsx
+++ b/public/components/FormGenerator/FormGenerator.test.tsx
@@ -147,7 +147,7 @@ describe("<FormGenerator /> spec", () => {
           test: ["values.test_component !== values.test"],
         });
 
-        expect(onChangeMock).toBeCalledWith(
+        expect(onChangeMock).toHaveBeenCalledWith(
           {
             test: "3",
           },
@@ -155,7 +155,7 @@ describe("<FormGenerator /> spec", () => {
           "3"
         );
 
-        expect(onChangeMock).toBeCalledWith(
+        expect(onChangeMock).toHaveBeenCalledWith(
           {
             test: "3",
           },
@@ -170,7 +170,7 @@ describe("<FormGenerator /> spec", () => {
 
     await userEvent.type(getByTestId("form-name-test_component").querySelector("input") as Element, "1");
     await waitFor(() => {
-      expect(onChangeMock).toBeCalledWith(
+      expect(onChangeMock).toHaveBeenCalledWith(
         {
           test: "3",
           test_component: "1",
@@ -218,7 +218,7 @@ describe("<FormGenerator /> spec", () => {
       await userEvent.click(getByTestId("submit"));
     });
 
-    expect(onValidate).toBeCalledWith({
+    expect(onValidate).toHaveBeenCalledWith({
       errors: {
         test: ["values.test_component !== values.test"],
       },
@@ -233,7 +233,7 @@ describe("<FormGenerator /> spec", () => {
       await userEvent.click(getByTestId("submit"));
     });
 
-    expect(onValidate).toBeCalledWith({
+    expect(onValidate).toHaveBeenCalledWith({
       errors: null,
       values: {
         test: "",
@@ -278,7 +278,7 @@ describe("<FormGenerator /> spec", () => {
       await userEvent.click(getByTestId("submit"));
     });
 
-    expect(onValidate).toBeCalledWith({
+    expect(onValidate).toHaveBeenCalledWith({
       errors: {
         test: ["values.test_component !== values.test"],
       },
@@ -293,7 +293,7 @@ describe("<FormGenerator /> spec", () => {
       await userEvent.click(getByTestId("submit"));
     });
 
-    expect(onValidate).toBeCalledWith({
+    expect(onValidate).toHaveBeenCalledWith({
       errors: null,
       values: {
         test: "",

--- a/public/components/FormGenerator/__snapshots__/FormGenerator.test.tsx.snap
+++ b/public/components/FormGenerator/__snapshots__/FormGenerator.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<FormGenerator /> spec render the component 1`] = `
 HTMLCollection [

--- a/public/components/IndexDetail/__snapshots__/IndexDetail.test.tsx.snap
+++ b/public/components/IndexDetail/__snapshots__/IndexDetail.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<IndexDetail /> spec renders the component 1`] = `
 <div
@@ -148,7 +148,7 @@ exports[`<IndexDetail /> spec renders the component 1`] = `
                       value=""
                     />
                     <div
-                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                     />
                   </div>
                 </div>

--- a/public/components/IndexMapping/__snapshots__/IndexMapping.test.tsx.snap
+++ b/public/components/IndexMapping/__snapshots__/IndexMapping.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<IndexMapping /> spec render mappings with object type 1`] = `
 <div>

--- a/public/components/JSONDiffEditor/JSONDiffEditor.test.tsx
+++ b/public/components/JSONDiffEditor/JSONDiffEditor.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import JSONDiffEditor from "./index";
 

--- a/public/components/JSONDiffEditor/__snapshots__/JSONDiffEditor.test.tsx.snap
+++ b/public/components/JSONDiffEditor/__snapshots__/JSONDiffEditor.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<JSONDiffEditor /> spec renders the component 1`] = `
 HTMLCollection [

--- a/public/components/JSONEditor/JSONEditor.test.tsx
+++ b/public/components/JSONEditor/JSONEditor.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useRef } from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { fireEvent, render, waitFor, renderHook } from "@testing-library/react";
 import JSONEditor, { IJSONEditorRef } from "./JSONEditor";
 
@@ -72,7 +72,7 @@ describe("<JSONEditor /> spec", () => {
     fireEvent.focus(textareaInput);
     fireEvent.blur(textareaInput);
 
-    expect(onChangeMock).toBeCalledTimes(0);
+    expect(onChangeMock).toHaveBeenCalledTimes(0);
   });
 
   it("it triggers onChange when json is input", async () => {
@@ -88,7 +88,7 @@ describe("<JSONEditor /> spec", () => {
     fireEvent.blur(textareaInput);
     await findByText("Your input does not match the validation of json format, please fix the error line with error aside.");
 
-    expect(onChangeMock).toBeCalledTimes(0);
+    expect(onChangeMock).toHaveBeenCalledTimes(0);
 
     fireEvent.focus(textareaInput);
     await inputTextArea({
@@ -98,8 +98,8 @@ describe("<JSONEditor /> spec", () => {
     });
     fireEvent.blur(textareaInput);
     await waitFor(() => {
-      expect(onChangeMock).toBeCalledTimes(1);
-      expect(onChangeMock).toBeCalledWith('{ "test": "1" }');
+      expect(onChangeMock).toHaveBeenCalledTimes(1);
+      expect(onChangeMock).toHaveBeenCalledWith('{ "test": "1" }');
     });
   });
 });

--- a/public/components/JSONEditor/__snapshots__/JSONEditor.test.tsx.snap
+++ b/public/components/JSONEditor/__snapshots__/JSONEditor.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<JSONEditor /> spec renders the component 1`] = `
 HTMLCollection [

--- a/public/components/JSONModal/JSONModal.test.tsx
+++ b/public/components/JSONModal/JSONModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, fireEvent } from "@testing-library/react";
 import JSONModal from "./JSONModal";
 import { DEFAULT_LEGACY_ERROR_NOTIFICATION } from "../../pages/VisualCreatePolicy/utils/constants";

--- a/public/components/JSONModal/__snapshots__/JSONModal.test.tsx.snap
+++ b/public/components/JSONModal/__snapshots__/JSONModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<JSONModal /> spec renders the component 1`] = `
 <div

--- a/public/components/LegacyNotification/LegacyNotification.test.tsx
+++ b/public/components/LegacyNotification/LegacyNotification.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import LegacyNotification from "./LegacyNotification";
 import { DEFAULT_LEGACY_ERROR_NOTIFICATION } from "../../utils/constants";

--- a/public/components/LegacyNotification/__snapshots__/LegacyNotification.test.tsx.snap
+++ b/public/components/LegacyNotification/__snapshots__/LegacyNotification.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<LegacyNotification /> spec renders the component 1`] = `
 <div

--- a/public/components/MappingLabel/__snapshots__/MappingLabel.test.tsx.snap
+++ b/public/components/MappingLabel/__snapshots__/MappingLabel.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<TemplateDetail /> spec render component 1`] = `
 <div>

--- a/public/components/MonacoJSONEditor/MonacoJSONEditor.test.tsx
+++ b/public/components/MonacoJSONEditor/MonacoJSONEditor.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import MonacoJSONEditor from "./index";
 

--- a/public/components/MonacoJSONEditor/__snapshots__/MonacoJSONEditor.test.tsx.snap
+++ b/public/components/MonacoJSONEditor/__snapshots__/MonacoJSONEditor.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<MonacoJSONEditor /> spec renders the component 1`] = `
 HTMLCollection [

--- a/public/components/PolicyModal/PolicyModal.test.tsx
+++ b/public/components/PolicyModal/PolicyModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, fireEvent } from "@testing-library/react";
 import PolicyModal from "./PolicyModal";
 

--- a/public/components/PolicyModal/__snapshots__/PolicyModal.test.tsx.snap
+++ b/public/components/PolicyModal/__snapshots__/PolicyModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<PolicyModal /> spec renders the component 1`] = `
 <div

--- a/public/components/RemoteSelect/RemoteSelect.test.tsx
+++ b/public/components/RemoteSelect/RemoteSelect.test.tsx
@@ -55,17 +55,17 @@ describe("<AliasSelect /> spec", () => {
     });
     await userEvent.click(document.querySelector('button[title="test"]') as Element);
     await waitFor(() => {
-      expect(onChangeMock).toBeCalledTimes(1);
-      expect(onChangeMock).toBeCalledWith(["test"]);
+      expect(onChangeMock).toHaveBeenCalledTimes(1);
+      expect(onChangeMock).toHaveBeenCalledWith(["test"]);
     });
     await userEvent.type(getByTestId("comboBoxInput"), "test2{enter}");
     await waitFor(() => {
-      expect(onChangeMock).toBeCalledTimes(2);
-      expect(onChangeMock).toBeCalledWith(["test", "test2"]);
+      expect(onChangeMock).toHaveBeenCalledTimes(2);
+      expect(onChangeMock).toHaveBeenCalledWith(["test", "test2"]);
     });
     await userEvent.type(getByTestId("comboBoxInput"), "  {enter}");
     await waitFor(() => {
-      expect(onChangeMock).toBeCalledTimes(2);
+      expect(onChangeMock).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/public/components/RemoteSelect/__snapshots__/RemoteSelect.test.tsx.snap
+++ b/public/components/RemoteSelect/__snapshots__/RemoteSelect.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<AliasSelect /> spec renders the component 1`] = `
 <div
@@ -30,7 +30,7 @@ exports[`<AliasSelect /> spec renders the component 1`] = `
             value=""
           />
           <div
-            style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+            style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
           />
         </div>
       </div>
@@ -84,7 +84,7 @@ exports[`<AliasSelect /> spec renders with error 1`] = `
             value=""
           />
           <div
-            style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+            style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
           />
         </div>
       </div>

--- a/public/components/SimplePopover/__snapshots__/SimplePopover.test.tsx.snap
+++ b/public/components/SimplePopover/__snapshots__/SimplePopover.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SimplePopover /> spec renders the component 1`] = `
 HTMLCollection [

--- a/public/components/SwitchableEditor/SwitchableEditor.test.tsx
+++ b/public/components/SwitchableEditor/SwitchableEditor.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import SwitchableEditor from "./index";
 import userEventModule from "@testing-library/user-event";
@@ -32,6 +32,6 @@ describe("<SwitchableEditor /> spec", () => {
     await userEvent.paste(`{ "name": "test" }`);
     await userEvent.click(document.body);
     await waitFor(() => {});
-    expect(onChangeMock).toBeCalledWith(`{ "name": "test" }`);
+    expect(onChangeMock).toHaveBeenCalledWith(`{ "name": "test" }`);
   });
 });

--- a/public/components/SwitchableEditor/__snapshots__/SwitchableEditor.test.tsx.snap
+++ b/public/components/SwitchableEditor/__snapshots__/SwitchableEditor.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SwitchableEditor /> spec renders the component 1`] = `
 HTMLCollection [

--- a/public/components/Toast/__snapshots__/Toast.test.tsx.snap
+++ b/public/components/Toast/__snapshots__/Toast.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SimpleEuiToast show render the component 1`] = `
 <body>

--- a/public/components/UnsavedChangesBottomBar/__snapshots__/UnsavedChangesBottomBar.test.tsx.snap
+++ b/public/components/UnsavedChangesBottomBar/__snapshots__/UnsavedChangesBottomBar.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<FormGenerator /> spec render the component 1`] = `
 HTMLCollection [

--- a/public/containers/ChannelSelect/ChannelSelect.test.tsx
+++ b/public/containers/ChannelSelect/ChannelSelect.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import ChannelSelect, { ChannelSelectProps } from "./ChannelSelect";
 import { browserServicesMock, coreServicesMock } from "../../../test/mocks";
@@ -29,27 +29,25 @@ describe("<ChannelNotification /> spec", () => {
   const userEvent = userEventModule.setup();
 
   it("renders the component", async () => {
-    browserServicesMock.notificationService.getChannels = jest.fn(
-      async (): Promise<any> => {
-        return {
-          ok: true,
-          response: {
-            start_index: 0,
-            total_hits: 1,
-            total_hit_relation: "eq",
-            channel_list: [
-              {
-                config_id: "1",
-                name: "1",
-                description: "2",
-                config_type: "chime",
-                is_enabled: true,
-              },
-            ],
-          },
-        };
-      }
-    );
+    browserServicesMock.notificationService.getChannels = jest.fn(async (): Promise<any> => {
+      return {
+        ok: true,
+        response: {
+          start_index: 0,
+          total_hits: 1,
+          total_hit_relation: "eq",
+          channel_list: [
+            {
+              config_id: "1",
+              name: "1",
+              description: "2",
+              config_type: "chime",
+              is_enabled: true,
+            },
+          ],
+        },
+      };
+    });
     const onChangeMock = jest.fn();
     const { container, getByTestId } = renderWithServiceAndCore({
       onChange: onChangeMock,
@@ -58,13 +56,13 @@ describe("<ChannelNotification /> spec", () => {
       expect(container.querySelector(".euiLoadingSpinner")).toBeNull();
     });
     await waitFor(() => {
-      expect(browserServicesMock.notificationService.getChannels).toBeCalledTimes(1);
+      expect(browserServicesMock.notificationService.getChannels).toHaveBeenCalledTimes(1);
     });
     expect(container).toMatchSnapshot();
     await userEvent.type(getByTestId("1")?.querySelector('[data-test-subj="comboBoxSearchInput"]') as Element, "1{enter}");
     await waitFor(() => {
-      expect(onChangeMock).toBeCalledTimes(1);
-      expect(onChangeMock).toBeCalledWith([
+      expect(onChangeMock).toHaveBeenCalledTimes(1);
+      expect(onChangeMock).toHaveBeenCalledWith([
         {
           id: "1",
         },

--- a/public/containers/ChannelSelect/__snapshots__/ChannelSelect.test.tsx.snap
+++ b/public/containers/ChannelSelect/__snapshots__/ChannelSelect.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ChannelNotification /> spec renders the component 1`] = `
 <div>
@@ -47,7 +47,7 @@ exports[`<ChannelNotification /> spec renders the component 1`] = `
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>
@@ -114,7 +114,7 @@ exports[`<ChannelNotification /> spec renders the component 1`] = `
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>

--- a/public/containers/ClearCacheModal/ClearCacheModal.test.tsx
+++ b/public/containers/ClearCacheModal/ClearCacheModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { browserServicesMock, coreServicesMock } from "../../../test/mocks";
 import { CoreServicesContext } from "../../components/core_services";
 import { ServicesContext } from "../../services";

--- a/public/containers/ClearCacheModal/__snapshots__/ClearCacheModal.test.tsx.snap
+++ b/public/containers/ClearCacheModal/__snapshots__/ClearCacheModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ClearCacheModal /> spec renders the component 1`] = `
 HTMLCollection [

--- a/public/containers/ErrorNotification/ErrorNotification.test.tsx
+++ b/public/containers/ErrorNotification/ErrorNotification.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import ErrorNotificationContainer, { ErrorNotificationProps } from "./ErrorNotification";
 import { ServicesContext } from "../../services";

--- a/public/containers/ErrorNotification/__snapshots__/ErrorNotification.test.tsx.snap
+++ b/public/containers/ErrorNotification/__snapshots__/ErrorNotification.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ErrorNotification /> spec renders the component 1`] = `
 <div

--- a/public/containers/FlushIndexModal/FlushIndexModal.test.tsx
+++ b/public/containers/FlushIndexModal/FlushIndexModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { browserServicesMock, coreServicesMock } from "../../../test/mocks";
 import { CoreServicesContext } from "../../components/core_services";

--- a/public/containers/FlushIndexModal/__snapshots__/FlushIndexModal.test.tsx.snap
+++ b/public/containers/FlushIndexModal/__snapshots__/FlushIndexModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<FlushIndexModal /> spec renders the component with alias 1`] = `
 HTMLCollection [

--- a/public/containers/IndexDetail/IndexDetail.test.tsx
+++ b/public/containers/IndexDetail/IndexDetail.test.tsx
@@ -28,37 +28,33 @@ beforeEach(() => {
   (getNavigationUI as jest.Mock).mockReturnValue({});
 });
 
-browserServicesMock.commonService.apiCaller = jest.fn(
-  async (payload): Promise<any> => {
-    if (payload.data?.index?.includes("error_index")) {
-      return {
-        ok: false,
-        error: "error index",
-      };
-    }
-
+browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+  if (payload.data?.index?.includes("error_index")) {
     return {
-      ok: true,
-      response: (payload.data.index || []).map(
-        (index: string): CatIndex => {
-          return {
-            index,
-            "docs.count": "0",
-            "docs.deleted": "1",
-            "pri.store.size": "1",
-            data_stream: "no",
-            "store.size": "1mb",
-            rep: "2",
-            uuid: "1",
-            health: "green",
-            pri: "4",
-            status: "open",
-          };
-        }
-      ),
+      ok: false,
+      error: "error index",
     };
   }
-);
+
+  return {
+    ok: true,
+    response: (payload.data.index || []).map((index: string): CatIndex => {
+      return {
+        index,
+        "docs.count": "0",
+        "docs.deleted": "1",
+        "pri.store.size": "1",
+        data_stream: "no",
+        "store.size": "1mb",
+        rep: "2",
+        uuid: "1",
+        health: "green",
+        pri: "4",
+        status: "open",
+      };
+    }),
+  };
+});
 
 function renderWithServiceAndCore(props: IIndexDetailProps) {
   return {
@@ -82,8 +78,8 @@ describe("<IndexDetail /> spec", () => {
     expect(queryByText("children content here")).toBeNull();
     await waitFor(() => {
       expect(container).toMatchSnapshot();
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(1);
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(1);
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         endpoint: "cat.indices",
         data: {
           index: ["test"],
@@ -103,10 +99,10 @@ describe("<IndexDetail /> spec", () => {
     });
 
     await waitFor(() => {
-      expect(coreServicesMock.notifications.toasts.addDanger).toBeCalledTimes(1);
-      expect(coreServicesMock.notifications.toasts.addDanger).toBeCalledWith("error index");
-      expect(onGetIndicesDetailMock).toBeCalledTimes(1);
-      expect(onGetIndicesDetailMock).toBeCalledWith([]);
+      expect(coreServicesMock.notifications.toasts.addDanger).toHaveBeenCalledTimes(1);
+      expect(coreServicesMock.notifications.toasts.addDanger).toHaveBeenCalledWith("error index");
+      expect(onGetIndicesDetailMock).toHaveBeenCalledTimes(1);
+      expect(onGetIndicesDetailMock).toHaveBeenCalledWith([]);
     });
   });
 });

--- a/public/containers/IndexDetail/__snapshots__/IndexDetail.test.tsx.snap
+++ b/public/containers/IndexDetail/__snapshots__/IndexDetail.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<IndexDetail /> spec render the component 1`] = `
 <div>

--- a/public/containers/IndexForm/__snapshots__/IndexForm.test.tsx.snap
+++ b/public/containers/IndexForm/__snapshots__/IndexForm.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<IndexForm /> spec render page 1`] = `
 <div>
@@ -149,7 +149,7 @@ exports[`<IndexForm /> spec render page 1`] = `
                         value=""
                       />
                       <div
-                        style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                        style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                       />
                     </div>
                   </div>

--- a/public/containers/NotificationConfig/NotificationCallout.test.tsx
+++ b/public/containers/NotificationConfig/NotificationCallout.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import NotificationCallout, { INotificationCalloutProps } from "./NotificationCallout";
 import { render, waitFor } from "@testing-library/react";
 import { browserServicesMock } from "../../../test/mocks";

--- a/public/containers/NotificationConfig/NotificationConfig.test.tsx
+++ b/public/containers/NotificationConfig/NotificationConfig.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useRef } from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import NotificationConfig, { NotificationConfigProps, NotificationConfigRef } from "./NotificationConfig";
 import { render, waitFor } from "@testing-library/react";
 import { browserServicesMock, coreServicesMock } from "../../../test/mocks";
@@ -171,35 +171,33 @@ describe("<ChannelNotification /> spec", () => {
   const userEvent = userEventModule.setup();
 
   beforeEach(() => {
-    browserServicesMock.notificationService.getChannels = jest.fn(
-      async (): Promise<any> => {
-        return {
-          ok: true,
-          response: {
-            start_index: 0,
-            total_hits: 1,
-            total_hit_relation: "eq",
-            channel_list: [
-              {
-                config_id: "1",
-                name: "1",
-                description: "2",
-                config_type: "chime",
-                is_enabled: true,
-              },
-            ],
-          },
-        };
-      }
-    );
+    browserServicesMock.notificationService.getChannels = jest.fn(async (): Promise<any> => {
+      return {
+        ok: true,
+        response: {
+          start_index: 0,
+          total_hits: 1,
+          total_hit_relation: "eq",
+          channel_list: [
+            {
+              config_id: "1",
+              name: "1",
+              description: "2",
+              config_type: "chime",
+              is_enabled: true,
+            },
+          ],
+        },
+      };
+    });
   });
 
   /**
    * 000
    */
   it("renders with no permission and no default notification", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => chainRules([payload], rulesForNoUpdatePermission, rulesForNoViewPermission, rulesForBackup)
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> =>
+      chainRules([payload], rulesForNoUpdatePermission, rulesForNoViewPermission, rulesForBackup)
     );
     const { container } = renderWithServiceAndCore({
       actionType: ActionType.RESIZE,
@@ -212,8 +210,8 @@ describe("<ChannelNotification /> spec", () => {
    * 010
    */
   it("renders with create permission and no default notification", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => chainRules([payload], rulesForHasUpdatePermission, rulesForNoViewPermission, rulesForBackup)
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> =>
+      chainRules([payload], rulesForHasUpdatePermission, rulesForNoViewPermission, rulesForBackup)
     );
     const { container, queryByTestId, findByText } = renderWithServiceAndCore({
       actionType: ActionType.RESIZE,
@@ -230,9 +228,8 @@ describe("<ChannelNotification /> spec", () => {
    * 100
    */
   it("renders with view permission and no default notification", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> =>
-        chainRules([payload], rulesForNoUpdatePermission, rulesForNoDefaultNotificationHasViewPermission, rulesForBackup)
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> =>
+      chainRules([payload], rulesForNoUpdatePermission, rulesForNoDefaultNotificationHasViewPermission, rulesForBackup)
     );
     const { container } = renderWithServiceAndCore({
       actionType: ActionType.RESIZE,
@@ -245,9 +242,8 @@ describe("<ChannelNotification /> spec", () => {
    * 101
    */
   it("renders with view permission and default notification", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> =>
-        chainRules([payload], rulesForNoUpdatePermission, rulesForHasDefaultNotificationAndViewPermission, rulesForBackup)
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> =>
+      chainRules([payload], rulesForNoUpdatePermission, rulesForHasDefaultNotificationAndViewPermission, rulesForBackup)
     );
     const { container, queryByTestId, findByText } = renderWithServiceAndCore({
       actionType: ActionType.RESIZE,
@@ -262,8 +258,8 @@ describe("<ChannelNotification /> spec", () => {
    * 110
    */
   it("renders with full permission and no default notification", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => chainRules([payload], rulesForHasUpdatePermission, rulesForNoViewPermission, rulesForBackup)
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> =>
+      chainRules([payload], rulesForHasUpdatePermission, rulesForNoViewPermission, rulesForBackup)
     );
     const { container, queryByTestId, queryByText, findByText, getByTestId, findByTestId } = renderWithServiceAndCore({
       actionType: ActionType.RESIZE,
@@ -287,8 +283,8 @@ describe("<ChannelNotification /> spec", () => {
    * 111
    */
   it("renders with full permission and default notification", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => chainRules([payload], rulesForHasUpdatePermission, rulesForHasViewPermission, rulesForBackup)
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> =>
+      chainRules([payload], rulesForHasUpdatePermission, rulesForHasViewPermission, rulesForBackup)
     );
     const { container, findByText, findByTestId, queryByText, getByTestId } = renderWithServiceAndCore({
       actionType: ActionType.RESIZE,
@@ -310,7 +306,7 @@ describe("<ChannelNotification /> spec", () => {
     );
     await userEvent.click(getByTestId("submit"));
     await waitFor(() =>
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         endpoint: "transport.request",
         data: {
           body: {

--- a/public/containers/NotificationConfig/__snapshots__/NotificationCallout.test.tsx.snap
+++ b/public/containers/NotificationConfig/__snapshots__/NotificationCallout.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ChannelNotification /> spec renders with create permission and no default notification 1`] = `
 <div>

--- a/public/containers/NotificationConfig/__snapshots__/NotificationConfig.test.tsx.snap
+++ b/public/containers/NotificationConfig/__snapshots__/NotificationConfig.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ChannelNotification /> spec renders with create permission and no default notification 1`] = `
 <div>

--- a/public/lib/JobScheduler/JobScheduler.test.ts
+++ b/public/lib/JobScheduler/JobScheduler.test.ts
@@ -50,7 +50,7 @@ describe("JobScheduler spec", () => {
         timeout: 10000,
       }
     );
-    expect(callback).toBeCalledTimes(3);
+    expect(callback).toHaveBeenCalledTimes(3);
 
     // setup a long timeout job
     const testJob = await jobScheduler.addJob({
@@ -112,8 +112,8 @@ describe("JobScheduler spec", () => {
     jobScheduler.init();
     await new Promise((resolve) => setTimeout(resolve, 3000));
     expect(jobScheduler.getAllJobs()).resolves.toHaveLength(0);
-    expect(callback).toBeCalledTimes(1);
-    expect(timeoutCallback).toBeCalledTimes(1);
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(timeoutCallback).toHaveBeenCalledTimes(1);
     const result = await jobScheduler.changeJob("1", {});
     expect(result).toBe(false);
   });

--- a/public/pages/Aliases/components/IndexControls/IndexControls.test.tsx
+++ b/public/pages/Aliases/components/IndexControls/IndexControls.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import userEventModule from "@testing-library/user-event";
 import IndexControls from "./IndexControls";
@@ -42,15 +42,15 @@ describe("<IndexControls /> spec", () => {
     );
 
     await userEvent.type(getByTestId("comboBoxSearchInput"), "closed{enter}");
-    expect(onSearchChangeMock).toBeCalledTimes(1);
-    expect(onSearchChangeMock).toBeCalledWith({
+    expect(onSearchChangeMock).toHaveBeenCalledTimes(1);
+    expect(onSearchChangeMock).toHaveBeenCalledWith({
       search: "",
       status: "closed",
     });
     await userEvent.type(getByPlaceholderText("Search..."), "test");
     await waitFor(() => {
-      expect(onSearchChangeMock).toBeCalledTimes(5);
-      expect(onSearchChangeMock).toBeCalledWith({
+      expect(onSearchChangeMock).toHaveBeenCalledTimes(5);
+      expect(onSearchChangeMock).toHaveBeenCalledWith({
         search: "test",
         status: "closed",
       });

--- a/public/pages/Aliases/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
+++ b/public/pages/Aliases/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<IndexControls /> spec renders the component 1`] = `
 <div
@@ -98,7 +98,7 @@ exports[`<IndexControls /> spec renders the component 1`] = `
                 value=""
               />
               <div
-                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
               />
             </div>
           </div>

--- a/public/pages/Aliases/containers/AliasActions/AliasActions.test.tsx
+++ b/public/pages/Aliases/containers/AliasActions/AliasActions.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import userEventModule from "@testing-library/user-event";
 import { browserServicesMock, coreServicesMock } from "../../../../../test/mocks";
@@ -90,25 +90,23 @@ describe("<AliasesActions /> spec", () => {
   it("delete alias by calling commonService", async () => {
     const onDelete = jest.fn();
     let times = 0;
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "indices.deleteAlias") {
-          if (times >= 1) {
-            return {
-              ok: true,
-              response: {},
-            };
-          } else {
-            times++;
-            return {
-              ok: false,
-              error: "test error",
-            };
-          }
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "indices.deleteAlias") {
+        if (times >= 1) {
+          return {
+            ok: true,
+            response: {},
+          };
+        } else {
+          times++;
+          return {
+            ok: false,
+            error: "test error",
+          };
         }
-        return { ok: true, response: {} };
       }
-    );
+      return { ok: true, response: {} };
+    });
     const { container, getByTestId, getByPlaceholderText } = renderWithRouter({
       selectedItems: [
         {
@@ -159,24 +157,22 @@ describe("<AliasesActions /> spec", () => {
   });
 
   it("clear cache for aliases by calling commonService", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        switch (payload.endpoint) {
-          case "cluster.state":
-            return {
-              ok: true,
-              response: {
-                blocks: {},
-              },
-            };
-          default:
-            return {
-              ok: true,
-              response: {},
-            };
-        }
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      switch (payload.endpoint) {
+        case "cluster.state":
+          return {
+            ok: true,
+            response: {
+              blocks: {},
+            },
+          };
+        default:
+          return {
+            ok: true,
+            response: {},
+          };
       }
-    );
+    });
     const { container, getByTestId, getByText } = renderWithRouter({
       selectedItems: [
         {
@@ -224,33 +220,31 @@ describe("<AliasesActions /> spec", () => {
   });
 
   it("cannot clear cache for aliases if some indexes are closed or blocked", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (): Promise<any> => {
-        return {
-          ok: true,
-          response: {
-            blocks: {
-              indices: {
-                test_1: {
-                  "4": {
-                    description: "index closed",
-                    retryable: false,
-                    levels: ["read", "write"],
-                  },
+    browserServicesMock.commonService.apiCaller = jest.fn(async (): Promise<any> => {
+      return {
+        ok: true,
+        response: {
+          blocks: {
+            indices: {
+              test_1: {
+                "4": {
+                  description: "index closed",
+                  retryable: false,
+                  levels: ["read", "write"],
                 },
-                test_2: {
-                  "5": {
-                    description: "index read-only (api)",
-                    retryable: false,
-                    levels: ["write", "metadata_write"],
-                  },
+              },
+              test_2: {
+                "5": {
+                  description: "index read-only (api)",
+                  retryable: false,
+                  levels: ["write", "metadata_write"],
                 },
               },
             },
           },
-        };
-      }
-    );
+        },
+      };
+    });
 
     const { container, getByTestId } = renderWithRouter({
       selectedItems: [
@@ -301,22 +295,20 @@ describe("<AliasesActions /> spec", () => {
   });
 
   it("filter aliases failed when clearing caches for multiple aliases", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        switch (payload.endpoint) {
-          case "cluster.state":
-            return {
-              ok: true,
-              error: "test failure",
-            };
-          default:
-            return {
-              ok: true,
-              response: {},
-            };
-        }
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      switch (payload.endpoint) {
+        case "cluster.state":
+          return {
+            ok: true,
+            error: "test failure",
+          };
+        default:
+          return {
+            ok: true,
+            response: {},
+          };
       }
-    );
+    });
     const { container, getByTestId, getByText } = renderWithRouter({
       selectedItems: [
         {
@@ -410,34 +402,32 @@ describe("<AliasesActions /> spec", () => {
   });
 
   it("refresh alias by calling commonService", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cluster.state") {
-          return {
-            ok: true,
-            response: {
-              blocks: {
-                indices: {
-                  test_index1: {
-                    "4": {},
-                  },
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cluster.state") {
+        return {
+          ok: true,
+          response: {
+            blocks: {
+              indices: {
+                test_index1: {
+                  "4": {},
                 },
               },
             },
-          };
-        } else if (payload.endpoint === "indices.refresh") {
-          return {
-            ok: true,
-            response: {},
-          };
-        } else if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: "red_index close\n",
-          };
-        }
+          },
+        };
+      } else if (payload.endpoint === "indices.refresh") {
+        return {
+          ok: true,
+          response: {},
+        };
+      } else if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: "red_index close\n",
+        };
       }
-    );
+    });
 
     const { getByTestId, getByText, queryByTestId } = renderWithRouter({
       selectedItems,
@@ -485,28 +475,26 @@ describe("<AliasesActions /> spec", () => {
   });
 
   it("refresh multiple aliases by calling commonService", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cluster.state") {
-          return {
-            ok: true,
-            response: {
-              blocks: {},
-            },
-          };
-        } else if (payload.endpoint === "indices.refresh") {
-          return {
-            ok: true,
-            response: {},
-          };
-        } else if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: "red_index open\n",
-          };
-        }
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cluster.state") {
+        return {
+          ok: true,
+          response: {
+            blocks: {},
+          },
+        };
+      } else if (payload.endpoint === "indices.refresh") {
+        return {
+          ok: true,
+          response: {},
+        };
+      } else if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: "red_index open\n",
+        };
       }
-    );
+    });
 
     const { getByTestId, getByText } = renderWithRouter({
       selectedItems: [
@@ -539,34 +527,32 @@ describe("<AliasesActions /> spec", () => {
   });
 
   it("refresh alias blocked because all index are blocked", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cluster.state") {
-          return {
-            ok: true,
-            response: {
-              blocks: {
-                indices: {
-                  test_index: {
-                    "4": {},
-                  },
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cluster.state") {
+        return {
+          ok: true,
+          response: {
+            blocks: {
+              indices: {
+                test_index: {
+                  "4": {},
                 },
               },
             },
-          };
-        } else if (payload.endpoint === "indices.refresh") {
-          return {
-            ok: true,
-            response: {},
-          };
-        } else if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: "red_index open\n",
-          };
-        }
+          },
+        };
+      } else if (payload.endpoint === "indices.refresh") {
+        return {
+          ok: true,
+          response: {},
+        };
+      } else if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: "red_index open\n",
+        };
       }
-    );
+    });
 
     const { getByTestId } = renderWithRouter({
       selectedItems,
@@ -577,31 +563,28 @@ describe("<AliasesActions /> spec", () => {
 
     await waitFor(() => {
       expect(coreServicesMock.notifications.toasts.addDanger).toHaveBeenCalledWith({
-        text:
-          "All selected aliases cannot be refreshed because each alias has one or more indexes that are either closed or in red status.",
+        text: "All selected aliases cannot be refreshed because each alias has one or more indexes that are either closed or in red status.",
         title: "Unable to refresh aliases.",
       });
     });
   });
 
   it("refresh alias even failed to get index status", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cluster.state") {
-          throw "failed to call cluster.state";
-        } else if (payload.endpoint === "indices.refresh") {
-          return {
-            ok: true,
-            response: {},
-          };
-        } else if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: "red_index open\n",
-          };
-        }
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cluster.state") {
+        throw "failed to call cluster.state";
+      } else if (payload.endpoint === "indices.refresh") {
+        return {
+          ok: true,
+          response: {},
+        };
+      } else if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: "red_index open\n",
+        };
       }
-    );
+    });
 
     const { getByTestId, getByText } = renderWithRouter({
       selectedItems: [
@@ -629,23 +612,21 @@ describe("<AliasesActions /> spec", () => {
   });
 
   it("refresh multi alias even failed to get index status", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cluster.state") {
-          throw "failed to call cluster.state";
-        } else if (payload.endpoint === "indices.refresh") {
-          return {
-            ok: true,
-            response: {},
-          };
-        } else if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: "red_index open\n",
-          };
-        }
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cluster.state") {
+        throw "failed to call cluster.state";
+      } else if (payload.endpoint === "indices.refresh") {
+        return {
+          ok: true,
+          response: {},
+        };
+      } else if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: "red_index open\n",
+        };
       }
-    );
+    });
 
     const { getByTestId, getByText, queryByTestId } = renderWithRouter({
       selectedItems,

--- a/public/pages/Aliases/containers/AliasActions/__snapshots__/AliasActions.test.tsx.snap
+++ b/public/pages/Aliases/containers/AliasActions/__snapshots__/AliasActions.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<AliasesActions /> spec cannot clear cache for aliases if some indexes are closed or blocked 1`] = `
 <div

--- a/public/pages/Aliases/containers/Aliases/Aliases.test.tsx
+++ b/public/pages/Aliases/containers/Aliases/Aliases.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import { Redirect, Route, Switch } from "react-router-dom";
 import { HashRouter as Router } from "react-router-dom";
@@ -137,13 +137,13 @@ describe("<Aliases /> spec", () => {
 
     expect(container.firstChild).toMatchSnapshot();
     await waitFor(() => {
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(1);
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(1);
     });
     await userEvent.click(getByTestId("tableHeaderCell_alias_0").querySelector("button") as Element);
     await waitFor(() => {
       expect(queryByText("1 more")).not.toBeNull();
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(2);
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(2);
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         data: { format: "json", name: `**`, s: "alias:asc" },
         endpoint: "cat.aliases",
       });
@@ -151,20 +151,13 @@ describe("<Aliases /> spec", () => {
   });
 
   it("with some actions", async () => {
-    const {
-      findByTitle,
-      findByTestId,
-      getByTestId,
-      getByPlaceholderText,
-      getByTitle,
-      findByPlaceholderText,
-      getByText,
-    } = renderWithRouter();
-    expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(1);
+    const { findByTitle, findByTestId, getByTestId, getByPlaceholderText, getByTitle, findByPlaceholderText, getByText } =
+      renderWithRouter();
+    expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(1);
     await userEvent.type(getByPlaceholderText("Search..."), `${testAliasId}{enter}`);
     await waitFor(() => {
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(2);
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(2);
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         data: { format: "json", name: `*${testAliasId}*`, s: "alias:desc" },
         endpoint: "cat.aliases",
       });
@@ -180,7 +173,7 @@ describe("<Aliases /> spec", () => {
     expect(getByPlaceholderText("Specify alias name")).toBeDisabled();
     expect((getByPlaceholderText("Specify alias name") as HTMLInputElement).value).toEqual(testAliasId);
     expect(getByTitle("1")).toBeInTheDocument();
-    expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(6);
+    expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(6);
     await userEvent.type(
       getByTestId("form-name-indexArray").querySelector('[data-test-subj="comboBoxSearchInput"]') as Element,
       "2{enter}"
@@ -188,7 +181,7 @@ describe("<Aliases /> spec", () => {
     await userEvent.click(document.querySelector('[title="1"] button') as Element);
     await userEvent.click(getByText("Save changes"));
     await waitFor(() => {
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         data: {
           body: {
             actions: [
@@ -228,14 +221,14 @@ describe("<Aliases /> spec", () => {
     await waitFor(() => {});
     await userEvent.click(getByTestId("createAliasButton"));
     await waitFor(() => {
-      expect(coreServicesMock.notifications.toasts.addDanger).toBeCalledTimes(1);
-      expect(coreServicesMock.notifications.toasts.addDanger).toBeCalledWith("alias exist");
+      expect(coreServicesMock.notifications.toasts.addDanger).toHaveBeenCalledTimes(1);
+      expect(coreServicesMock.notifications.toasts.addDanger).toHaveBeenCalledWith("alias exist");
     });
     await userEvent.clear(getByPlaceholderText("Specify alias name"));
     await userEvent.type(getByPlaceholderText("Specify alias name"), testAliasId);
     await userEvent.click(getByTestId("createAliasButton"));
     await waitFor(() => {
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         data: {
           index: ["1"],
           name: testAliasId,

--- a/public/pages/Aliases/containers/Aliases/__snapshots__/Aliases.test.tsx.snap
+++ b/public/pages/Aliases/containers/Aliases/__snapshots__/Aliases.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Aliases /> spec renders the component 1`] = `
 <div
@@ -194,7 +194,7 @@ exports[`<Aliases /> spec renders the component 1`] = `
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>

--- a/public/pages/Aliases/containers/CreateAlias/CreateAlias.test.tsx
+++ b/public/pages/Aliases/containers/CreateAlias/CreateAlias.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import CreateAlias from "./index";
 import { browserServicesMock } from "../../../../../test/mocks";

--- a/public/pages/Aliases/containers/CreateAlias/__snapshots__/CreateAlias.test.tsx.snap
+++ b/public/pages/Aliases/containers/CreateAlias/__snapshots__/CreateAlias.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreateAlias /> spec renders the component 1`] = `
 HTMLCollection [
@@ -174,7 +174,7 @@ HTMLCollection [
                                 value=""
                               />
                               <div
-                                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                               />
                             </div>
                           </div>

--- a/public/pages/Aliases/containers/DeleteAliasModal/DeleteAliasModal.test.tsx
+++ b/public/pages/Aliases/containers/DeleteAliasModal/DeleteAliasModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import DeleteAliasModal from "./DeleteAliasModal";
 

--- a/public/pages/Aliases/containers/DeleteAliasModal/__snapshots__/DeleteAliasModal.test.tsx.snap
+++ b/public/pages/Aliases/containers/DeleteAliasModal/__snapshots__/DeleteAliasModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DeleteIndexModal /> spec renders the component 1`] = `
 HTMLCollection [

--- a/public/pages/ChangePolicy/components/ChangeManagedIndices/ChangeManagedIndices.test.tsx
+++ b/public/pages/ChangePolicy/components/ChangeManagedIndices/ChangeManagedIndices.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import ChangeManagedIndices from "./ChangeManagedIndices";
 import { browserServicesMock } from "../../../../../test/mocks";

--- a/public/pages/ChangePolicy/components/ChangeManagedIndices/__snapshots__/ChangeManagedIndices.test.tsx.snap
+++ b/public/pages/ChangePolicy/components/ChangeManagedIndices/__snapshots__/ChangeManagedIndices.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ChangeManagedIndices /> spec renders the component 1`] = `
 <div
@@ -68,7 +68,7 @@ exports[`<ChangeManagedIndices /> spec renders the component 1`] = `
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>
@@ -155,7 +155,7 @@ exports[`<ChangeManagedIndices /> spec renders the component 1`] = `
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>

--- a/public/pages/ChangePolicy/components/NewPolicy/NewPolicy.test.tsx
+++ b/public/pages/ChangePolicy/components/NewPolicy/NewPolicy.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import NewPolicy from "./NewPolicy";
 import { browserServicesMock } from "../../../../../test/mocks";

--- a/public/pages/ChangePolicy/components/NewPolicy/__snapshots__/NewPolicy.test.tsx.snap
+++ b/public/pages/ChangePolicy/components/NewPolicy/__snapshots__/NewPolicy.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<NewPolicy /> spec renders the component 1`] = `
 <div
@@ -92,7 +92,7 @@ exports[`<NewPolicy /> spec renders the component 1`] = `
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>

--- a/public/pages/ChangePolicy/containers/ChangePolicy/ChangePolicy.test.tsx
+++ b/public/pages/ChangePolicy/containers/ChangePolicy/ChangePolicy.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import { HashRouter as Router, Redirect, Route, Switch } from "react-router-dom";
 import { CoreStart } from "opensearch-dashboards/public";

--- a/public/pages/ChangePolicy/containers/ChangePolicy/__snapshots__/ChangePolicy.test.tsx.snap
+++ b/public/pages/ChangePolicy/containers/ChangePolicy/__snapshots__/ChangePolicy.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ChangePolicy /> spec renders the component 1`] = `
 <div
@@ -81,7 +81,7 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
                       value=""
                     />
                     <div
-                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                     />
                   </div>
                 </div>
@@ -168,7 +168,7 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
                       value=""
                     />
                     <div
-                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                     />
                   </div>
                 </div>
@@ -292,7 +292,7 @@ exports[`<ChangePolicy /> spec renders the component 1`] = `
                       value=""
                     />
                     <div
-                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                     />
                   </div>
                 </div>

--- a/public/pages/ComposableTemplates/components/IndexControls/IndexControls.test.tsx
+++ b/public/pages/ComposableTemplates/components/IndexControls/IndexControls.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import userEventModule from "@testing-library/user-event";
 import IndexControls from "./IndexControls";
@@ -24,8 +24,8 @@ describe("<IndexControls /> spec", () => {
 
     await userEvent.type(getByPlaceholderText("Search..."), "test");
     await waitFor(() => {
-      expect(onSearchChangeMock).toBeCalledTimes(4);
-      expect(onSearchChangeMock).toBeCalledWith({
+      expect(onSearchChangeMock).toHaveBeenCalledTimes(4);
+      expect(onSearchChangeMock).toHaveBeenCalledWith({
         search: "test",
       });
     });

--- a/public/pages/ComposableTemplates/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
+++ b/public/pages/ComposableTemplates/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<IndexControls /> spec renders the component 1`] = `
 <div

--- a/public/pages/ComposableTemplates/containers/AssociatedTemplatesModal/AssociatedTemplatesModal.test.tsx
+++ b/public/pages/ComposableTemplates/containers/AssociatedTemplatesModal/AssociatedTemplatesModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import AssociatedTemplatesModal from "./AssociatedTemplatesModal";
 import userEventModule from "@testing-library/user-event";
@@ -20,38 +20,36 @@ describe("<AssociatedTemplatesModal /> spec", () => {
     const componentTemplateName = "test_component_template";
     const unlinkHandlerMock = jest.fn();
     let time = 0;
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.data?.path?.startsWith("/_component_template/")) {
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.data?.path?.startsWith("/_component_template/")) {
+        return {
+          ok: true,
+          response: {},
+        };
+      } else if (payload.data?.path?.startsWith("/_index_template")) {
+        if (payload.data?.method === "POST") {
+          time++;
           return {
-            ok: true,
-            response: {},
-          };
-        } else if (payload.data?.path?.startsWith("/_index_template")) {
-          if (payload.data?.method === "POST") {
-            time++;
-            return {
-              ok: time !== 1,
-              error: "error",
-            };
-          }
-          return {
-            ok: true,
-            response: {
-              index_templates: [
-                {
-                  name: templateName,
-                  index_template: {
-                    composed_of: [componentTemplateName],
-                  },
-                },
-              ],
-            },
+            ok: time !== 1,
+            error: "error",
           };
         }
-        return { ok: true, response: {} };
+        return {
+          ok: true,
+          response: {
+            index_templates: [
+              {
+                name: templateName,
+                index_template: {
+                  composed_of: [componentTemplateName],
+                },
+              },
+            ],
+          },
+        };
       }
-    );
+      return { ok: true, response: {} };
+    });
     const { findByText, getByTestId, queryByText } = render(
       <CoreServicesContext.Provider value={coreServicesMock}>
         <ServicesContext.Provider value={browserServicesMock}>
@@ -80,17 +78,17 @@ describe("<AssociatedTemplatesModal /> spec", () => {
     );
     await userEvent.click(getByTestId(`Unlink from ${templateName}?-confirm`));
     await waitFor(() => {
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(3);
-      expect(coreServicesMock.notifications.toasts.addDanger).toBeCalledWith("error");
-      expect(unlinkHandlerMock).toBeCalledTimes(0);
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(3);
+      expect(coreServicesMock.notifications.toasts.addDanger).toHaveBeenCalledWith("error");
+      expect(unlinkHandlerMock).toHaveBeenCalledTimes(0);
     });
     await userEvent.click(getByTestId(`Unlink from ${templateName}?-confirm`));
     await waitFor(() => {
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(6);
-      expect(coreServicesMock.notifications.toasts.addSuccess).toBeCalledWith(
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(6);
+      expect(coreServicesMock.notifications.toasts.addSuccess).toHaveBeenCalledWith(
         `${componentTemplateName} has been successfully unlinked from ${templateName}.`
       );
-      expect(unlinkHandlerMock).toBeCalledWith(templateName);
+      expect(unlinkHandlerMock).toHaveBeenCalledWith(templateName);
     });
     await userEvent.click(getByTestId("euiFlyoutCloseButton"));
     await waitFor(() => {

--- a/public/pages/ComposableTemplates/containers/AssociatedTemplatesModal/__snapshots__/AssociatedTemplatesModal.test.tsx.snap
+++ b/public/pages/ComposableTemplates/containers/AssociatedTemplatesModal/__snapshots__/AssociatedTemplatesModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<AssociatedTemplatesModal /> spec renders the component 1`] = `
 HTMLCollection [

--- a/public/pages/ComposableTemplates/containers/ComposableTemplates/ComposableTemplates.test.tsx
+++ b/public/pages/ComposableTemplates/containers/ComposableTemplates/ComposableTemplates.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { act, render, waitFor } from "@testing-library/react";
 import { Redirect, Route, Switch } from "react-router-dom";
 import { HashRouter as Router } from "react-router-dom";
@@ -132,21 +132,21 @@ describe("<ComposableTemplates /> spec", () => {
 
     expect(container.firstChild).toMatchSnapshot();
     await waitFor(() => {
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(2);
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(2);
     });
     await userEvent.click(getByTestId("tableHeaderCell_name_0").querySelector("button") as Element);
     await waitFor(() => {
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(3);
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(3);
     });
   });
 
   it("with some actions", async () => {
     const { getByPlaceholderText, getByTestId, findByTestId, findByText, queryByTestId } = renderWithRouter();
 
-    expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(2);
+    expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(2);
     await userEvent.click(getByTestId("tableHeaderCell_name_0").querySelector('[data-test-subj="tableHeaderSortButton"]') as Element);
     await waitFor(() => {
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(3);
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(3);
     });
     /**
      * search
@@ -157,8 +157,8 @@ describe("<ComposableTemplates /> spec", () => {
       expect(queryByTestId(`templateDetail-${testTemplateId}`)).toBeNull();
     });
     await waitFor(() => {
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(5);
-      expect(coreServicesMock.notifications.toasts.addDanger).toBeCalledTimes(1);
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(5);
+      expect(coreServicesMock.notifications.toasts.addDanger).toHaveBeenCalledTimes(1);
     });
     await userEvent.clear(getByPlaceholderText("Search..."));
     await findByTestId(`templateDetail-${testTemplateId}`);
@@ -198,7 +198,7 @@ describe("<ComposableTemplates /> spec", () => {
       await userEvent.click(getByTestId("deleteConfirmButton"));
     });
     await waitFor(() => {
-      expect(coreServicesMock.notifications.toasts.addSuccess).toBeCalledWith(`Delete [${testTemplateId}] successfully`);
+      expect(coreServicesMock.notifications.toasts.addSuccess).toHaveBeenCalledWith(`Delete [${testTemplateId}] successfully`);
     });
 
     /**

--- a/public/pages/ComposableTemplates/containers/ComposableTemplates/__snapshots__/ComposableTemplates.test.tsx.snap
+++ b/public/pages/ComposableTemplates/containers/ComposableTemplates/__snapshots__/ComposableTemplates.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ComposableTemplates /> spec renders the component 1`] = `
 <div

--- a/public/pages/ComposableTemplates/containers/ComposableTemplatesActions/ComposableTemplatesActions.test.tsx
+++ b/public/pages/ComposableTemplates/containers/ComposableTemplatesActions/ComposableTemplatesActions.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import userEventModule from "@testing-library/user-event";
 import { browserServicesMock, coreServicesMock } from "../../../../../test/mocks";
@@ -35,16 +35,14 @@ describe("<ComposableTemplatesActions /> spec", () => {
   const userEvent = userEventModule.setup();
 
   beforeEach(() => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (): Promise<any> => {
-        return {
-          ok: true,
-          response: {
-            index_templates: [],
-          },
-        };
-      }
-    );
+    browserServicesMock.commonService.apiCaller = jest.fn(async (): Promise<any> => {
+      return {
+        ok: true,
+        response: {
+          index_templates: [],
+        },
+      };
+    });
   });
   it("renders the component and all the actions should be disabled when no items selected", async () => {
     const { container, getByTestId } = renderWithRouter({
@@ -64,25 +62,23 @@ describe("<ComposableTemplatesActions /> spec", () => {
   it("delete templates by calling commonService", async () => {
     const onDelete = jest.fn();
     let times = 0;
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.data?.path?.startsWith("/_component_template/")) {
-          if (times >= 1) {
-            return {
-              ok: true,
-              response: {},
-            };
-          } else {
-            times++;
-            return {
-              ok: false,
-              error: "test error",
-            };
-          }
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.data?.path?.startsWith("/_component_template/")) {
+        if (times >= 1) {
+          return {
+            ok: true,
+            response: {},
+          };
+        } else {
+          times++;
+          return {
+            ok: false,
+            error: "test error",
+          };
         }
-        return { ok: true, response: {} };
       }
-    );
+      return { ok: true, response: {} };
+    });
     const { container, getByTestId, findAllByText } = renderWithRouter({
       selectedItems: ["test_template"],
       onDelete,
@@ -121,31 +117,29 @@ describe("<ComposableTemplatesActions /> spec", () => {
   }, 30000);
 
   it("renders delete action by using renderDeleteButton", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.data?.path?.startsWith("/_component_template/")) {
-          return {
-            ok: true,
-            response: {},
-          };
-        } else if (payload.data?.path?.startsWith("/_index_template")) {
-          return {
-            ok: true,
-            response: {
-              index_templates: [
-                {
-                  name: "test",
-                  index_template: {
-                    composed_of: ["test_component_template"],
-                  },
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.data?.path?.startsWith("/_component_template/")) {
+        return {
+          ok: true,
+          response: {},
+        };
+      } else if (payload.data?.path?.startsWith("/_index_template")) {
+        return {
+          ok: true,
+          response: {
+            index_templates: [
+              {
+                name: "test",
+                index_template: {
+                  composed_of: ["test_component_template"],
                 },
-              ],
-            },
-          };
-        }
-        return { ok: true, response: {} };
+              },
+            ],
+          },
+        };
       }
-    );
+      return { ok: true, response: {} };
+    });
     const { container, findByText, getByText, findByTestId, getByTestId } = renderWithRouter({
       selectedItems: ["test_component_template"],
       onDelete: () => {},
@@ -165,8 +159,8 @@ describe("<ComposableTemplatesActions /> spec", () => {
     await userEvent.click(getByTestId("deleteConfirmUnlinkButton"));
     await waitFor(
       () => {
-        expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(4);
-        expect(coreServicesMock.notifications.toasts.addSuccess).toBeCalledWith(`Delete [test_component_template] successfully`);
+        expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(4);
+        expect(coreServicesMock.notifications.toasts.addSuccess).toHaveBeenCalledWith(`Delete [test_component_template] successfully`);
       },
       {
         timeout: 3000,

--- a/public/pages/ComposableTemplates/containers/ComposableTemplatesActions/__snapshots__/ComposableTemplatesActions.test.tsx.snap
+++ b/public/pages/ComposableTemplates/containers/ComposableTemplatesActions/__snapshots__/ComposableTemplatesActions.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ComposableTemplatesActions /> spec delete templates by calling commonService 1`] = `
 <button

--- a/public/pages/ComposableTemplates/containers/DeleteComposableTemplatesModal/DeleteComposableTemplatesModal.test.tsx
+++ b/public/pages/ComposableTemplates/containers/DeleteComposableTemplatesModal/DeleteComposableTemplatesModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import DeleteTemplateModal, { DeleteTemplateModalProps } from "./DeleteComposableTemplatesModal";
 import { browserServicesMock, coreServicesMock } from "../../../../../test/mocks";

--- a/public/pages/ComposableTemplates/containers/DeleteComposableTemplatesModal/__snapshots__/DeleteComposableTemplatesModal.test.tsx.snap
+++ b/public/pages/ComposableTemplates/containers/DeleteComposableTemplatesModal/__snapshots__/DeleteComposableTemplatesModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DeleteTemplateModal /> spec renders the component 1`] = `
 HTMLCollection [

--- a/public/pages/CreateComposableTemplate/containers/CreateComposableTemplate/__snapshots__/CreateComposableTemplate.test.tsx.snap
+++ b/public/pages/CreateComposableTemplate/containers/CreateComposableTemplate/__snapshots__/CreateComposableTemplate.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreateComposableTemplate /> spec it goes to templates page when click cancel 1`] = `
 <div>

--- a/public/pages/CreateComposableTemplate/containers/TemplateDetail/TemplateDetail.test.tsx
+++ b/public/pages/CreateComposableTemplate/containers/TemplateDetail/TemplateDetail.test.tsx
@@ -108,6 +108,6 @@ describe("<TemplateDetail /> spec", () => {
     await findByText("Delete good_template");
     await userEvent.click(getByTestId("deleteConfirmButton"));
     await findByText(`This is ${ROUTES.COMPOSABLE_TEMPLATES}`);
-    expect(coreServicesMock.notifications.toasts.addSuccess).toBeCalled();
+    expect(coreServicesMock.notifications.toasts.addSuccess).toHaveBeenCalled();
   });
 });

--- a/public/pages/CreateComposableTemplate/containers/TemplateDetail/__snapshots__/TemplateDetail.test.tsx.snap
+++ b/public/pages/CreateComposableTemplate/containers/TemplateDetail/__snapshots__/TemplateDetail.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<TemplateDetail /> spec render component 1`] = `
 <div>

--- a/public/pages/CreateDataStream/containers/CreateDataStream/__snapshots__/CreateDataStream.test.tsx.snap
+++ b/public/pages/CreateDataStream/containers/CreateDataStream/__snapshots__/CreateDataStream.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreateDataStream /> spec it goes to data streams page when click cancel 1`] = `
 <div>
@@ -190,7 +190,7 @@ exports[`<CreateDataStream /> spec it goes to data streams page when click cance
                           value=""
                         />
                         <div
-                          style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                          style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                         />
                       </div>
                     </div>

--- a/public/pages/CreateDataStream/containers/DataStreamDetail/__snapshots__/DataStreamDetail.test.tsx.snap
+++ b/public/pages/CreateDataStream/containers/DataStreamDetail/__snapshots__/DataStreamDetail.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DataStreamDetail /> spec render component 1`] = `
 <div>
@@ -187,7 +187,7 @@ exports[`<DataStreamDetail /> spec render component 1`] = `
                         value=""
                       />
                       <div
-                        style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                        style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                       />
                     </div>
                   </div>

--- a/public/pages/CreateIndex/containers/IndexForm/IndexForm.test.tsx
+++ b/public/pages/CreateIndex/containers/IndexForm/IndexForm.test.tsx
@@ -100,7 +100,7 @@ describe("<IndexForm /> spec", () => {
 
     await waitFor(() => {
       // it shows detail and does not call any api when nothing modified
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(2);
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -122,8 +122,8 @@ describe("<IndexForm /> spec", () => {
     await userEvent.click(getByText("Update"));
 
     await waitFor(() => {
-      expect(coreServicesMock.notifications.toasts.addSuccess).toBeCalledTimes(1);
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+      expect(coreServicesMock.notifications.toasts.addSuccess).toHaveBeenCalledTimes(1);
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         endpoint: "indices.updateAliases",
         method: "PUT",
         data: {
@@ -146,7 +146,7 @@ describe("<IndexForm /> spec", () => {
         },
       });
 
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         endpoint: "indices.putSettings",
         method: "PUT",
         data: {
@@ -158,7 +158,7 @@ describe("<IndexForm /> spec", () => {
         },
       });
 
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         endpoint: "indices.putMapping",
         method: "PUT",
         data: {
@@ -190,8 +190,8 @@ describe("<IndexForm /> spec", () => {
 
     await waitFor(() => {
       // shows detail alias and update alias only
-      expect(coreServicesMock.notifications.toasts.addSuccess).toBeCalledTimes(1);
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+      expect(coreServicesMock.notifications.toasts.addSuccess).toHaveBeenCalledTimes(1);
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         endpoint: "indices.updateAliases",
         method: "PUT",
         data: {
@@ -233,9 +233,9 @@ describe("<IndexForm /> spec", () => {
     await userEvent.click(getByText("Update"));
 
     await waitFor(() => {
-      expect(coreServicesMock.notifications.toasts.addSuccess).toBeCalledTimes(1);
+      expect(coreServicesMock.notifications.toasts.addSuccess).toHaveBeenCalledTimes(1);
 
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         endpoint: "indices.putMapping",
         method: "PUT",
         data: {
@@ -264,9 +264,9 @@ describe("<IndexForm /> spec", () => {
     await userEvent.click(getByText("Update"));
 
     await waitFor(() => {
-      expect(coreServicesMock.notifications.toasts.addSuccess).toBeCalledTimes(1);
+      expect(coreServicesMock.notifications.toasts.addSuccess).toHaveBeenCalledTimes(1);
 
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         endpoint: "indices.putSettings",
         method: "PUT",
         data: {
@@ -289,8 +289,8 @@ describe("<IndexForm /> spec", () => {
     await waitFor(() => {});
     await userEvent.click(getByText("Cancel"));
     await (() => {
-      expect(onCancelMock).toBeCalledTimes(1);
-      expect(onCancelMock).toBeCalledWith(undefined);
+      expect(onCancelMock).toHaveBeenCalledTimes(1);
+      expect(onCancelMock).toHaveBeenCalledWith(undefined);
     });
   });
 });

--- a/public/pages/CreateIndexTemplate/components/DefineTemplate/DefineTemplate.test.tsx
+++ b/public/pages/CreateIndexTemplate/components/DefineTemplate/DefineTemplate.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { act, render, waitFor } from "@testing-library/react";
 import { browserServicesMock, coreServicesMock } from "../../../../../test/mocks";
 import DefineTemplate from "./DefineTemplate";
@@ -58,16 +58,14 @@ describe("<ComposableTemplatesActions /> spec", () => {
   const userEvent = userEventModule.setup();
 
   beforeEach(() => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (): Promise<any> => {
-        return {
-          ok: true,
-          response: {
-            index_templates: [],
-          },
-        };
-      }
-    );
+    browserServicesMock.commonService.apiCaller = jest.fn(async (): Promise<any> => {
+      return {
+        ok: true,
+        response: {
+          index_templates: [],
+        },
+      };
+    });
   });
   it("renders the component in non-edit mode", async () => {
     const onChangeMock = jest.fn();
@@ -84,7 +82,7 @@ describe("<ComposableTemplatesActions /> spec", () => {
     await userEvent.click(container.querySelector("#checkboxForIndexTemplateFlowSimple")?.parentNode as Element);
     await waitFor(() => {
       expect((container.querySelector("#checkboxForIndexTemplateFlowSimple") as HTMLInputElement).checked).toBeTruthy;
-      expect(onChangeMock).toBeCalledTimes(0);
+      expect(onChangeMock).toHaveBeenCalledTimes(0);
     });
     await act(async () => {
       await userEvent.type(getByTestId("form-row-name").querySelector("input") as Element, "1");
@@ -98,7 +96,7 @@ describe("<ComposableTemplatesActions /> spec", () => {
       expect(document.querySelector(".euiFormLabel-isInvalid")).not.toBeInTheDocument();
     });
     await waitFor(() => {
-      expect(onChangeMock).toBeCalledWith({
+      expect(onChangeMock).toHaveBeenCalledWith({
         name: "1",
         index_patterns: [".kibana*"],
         priority: "1",

--- a/public/pages/CreateIndexTemplate/components/DefineTemplate/__snapshots__/DefineTemplate.test.tsx.snap
+++ b/public/pages/CreateIndexTemplate/components/DefineTemplate/__snapshots__/DefineTemplate.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ComposableTemplatesActions /> spec renders the component in edit mode 1`] = `
 <div>
@@ -175,7 +175,7 @@ exports[`<ComposableTemplatesActions /> spec renders the component in edit mode 
                           value=""
                         />
                         <div
-                          style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                          style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                         />
                       </div>
                     </div>
@@ -633,7 +633,7 @@ exports[`<ComposableTemplatesActions /> spec renders the component in non-edit m
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>

--- a/public/pages/CreateIndexTemplate/containers/CreateIndexTemplate/CreateIndexTemplate.test.tsx
+++ b/public/pages/CreateIndexTemplate/containers/CreateIndexTemplate/CreateIndexTemplate.test.tsx
@@ -85,7 +85,7 @@ describe("<CreateIndexTemplate /> spec", () => {
     await userEvent.type(patternInput, `test_patterns{enter}`);
 
     await userEvent.click(submitButton);
-    await waitFor(() => expect(coreServicesMock.notifications.toasts.addDanger).toBeCalledWith("bad template"));
+    await waitFor(() => expect(coreServicesMock.notifications.toasts.addDanger).toHaveBeenCalledWith("bad template"));
     await userEvent.clear(templateNameInput);
     await userEvent.type(templateNameInput, "good_template");
 
@@ -109,7 +109,7 @@ describe("<CreateIndexTemplate /> spec", () => {
     await userEvent.click(submitButton);
     await waitFor(
       () => {
-        expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+        expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
           endpoint: "transport.request",
           data: {
             method: "PUT",

--- a/public/pages/CreateIndexTemplate/containers/CreateIndexTemplate/__snapshots__/CreateIndexTemplate.test.tsx.snap
+++ b/public/pages/CreateIndexTemplate/containers/CreateIndexTemplate/__snapshots__/CreateIndexTemplate.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreateIndexTemplate /> spec render template pages 1`] = `
 <div>

--- a/public/pages/CreateIndexTemplate/containers/TemplateDetail/TemplateDetail.test.tsx
+++ b/public/pages/CreateIndexTemplate/containers/TemplateDetail/TemplateDetail.test.tsx
@@ -109,7 +109,7 @@ describe("<TemplateDetail /> spec", () => {
      */
     await userEvent.click(getByTestId("CreateIndexTemplatePreviewButton"));
     await waitFor(() => {
-      expect(coreServicesMock.notifications.toasts.addDanger).toBeCalledWith("error");
+      expect(coreServicesMock.notifications.toasts.addDanger).toHaveBeenCalledWith("error");
     });
     await userEvent.click(getByTestId("CreateIndexTemplatePreviewButton"));
     await findAllByText("Preview template");
@@ -174,14 +174,14 @@ describe("<TemplateDetail /> spec", () => {
       await userEvent.click(getByTestId("updateTemplateButton"));
     });
     await waitFor(() => {
-      expect(coreServicesMock.notifications.toasts.addDanger).toBeCalledWith(`error`);
+      expect(coreServicesMock.notifications.toasts.addDanger).toHaveBeenCalledWith(`error`);
     });
 
     await act(async () => {
       await userEvent.click(getByTestId("updateTemplateButton"));
     });
     await waitFor(() => {
-      expect(coreServicesMock.notifications.toasts.addSuccess).toBeCalledWith(`good_template has been successfully updated.`);
+      expect(coreServicesMock.notifications.toasts.addSuccess).toHaveBeenCalledWith(`good_template has been successfully updated.`);
     });
   });
 
@@ -214,7 +214,7 @@ describe("<TemplateDetail /> spec", () => {
     await userEvent.type(getByTestId("deleteInput"), "delete");
     await userEvent.click(getByTestId("deleteConfirmButton"));
     await findByText(`This is ${ROUTES.TEMPLATES}`);
-    expect(coreServicesMock.notifications.toasts.addSuccess).toBeCalled();
+    expect(coreServicesMock.notifications.toasts.addSuccess).toHaveBeenCalled();
   });
 
   it("simulate error", async () => {
@@ -244,7 +244,7 @@ describe("<TemplateDetail /> spec", () => {
       templateName: "good_template",
     });
     await waitFor(() => {
-      expect(coreServicesMock.notifications.toasts.addDanger).toBeCalledWith("error");
+      expect(coreServicesMock.notifications.toasts.addDanger).toHaveBeenCalledWith("error");
     });
   });
 

--- a/public/pages/CreateIndexTemplate/containers/TemplateDetail/__snapshots__/TemplateDetail.test.tsx.snap
+++ b/public/pages/CreateIndexTemplate/containers/TemplateDetail/__snapshots__/TemplateDetail.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
 <div>
@@ -273,7 +273,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>
@@ -612,7 +612,7 @@ exports[`<TemplateDetail /> spec render component in non-edit-mode 1`] = `
                       value=""
                     />
                     <div
-                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                     />
                   </div>
                 </div>

--- a/public/pages/CreatePolicy/components/ConfigurePolicy/__snapshots__/ConfigurePolicy.test.tsx.snap
+++ b/public/pages/CreatePolicy/components/ConfigurePolicy/__snapshots__/ConfigurePolicy.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ConfigurePolicy /> spec renders the component 1`] = `
 <div

--- a/public/pages/CreatePolicy/components/DefinePolicy/__snapshots__/DefinePolicy.test.tsx.snap
+++ b/public/pages/CreatePolicy/components/DefinePolicy/__snapshots__/DefinePolicy.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DefinePolicy /> spec renders the component 1`] = `
 <div

--- a/public/pages/CreatePolicy/containers/CreatePolicy/__snapshots__/CreatePolicy.test.tsx.snap
+++ b/public/pages/CreatePolicy/containers/CreatePolicy/__snapshots__/CreatePolicy.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreatePolicy /> spec renders the create component 1`] = `
 <div

--- a/public/pages/CreatePolicy/utils/__snapshots__/helpers.test.tsx.snap
+++ b/public/pages/CreatePolicy/utils/__snapshots__/helpers.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`inputLimitText renders the component with 0 inputs 1`] = `
 <div

--- a/public/pages/CreateRollup/containers/CreateRollupForm/__snapshots__/CreateRollupForm.test.tsx.snap
+++ b/public/pages/CreateRollup/containers/CreateRollupForm/__snapshots__/CreateRollupForm.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreateRollupForm /> spec renders the component 1`] = `
 <div
@@ -380,7 +380,7 @@ exports[`<CreateRollupForm /> spec renders the component 1`] = `
                             value=""
                           />
                           <div
-                            style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                            style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                           />
                         </div>
                       </div>
@@ -471,7 +471,7 @@ exports[`<CreateRollupForm /> spec renders the component 1`] = `
                             value=""
                           />
                           <div
-                            style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                            style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                           />
                         </div>
                       </div>

--- a/public/pages/CreateTransform/components/TransformOptions/Panels/DateHistogramPanel/__snapshots__/DateHistogramPanel.test.tsx.snap
+++ b/public/pages/CreateTransform/components/TransformOptions/Panels/DateHistogramPanel/__snapshots__/DateHistogramPanel.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DateHistogramPanel /> spec renders the component with calendar interval 1`] = `
 <div

--- a/public/pages/CreateTransform/containers/CreateTransformForm/__snapshots__/CreateTransformForm.test.tsx.snap
+++ b/public/pages/CreateTransform/containers/CreateTransformForm/__snapshots__/CreateTransformForm.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreateTransformForm /> spec renders the component 1`] = `
 <div
@@ -355,7 +355,7 @@ exports[`<CreateTransformForm /> spec renders the component 1`] = `
                                 value=""
                               />
                               <div
-                                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                               />
                             </div>
                           </div>
@@ -570,7 +570,7 @@ exports[`<CreateTransformForm /> spec renders the component 1`] = `
                                 value=""
                               />
                               <div
-                                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                               />
                             </div>
                           </div>

--- a/public/pages/DataStreams/components/IndexControls/IndexControls.test.tsx
+++ b/public/pages/DataStreams/components/IndexControls/IndexControls.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 // @ts-ignore
 import userEventModule from "@testing-library/user-event";
@@ -25,8 +25,8 @@ describe("<IndexControls /> spec", () => {
 
     await userEvent.type(getByPlaceholderText("Search..."), "test");
     await waitFor(() => {
-      expect(onSearchChangeMock).toBeCalledTimes(4);
-      expect(onSearchChangeMock).toBeCalledWith({
+      expect(onSearchChangeMock).toHaveBeenCalledTimes(4);
+      expect(onSearchChangeMock).toHaveBeenCalledWith({
         search: "test",
       });
     });

--- a/public/pages/DataStreams/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
+++ b/public/pages/DataStreams/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<IndexControls /> spec renders the component 1`] = `
 <div

--- a/public/pages/DataStreams/containers/DataStreams/DataStreams.test.tsx
+++ b/public/pages/DataStreams/containers/DataStreams/DataStreams.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import { Redirect, Route, Switch } from "react-router-dom";
 import { HashRouter as Router } from "react-router-dom";
@@ -102,17 +102,17 @@ describe("<DataStreams /> spec", () => {
 
     expect(container.firstChild).toMatchSnapshot();
     await waitFor(() => {
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(2);
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(2);
     });
   });
 
   it("with some actions", async () => {
     const { getByPlaceholderText } = renderWithRouter();
-    expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(2);
+    expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(2);
     await userEvent.type(getByPlaceholderText("Search..."), `${testTemplateId}{enter}`);
     await waitFor(() => {
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(4);
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(4);
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         data: { method: "GET", path: "_data_stream/**" },
         endpoint: "transport.request",
       });

--- a/public/pages/DataStreams/containers/DataStreams/__snapshots__/DataStreams.test.tsx.snap
+++ b/public/pages/DataStreams/containers/DataStreams/__snapshots__/DataStreams.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DataStreams /> spec renders the component 1`] = `
 <div

--- a/public/pages/DataStreams/containers/DataStreamsActions/DataStreamsActions.test.tsx
+++ b/public/pages/DataStreams/containers/DataStreamsActions/DataStreamsActions.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import userEventModule from "@testing-library/user-event";
 import { browserServicesMock, coreServicesMock } from "../../../../../test/mocks";
@@ -72,11 +72,9 @@ describe("<DataStreamsActions /> spec", () => {
 
   it("delete data streams by calling commonService", async () => {
     const onDelete = jest.fn();
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (): Promise<any> => {
-        return { ok: true, response: {} };
-      }
-    );
+    browserServicesMock.commonService.apiCaller = jest.fn(async (): Promise<any> => {
+      return { ok: true, response: {} };
+    });
     const { container, getByTestId, getByPlaceholderText } = renderWithRouter({
       selectedItems: [{ name: "test_data_stream" }],
       onDelete,
@@ -107,24 +105,22 @@ describe("<DataStreamsActions /> spec", () => {
   }, 30000);
 
   it("clear cache for data streams by calling commonService", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        switch (payload.endpoint) {
-          case "cluster.state":
-            return {
-              ok: true,
-              response: {
-                blocks: {},
-              },
-            };
-          default:
-            return {
-              ok: true,
-              response: {},
-            };
-        }
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      switch (payload.endpoint) {
+        case "cluster.state":
+          return {
+            ok: true,
+            response: {
+              blocks: {},
+            },
+          };
+        default:
+          return {
+            ok: true,
+            response: {},
+          };
       }
-    );
+    });
     const { container, getByTestId, getByText } = renderWithRouter({
       selectedItems: [
         {
@@ -175,33 +171,31 @@ describe("<DataStreamsActions /> spec", () => {
   });
 
   it("cannot clear cache for data streams if they are closed or blocked", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (): Promise<any> => {
-        return {
-          ok: true,
-          response: {
-            blocks: {
-              indices: {
-                ".ds-test_data_stream_1-000001": {
-                  "4": {
-                    description: "index closed",
-                    retryable: false,
-                    levels: ["read", "write"],
-                  },
+    browserServicesMock.commonService.apiCaller = jest.fn(async (): Promise<any> => {
+      return {
+        ok: true,
+        response: {
+          blocks: {
+            indices: {
+              ".ds-test_data_stream_1-000001": {
+                "4": {
+                  description: "index closed",
+                  retryable: false,
+                  levels: ["read", "write"],
                 },
-                ".ds-test_data_stream_2-000001": {
-                  "5": {
-                    description: "index read-only (api)",
-                    retryable: false,
-                    levels: ["write", "metadata_write"],
-                  },
+              },
+              ".ds-test_data_stream_2-000001": {
+                "5": {
+                  description: "index read-only (api)",
+                  retryable: false,
+                  levels: ["write", "metadata_write"],
                 },
               },
             },
           },
-        };
-      }
-    );
+        },
+      };
+    });
     const { container, getByTestId } = renderWithRouter({
       selectedItems: [
         {
@@ -258,22 +252,20 @@ describe("<DataStreamsActions /> spec", () => {
   });
 
   it("filter data streams failed when clearing caches for multiple data streams", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        switch (payload.endpoint) {
-          case "cluster.state":
-            return {
-              ok: true,
-              error: "test failure",
-            };
-          default:
-            return {
-              ok: true,
-              response: {},
-            };
-        }
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      switch (payload.endpoint) {
+        case "cluster.state":
+          return {
+            ok: true,
+            error: "test failure",
+          };
+        default:
+          return {
+            ok: true,
+            response: {},
+          };
       }
-    );
+    });
     const { container, getByTestId, getByText } = renderWithRouter({
       selectedItems: [
         {
@@ -412,34 +404,32 @@ describe("<DataStreamsActions /> spec", () => {
   });
 
   it("refresh data streams by calling commonService", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cluster.state") {
-          return {
-            ok: true,
-            response: {
-              blocks: {
-                indices: {
-                  ".ds-blocked-000001": {
-                    "4": {},
-                  },
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cluster.state") {
+        return {
+          ok: true,
+          response: {
+            blocks: {
+              indices: {
+                ".ds-blocked-000001": {
+                  "4": {},
                 },
               },
             },
-          };
-        } else if (payload.endpoint === "indices.refresh") {
-          return {
-            ok: true,
-            response: {},
-          };
-        } else if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: "red_index close\n",
-          };
-        }
+          },
+        };
+      } else if (payload.endpoint === "indices.refresh") {
+        return {
+          ok: true,
+          response: {},
+        };
+      } else if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: "red_index close\n",
+        };
       }
-    );
+    });
 
     const { getByTestId, getByText, queryByTestId } = renderWithRouter({
       selectedItems: [
@@ -511,37 +501,35 @@ describe("<DataStreamsActions /> spec", () => {
   }, 30000);
 
   it("refresh multiple data streams by calling commonService", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cluster.state") {
-          return {
-            ok: true,
-            response: {
-              blocks: {
-                indices: {
-                  ".ds-blocked-000001": {
-                    "4": {},
-                  },
-                  ".ds-blocked1-000001": {
-                    "4": {},
-                  },
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cluster.state") {
+        return {
+          ok: true,
+          response: {
+            blocks: {
+              indices: {
+                ".ds-blocked-000001": {
+                  "4": {},
+                },
+                ".ds-blocked1-000001": {
+                  "4": {},
                 },
               },
             },
-          };
-        } else if (payload.endpoint === "indices.refresh") {
-          return {
-            ok: true,
-            response: {},
-          };
-        } else if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: ".ds-red-000001 close\n",
-          };
-        }
+          },
+        };
+      } else if (payload.endpoint === "indices.refresh") {
+        return {
+          ok: true,
+          response: {},
+        };
+      } else if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: ".ds-red-000001 close\n",
+        };
       }
-    );
+    });
 
     const { getByTestId, getByText } = renderWithRouter({
       selectedItems: [
@@ -624,34 +612,32 @@ describe("<DataStreamsActions /> spec", () => {
   }, 30000);
 
   it("refresh data streams disabled because all indexes are closed calling commonService", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cluster.state") {
-          return {
-            ok: true,
-            response: {
-              blocks: {
-                indices: {
-                  ".ds-blocked-000001": {
-                    "4": {},
-                  },
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cluster.state") {
+        return {
+          ok: true,
+          response: {
+            blocks: {
+              indices: {
+                ".ds-blocked-000001": {
+                  "4": {},
                 },
               },
             },
-          };
-        } else if (payload.endpoint === "indices.refresh") {
-          return {
-            ok: true,
-            response: {},
-          };
-        } else if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: ".ds-red-000001 open\n",
-          };
-        }
+          },
+        };
+      } else if (payload.endpoint === "indices.refresh") {
+        return {
+          ok: true,
+          response: {},
+        };
+      } else if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: ".ds-red-000001 open\n",
+        };
       }
-    );
+    });
 
     const { getByTestId } = renderWithRouter({
       selectedItems: [
@@ -679,31 +665,28 @@ describe("<DataStreamsActions /> spec", () => {
 
     await waitFor(() => {
       expect(coreServicesMock.notifications.toasts.addDanger).toHaveBeenCalledWith({
-        text:
-          "All selected data streams cannot be refreshed because each data stream has one or more indexes that are either closed or in red status.",
+        text: "All selected data streams cannot be refreshed because each data stream has one or more indexes that are either closed or in red status.",
         title: "Unable to refresh data streams.",
       });
     });
   }, 30000);
 
   it("refresh data streams even failed to get index status", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cluster.state") {
-          throw "failed to call cluster.state";
-        } else if (payload.endpoint === "indices.refresh") {
-          return {
-            ok: true,
-            response: {},
-          };
-        } else if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: "red_index close\n",
-          };
-        }
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cluster.state") {
+        throw "failed to call cluster.state";
+      } else if (payload.endpoint === "indices.refresh") {
+        return {
+          ok: true,
+          response: {},
+        };
+      } else if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: "red_index close\n",
+        };
       }
-    );
+    });
 
     const { getByTestId, getByText } = renderWithRouter({
       selectedItems: [
@@ -735,23 +718,21 @@ describe("<DataStreamsActions /> spec", () => {
   }, 30000);
 
   it("refresh multi data streams even failed to get index status", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cluster.state") {
-          throw "failed to call cluster.state";
-        } else if (payload.endpoint === "indices.refresh") {
-          return {
-            ok: true,
-            response: {},
-          };
-        } else if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: "red_index close\n",
-          };
-        }
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cluster.state") {
+        throw "failed to call cluster.state";
+      } else if (payload.endpoint === "indices.refresh") {
+        return {
+          ok: true,
+          response: {},
+        };
+      } else if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: "red_index close\n",
+        };
       }
-    );
+    });
 
     const { getByTestId, getByText } = renderWithRouter({
       selectedItems: [

--- a/public/pages/DataStreams/containers/DataStreamsActions/__snapshots__/DataStreamsActions.test.tsx.snap
+++ b/public/pages/DataStreams/containers/DataStreamsActions/__snapshots__/DataStreamsActions.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DataStreamsActions /> spec cannot clear cache for data streams if they are closed or blocked 1`] = `
 <div

--- a/public/pages/DataStreams/containers/DeleteDataStreamsModal/DeleteDataStreamsModal.test.tsx
+++ b/public/pages/DataStreams/containers/DeleteDataStreamsModal/DeleteDataStreamsModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import DeleteTemplateModal from "./DeleteDataStreamsModal";
 

--- a/public/pages/DataStreams/containers/DeleteDataStreamsModal/__snapshots__/DeleteDataStreamsModal.test.tsx.snap
+++ b/public/pages/DataStreams/containers/DeleteDataStreamsModal/__snapshots__/DeleteDataStreamsModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DeleteTemplateModal /> spec renders the component 1`] = `
 HTMLCollection [

--- a/public/pages/EditRollup/containers/__snapshots__/EditRollup.test.tsx.snap
+++ b/public/pages/EditRollup/containers/__snapshots__/EditRollup.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<EditRollup /> spec renders the component 1`] = `
 <div

--- a/public/pages/ForceMerge/components/ForceMergeAdvancedOptions/__snapshots__/ForceMergeAdvancedOptions.test.tsx.snap
+++ b/public/pages/ForceMerge/components/ForceMergeAdvancedOptions/__snapshots__/ForceMergeAdvancedOptions.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ForceMergeAdvancedOptions /> spec renders the component 1`] = `
 Object {

--- a/public/pages/ForceMerge/components/IndexSelect/__snapshots__/IndexSelect.test.tsx.snap
+++ b/public/pages/ForceMerge/components/IndexSelect/__snapshots__/IndexSelect.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<IndexSelect /> spec renders the component 1`] = `
 Object {
@@ -35,7 +35,7 @@ Object {
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>
@@ -88,7 +88,7 @@ Object {
                   value=""
                 />
                 <div
-                  style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                  style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                 />
               </div>
             </div>

--- a/public/pages/ForceMerge/container/ForceMerge/ForceMerge.test.tsx
+++ b/public/pages/ForceMerge/container/ForceMerge/ForceMerge.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, fireEvent, waitFor, findByText } from "@testing-library/react";
 import userEventModule from "@testing-library/user-event";
 import { Route, RouteComponentProps, Switch } from "react-router-dom";

--- a/public/pages/ForceMerge/container/ForceMerge/__snapshots__/ForceMerge.test.tsx.snap
+++ b/public/pages/ForceMerge/container/ForceMerge/__snapshots__/ForceMerge.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ForceMerge /> spec renders the component 1`] = `
 <div
@@ -110,7 +110,7 @@ exports[`<ForceMerge /> spec renders the component 1`] = `
                       value=""
                     />
                     <div
-                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                     />
                   </div>
                 </div>

--- a/public/pages/IndexDetail/containers/IndexDetail/IndexDetail.test.tsx
+++ b/public/pages/IndexDetail/containers/IndexDetail/IndexDetail.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import userEventModule from "@testing-library/user-event";
 import { MemoryRouter as Router } from "react-router";
@@ -85,8 +85,8 @@ describe("container <IndexDetail /> spec", () => {
 
     await waitFor(() => {
       expect(container.firstChild).toMatchSnapshot();
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(1);
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(1);
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         endpoint: "indices.get",
         data: {
           index: "test_index",

--- a/public/pages/IndexDetail/containers/IndexDetail/__snapshots__/IndexDetail.test.tsx.snap
+++ b/public/pages/IndexDetail/containers/IndexDetail/__snapshots__/IndexDetail.test.tsx.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`container <IndexDetail /> spec render the component 1`] = `null`;

--- a/public/pages/Indices/components/ApplyPolicyModal/ApplyPolicyModal.test.tsx
+++ b/public/pages/Indices/components/ApplyPolicyModal/ApplyPolicyModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import ApplyPolicyModal from "./ApplyPolicyModal";
 import { browserServicesMock, coreServicesMock, httpClientMock } from "../../../../../test/mocks";

--- a/public/pages/Indices/components/ApplyPolicyModal/__snapshots__/ApplyPolicyModal.test.tsx.snap
+++ b/public/pages/Indices/components/ApplyPolicyModal/__snapshots__/ApplyPolicyModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ApplyPolicyModal /> spec renders the component 1`] = `
 <div
@@ -122,7 +122,7 @@ exports[`<ApplyPolicyModal /> spec renders the component 1`] = `
                             value=""
                           />
                           <div
-                            style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                            style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                           />
                         </div>
                       </div>

--- a/public/pages/Indices/components/CloseIndexModal/CloseIndexModal.test.tsx
+++ b/public/pages/Indices/components/CloseIndexModal/CloseIndexModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, fireEvent } from "@testing-library/react";
 import userEventModule from "@testing-library/user-event";
 import CloseIndexModal from "./CloseIndexModal";

--- a/public/pages/Indices/components/CloseIndexModal/__snapshots__/CloseIndexModal.test.tsx.snap
+++ b/public/pages/Indices/components/CloseIndexModal/__snapshots__/CloseIndexModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CloseIndexModal /> spec renders the component 1`] = `
 HTMLCollection [

--- a/public/pages/Indices/components/DeleteIndexModal/DeleteIndexModal.test.tsx
+++ b/public/pages/Indices/components/DeleteIndexModal/DeleteIndexModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import userEventModule from "@testing-library/user-event";
 import DeleteIndexModal from "./DeleteIndexModal";

--- a/public/pages/Indices/components/DeleteIndexModal/__snapshots__/DeleteIndexModal.test.tsx.snap
+++ b/public/pages/Indices/components/DeleteIndexModal/__snapshots__/DeleteIndexModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DeleteIndexModal /> spec renders the component 1`] = `
 HTMLCollection [

--- a/public/pages/Indices/components/IndexControls/IndexControls.test.tsx
+++ b/public/pages/Indices/components/IndexControls/IndexControls.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, fireEvent, waitFor } from "@testing-library/react";
 // @ts-ignore
 import userEventModule from "@testing-library/user-event";

--- a/public/pages/Indices/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
+++ b/public/pages/Indices/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<IndexControls /> spec renders data streams selection field 1`] = `
 <div

--- a/public/pages/Indices/components/IndexEmptyPrompt/IndexEmptyPrompt.test.tsx
+++ b/public/pages/Indices/components/IndexEmptyPrompt/IndexEmptyPrompt.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, fireEvent } from "@testing-library/react";
 import IndexEmptyPrompt, { TEXT } from "./IndexEmptyPrompt";
 

--- a/public/pages/Indices/components/IndexEmptyPrompt/__snapshots__/IndexEmptyPrompt.test.tsx.snap
+++ b/public/pages/Indices/components/IndexEmptyPrompt/__snapshots__/IndexEmptyPrompt.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<IndexEmptyPrompt /> spec renders the component 1`] = `
 <div

--- a/public/pages/Indices/components/OpenIndexModal/OpenIndexModal.test.tsx
+++ b/public/pages/Indices/components/OpenIndexModal/OpenIndexModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, fireEvent } from "@testing-library/react";
 import OpenIndexModal from "./OpenIndexModal";
 

--- a/public/pages/Indices/components/OpenIndexModal/__snapshots__/OpenIndexModal.test.tsx.snap
+++ b/public/pages/Indices/components/OpenIndexModal/__snapshots__/OpenIndexModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<OpenIndexModal /> spec renders the component 1`] = `
 HTMLCollection [

--- a/public/pages/Indices/containers/IndexDetail/IndexDetail.test.tsx
+++ b/public/pages/Indices/containers/IndexDetail/IndexDetail.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import { Route, Switch, HashRouter as Router } from "react-router-dom";
 import { browserServicesMock, coreServicesMock, apiCallerMock } from "../../../../../test/mocks";

--- a/public/pages/Indices/containers/IndexDetail/__snapshots__/IndexDetail.test.tsx.snap
+++ b/public/pages/Indices/containers/IndexDetail/__snapshots__/IndexDetail.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`container <IndexDetail /> spec render the component 1`] = `
 <span

--- a/public/pages/Indices/containers/Indices/Indices.test.tsx
+++ b/public/pages/Indices/containers/Indices/Indices.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 // @ts-ignore
 import userEventModule from "@testing-library/user-event";

--- a/public/pages/Indices/containers/Indices/__snapshots__/Indices.test.tsx.snap
+++ b/public/pages/Indices/containers/Indices/__snapshots__/Indices.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Indices /> spec renders the component 1`] = `
 <div

--- a/public/pages/Indices/containers/IndicesActions/IndicesActions.test.tsx
+++ b/public/pages/Indices/containers/IndicesActions/IndicesActions.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 // @ts-ignore
 import userEventModule from "@testing-library/user-event";
@@ -103,34 +103,32 @@ describe("<IndicesActions /> spec", () => {
   });
 
   it("clear cache for mulitple indexes by calling commonService", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        switch (payload.endpoint) {
-          case "cluster.state":
-            return {
-              ok: true,
-              response: {
-                blocks: {
-                  indices: {
-                    test_index1: {
-                      "5": {
-                        description: "index read-only (api)",
-                        retryable: false,
-                        levels: ["write", "metadata_write"],
-                      },
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      switch (payload.endpoint) {
+        case "cluster.state":
+          return {
+            ok: true,
+            response: {
+              blocks: {
+                indices: {
+                  test_index1: {
+                    "5": {
+                      description: "index read-only (api)",
+                      retryable: false,
+                      levels: ["write", "metadata_write"],
                     },
                   },
                 },
               },
-            };
-          default:
-            return {
-              ok: true,
-              response: {},
-            };
-        }
+            },
+          };
+        default:
+          return {
+            ok: true,
+            response: {},
+          };
       }
-    );
+    });
 
     const { container, getByTestId, getByText } = renderWithRouter({
       selectedItems: [
@@ -176,14 +174,12 @@ describe("<IndicesActions /> spec", () => {
   });
 
   it("clear cache for all indexes successfully by calling commonService", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (): Promise<any> => {
-        return {
-          ok: true,
-          response: {},
-        };
-      }
-    );
+    browserServicesMock.commonService.apiCaller = jest.fn(async (): Promise<any> => {
+      return {
+        ok: true,
+        response: {},
+      };
+    });
     const { container, getByTestId, getByText } = renderWithRouter({
       selectedItems: [],
     });
@@ -215,27 +211,25 @@ describe("<IndicesActions /> spec", () => {
   });
 
   it("clear cache for all indexes failed if some indexes are blocked", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (): Promise<any> => {
-        return {
-          ok: false,
-          error: "[cluster_block_exception] index [test_index1] blocked by: [FORBIDDEN/5/index read-only (api)];",
-          body: {
-            error: {
-              root_cause: [
-                {
-                  type: "cluster_block_exception",
-                  reason: "index[test_index1] blocked by: [FORBIDDEN/5/index read-only (api)];",
-                },
-              ],
-              type: "cluster_block_exception",
-              reason: "index[test_index1] blocked by: [FORBIDDEN/5/index read-only (api)];",
-            },
-            status: 403,
+    browserServicesMock.commonService.apiCaller = jest.fn(async (): Promise<any> => {
+      return {
+        ok: false,
+        error: "[cluster_block_exception] index [test_index1] blocked by: [FORBIDDEN/5/index read-only (api)];",
+        body: {
+          error: {
+            root_cause: [
+              {
+                type: "cluster_block_exception",
+                reason: "index[test_index1] blocked by: [FORBIDDEN/5/index read-only (api)];",
+              },
+            ],
+            type: "cluster_block_exception",
+            reason: "index[test_index1] blocked by: [FORBIDDEN/5/index read-only (api)];",
           },
-        };
-      }
-    );
+          status: 403,
+        },
+      };
+    });
     coreServicesMock.notifications.toasts.addError = jest.fn();
     const { container, getByTestId, getByText } = renderWithRouter({
       selectedItems: [],
@@ -272,26 +266,24 @@ describe("<IndicesActions /> spec", () => {
   });
 
   it("unable to clear cache when clearing cache for a closed or blocked index", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (): Promise<any> => {
-        return {
-          ok: true,
-          response: {
-            blocks: {
-              indices: {
-                test_index1: {
-                  "5": {
-                    description: "index read-only (api)",
-                    retryable: false,
-                    levels: ["write", "metadata_write"],
-                  },
+    browserServicesMock.commonService.apiCaller = jest.fn(async (): Promise<any> => {
+      return {
+        ok: true,
+        response: {
+          blocks: {
+            indices: {
+              test_index1: {
+                "5": {
+                  description: "index read-only (api)",
+                  retryable: false,
+                  levels: ["write", "metadata_write"],
                 },
               },
             },
           },
-        };
-      }
-    );
+        },
+      };
+    });
 
     const { container, getByTestId } = renderWithRouter({
       selectedItems: [
@@ -326,34 +318,32 @@ describe("<IndicesActions /> spec", () => {
   });
 
   it("filter some closed or blocked indices when clearing caches for multiple indices", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        switch (payload.endpoint) {
-          case "cluster.state":
-            return {
-              ok: true,
-              response: {
-                blocks: {
-                  indices: {
-                    test_index1: {
-                      "5": {
-                        description: "index read-only (api)",
-                        retryable: false,
-                        levels: ["write", "metadata_write"],
-                      },
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      switch (payload.endpoint) {
+        case "cluster.state":
+          return {
+            ok: true,
+            response: {
+              blocks: {
+                indices: {
+                  test_index1: {
+                    "5": {
+                      description: "index read-only (api)",
+                      retryable: false,
+                      levels: ["write", "metadata_write"],
                     },
                   },
                 },
               },
-            };
-          default:
-            return {
-              ok: true,
-              response: {},
-            };
-        }
+            },
+          };
+        default:
+          return {
+            ok: true,
+            response: {},
+          };
       }
-    );
+    });
 
     const { container, getByTestId, getByText } = renderWithRouter({
       selectedItems: [
@@ -406,22 +396,20 @@ describe("<IndicesActions /> spec", () => {
   });
 
   it("filter indices failed when clearing caches for multiple indices", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        switch (payload.endpoint) {
-          case "cluster.state":
-            return {
-              ok: false,
-              error: "test failure",
-            };
-          default:
-            return {
-              ok: true,
-              response: {},
-            };
-        }
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      switch (payload.endpoint) {
+        case "cluster.state":
+          return {
+            ok: false,
+            error: "test failure",
+          };
+        default:
+          return {
+            ok: true,
+            response: {},
+          };
       }
-    );
+    });
 
     const { container, getByTestId, getByText } = renderWithRouter({
       selectedItems: [
@@ -579,25 +567,23 @@ describe("<IndicesActions /> spec", () => {
   it("delete index by calling commonService", async () => {
     const onDelete = jest.fn();
     let times = 0;
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "indices.delete") {
-          if (times >= 1) {
-            return {
-              ok: true,
-              response: {},
-            };
-          } else {
-            times++;
-            return {
-              ok: false,
-              error: "test error",
-            };
-          }
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "indices.delete") {
+        if (times >= 1) {
+          return {
+            ok: true,
+            response: {},
+          };
+        } else {
+          times++;
+          return {
+            ok: false,
+            error: "test error",
+          };
         }
-        return { ok: true, response: {} };
       }
-    );
+      return { ok: true, response: {} };
+    });
     const { container, getByTestId, getByPlaceholderText } = renderWithRouter({
       selectedItems: [
         {
@@ -1012,34 +998,32 @@ describe("<IndicesActions /> spec", () => {
   });
 
   it("refresh selected indexes by calling commonService", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cluster.state") {
-          return {
-            ok: true,
-            response: {
-              blocks: {
-                indices: {
-                  blocked_index: {
-                    "4": {},
-                  },
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cluster.state") {
+        return {
+          ok: true,
+          response: {
+            blocks: {
+              indices: {
+                blocked_index: {
+                  "4": {},
                 },
               },
             },
-          };
-        } else if (payload.endpoint === "indices.refresh") {
-          return {
-            ok: true,
-            response: {},
-          };
-        } else if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: "red_index open\n",
-          };
-        }
+          },
+        };
+      } else if (payload.endpoint === "indices.refresh") {
+        return {
+          ok: true,
+          response: {},
+        };
+      } else if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: "red_index open\n",
+        };
       }
-    );
+    });
 
     const { getByTestId, getByText, queryByTestId } = renderWithRouter({
       selectedItems: [
@@ -1092,28 +1076,26 @@ describe("<IndicesActions /> spec", () => {
   });
 
   it("refresh multiple selected indexes by calling commonService", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cluster.state") {
-          return {
-            ok: true,
-            response: {
-              blocks: {},
-            },
-          };
-        } else if (payload.endpoint === "indices.refresh") {
-          return {
-            ok: true,
-            response: {},
-          };
-        } else if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: "red_index open\n",
-          };
-        }
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cluster.state") {
+        return {
+          ok: true,
+          response: {
+            blocks: {},
+          },
+        };
+      } else if (payload.endpoint === "indices.refresh") {
+        return {
+          ok: true,
+          response: {},
+        };
+      } else if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: "red_index open\n",
+        };
       }
-    );
+    });
 
     const { getByTestId, getByText } = renderWithRouter({
       selectedItems: [
@@ -1143,37 +1125,35 @@ describe("<IndicesActions /> spec", () => {
   });
 
   it("refresh selected indexes disabled because all of them are closed or in red status", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cluster.state") {
-          return {
-            ok: true,
-            response: {
-              blocks: {
-                indices: {
-                  blocked_index: {
-                    "4": {},
-                  },
-                  blocked_index1: {
-                    "4": {},
-                  },
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cluster.state") {
+        return {
+          ok: true,
+          response: {
+            blocks: {
+              indices: {
+                blocked_index: {
+                  "4": {},
+                },
+                blocked_index1: {
+                  "4": {},
                 },
               },
             },
-          };
-        } else if (payload.endpoint === "indices.refresh") {
-          return {
-            ok: true,
-            response: {},
-          };
-        } else if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: "red_index open\n",
-          };
-        }
+          },
+        };
+      } else if (payload.endpoint === "indices.refresh") {
+        return {
+          ok: true,
+          response: {},
+        };
+      } else if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: "red_index open\n",
+        };
       }
-    );
+    });
 
     const { getByTestId } = renderWithRouter({
       selectedItems: [
@@ -1200,33 +1180,31 @@ describe("<IndicesActions /> spec", () => {
   });
 
   it("refresh all open index by calling commonService", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cluster.state") {
-          return {
-            ok: true,
-            response: {
-              indices: {
-                red_index: {
-                  "4": {},
-                },
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cluster.state") {
+        return {
+          ok: true,
+          response: {
+            indices: {
+              red_index: {
+                "4": {},
               },
             },
-          };
-        } else if (payload.endpoint === "indices.refresh") {
-          return {
-            ok: true,
-            response: {},
-          };
-        } else if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: "red_index close\n",
-          };
-        }
-        return { ok: false, error: "wrong endpoint" };
+          },
+        };
+      } else if (payload.endpoint === "indices.refresh") {
+        return {
+          ok: true,
+          response: {},
+        };
+      } else if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: "red_index close\n",
+        };
       }
-    );
+      return { ok: false, error: "wrong endpoint" };
+    });
 
     const { getByTestId, getByText } = renderWithRouter({
       selectedItems: [],
@@ -1246,29 +1224,27 @@ describe("<IndicesActions /> spec", () => {
   });
 
   it("refresh all open index disabled due to red index", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cluster.state") {
-          return {
-            ok: true,
-            response: {
-              blocks: {},
-            },
-          };
-        } else if (payload.endpoint === "indices.refresh") {
-          return {
-            ok: true,
-            response: {},
-          };
-        } else if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: "red_index open\n",
-          };
-        }
-        return { ok: false, error: "wrong endpoint" };
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cluster.state") {
+        return {
+          ok: true,
+          response: {
+            blocks: {},
+          },
+        };
+      } else if (payload.endpoint === "indices.refresh") {
+        return {
+          ok: true,
+          response: {},
+        };
+      } else if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: "red_index open\n",
+        };
       }
-    );
+      return { ok: false, error: "wrong endpoint" };
+    });
 
     const { getByTestId } = renderWithRouter({
       selectedItems: [],
@@ -1286,24 +1262,22 @@ describe("<IndicesActions /> spec", () => {
   });
 
   it("refresh selected indexes even failed to get index status", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cluster.state") {
-          throw "failed to call cluster.state";
-        } else if (payload.endpoint === "indices.refresh") {
-          return {
-            ok: true,
-            response: {},
-          };
-        } else if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: "red_index open\n",
-          };
-        }
-        return { ok: false, error: "wrong endpoint" };
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cluster.state") {
+        throw "failed to call cluster.state";
+      } else if (payload.endpoint === "indices.refresh") {
+        return {
+          ok: true,
+          response: {},
+        };
+      } else if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: "red_index open\n",
+        };
       }
-    );
+      return { ok: false, error: "wrong endpoint" };
+    });
 
     const { getByTestId, getByText } = renderWithRouter({
       selectedItems: [
@@ -1330,24 +1304,22 @@ describe("<IndicesActions /> spec", () => {
   });
 
   it("refresh multi selected indexes even failed to get index status", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cluster.state") {
-          throw "failed to call cluster.state";
-        } else if (payload.endpoint === "indices.refresh") {
-          return {
-            ok: true,
-            response: {},
-          };
-        } else if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: "red_index open\n",
-          };
-        }
-        return { ok: false, error: "wrong endpoint" };
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cluster.state") {
+        throw "failed to call cluster.state";
+      } else if (payload.endpoint === "indices.refresh") {
+        return {
+          ok: true,
+          response: {},
+        };
+      } else if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: "red_index open\n",
+        };
       }
-    );
+      return { ok: false, error: "wrong endpoint" };
+    });
 
     const { getByTestId, getByText } = renderWithRouter({
       selectedItems: [

--- a/public/pages/Indices/containers/IndicesActions/__snapshots__/IndicesActions.test.tsx.snap
+++ b/public/pages/Indices/containers/IndicesActions/__snapshots__/IndicesActions.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<IndicesActions /> spec Split index by calling commonService 1`] = `
 <div

--- a/public/pages/ManagedIndices/components/InfoModal/InfoModal.test.tsx
+++ b/public/pages/ManagedIndices/components/InfoModal/InfoModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, fireEvent } from "@testing-library/react";
 import InfoModal from "./InfoModal";
 

--- a/public/pages/ManagedIndices/components/InfoModal/__snapshots__/InfoModal.test.tsx.snap
+++ b/public/pages/ManagedIndices/components/InfoModal/__snapshots__/InfoModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<InfoModal /> spec renders the component 1`] = `
 <div

--- a/public/pages/ManagedIndices/components/ManagedIndexControls/ManagedIndexControls.test.tsx
+++ b/public/pages/ManagedIndices/components/ManagedIndexControls/ManagedIndexControls.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, fireEvent, waitFor } from "@testing-library/react";
 // @ts-ignore
 import userEventModule from "@testing-library/user-event";

--- a/public/pages/ManagedIndices/components/ManagedIndexControls/__snapshots__/ManagedIndexControls.test.tsx.snap
+++ b/public/pages/ManagedIndices/components/ManagedIndexControls/__snapshots__/ManagedIndexControls.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ManagedIndexControls /> spec renders data streams selection field 1`] = `
 <div

--- a/public/pages/ManagedIndices/components/ManagedIndexEmptyPrompt/ManagedIndexEmptyPrompt.test.tsx
+++ b/public/pages/ManagedIndices/components/ManagedIndexEmptyPrompt/ManagedIndexEmptyPrompt.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, fireEvent } from "@testing-library/react";
 import ManagedIndexEmptyPrompt, { TEXT } from "./ManagedIndexEmptyPrompt";
 import historyMock from "../../../../../test/mocks/historyMock";

--- a/public/pages/ManagedIndices/components/ManagedIndexEmptyPrompt/__snapshots__/ManagedIndexEmptyPrompt.test.tsx.snap
+++ b/public/pages/ManagedIndices/components/ManagedIndexEmptyPrompt/__snapshots__/ManagedIndexEmptyPrompt.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ManagedIndexEmptyPrompt /> spec renders the component 1`] = `
 <div

--- a/public/pages/ManagedIndices/components/RetryModal/RetryModal.test.tsx
+++ b/public/pages/ManagedIndices/components/RetryModal/RetryModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, fireEvent, waitFor } from "@testing-library/react";
 import userEventModule from "@testing-library/user-event";
 import RetryModal from "./RetryModal";

--- a/public/pages/ManagedIndices/components/RetryModal/__snapshots__/RetryModal.test.tsx.snap
+++ b/public/pages/ManagedIndices/components/RetryModal/__snapshots__/RetryModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<RetryModal /> spec renders the component 1`] = `
 <div

--- a/public/pages/ManagedIndices/components/RolloverAliasModal/RolloverAliasModal.test.tsx
+++ b/public/pages/ManagedIndices/components/RolloverAliasModal/RolloverAliasModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, fireEvent, waitFor } from "@testing-library/react";
 import userEventModule from "@testing-library/user-event";
 import RolloverAliasModal from "./RolloverAliasModal";

--- a/public/pages/ManagedIndices/components/RolloverAliasModal/__snapshots__/RolloverAliasModal.test.tsx.snap
+++ b/public/pages/ManagedIndices/components/RolloverAliasModal/__snapshots__/RolloverAliasModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<RolloverAliasModal /> spec renders the component 1`] = `
 <div

--- a/public/pages/ManagedIndices/containers/ManagedIndices/ManagedIndices.test.tsx
+++ b/public/pages/ManagedIndices/containers/ManagedIndices/ManagedIndices.test.tsx
@@ -6,7 +6,7 @@
 import React from "react";
 import { Redirect, Route, Switch } from "react-router-dom";
 import { HashRouter as Router } from "react-router-dom";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, fireEvent, waitFor } from "@testing-library/react";
 import userEventModule from "@testing-library/user-event";
 import { CoreStart } from "opensearch-dashboards/public";

--- a/public/pages/ManagedIndices/containers/ManagedIndices/__snapshots__/ManagedIndices.test.tsx.snap
+++ b/public/pages/ManagedIndices/containers/ManagedIndices/__snapshots__/ManagedIndices.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ManagedIndices /> spec renders the component 1`] = `
 <div

--- a/public/pages/Notifications/containers/Notifications/Notifications.test.tsx
+++ b/public/pages/Notifications/containers/Notifications/Notifications.test.tsx
@@ -55,53 +55,49 @@ describe("<Notifications /> spec", () => {
   const userEvent = userEventModule.setup();
 
   beforeEach(() => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        switch (payload.endpoint) {
-          case "transport.request": {
-            if (payload.data?.path?.startsWith("/_plugins/_im/lron")) {
-              return {
-                ok: true,
-                response: {
-                  lron_configs: [],
-                  total_number: 0,
-                },
-              };
-            } else {
-              return {
-                ok: true,
-                response: {},
-              };
-            }
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      switch (payload.endpoint) {
+        case "transport.request": {
+          if (payload.data?.path?.startsWith("/_plugins/_im/lron")) {
+            return {
+              ok: true,
+              response: {
+                lron_configs: [],
+                total_number: 0,
+              },
+            };
+          } else {
+            return {
+              ok: true,
+              response: {},
+            };
           }
         }
-        return {
-          ok: true,
-          response: {},
-        };
       }
-    );
-    browserServicesMock.notificationService.getChannels = jest.fn(
-      async (): Promise<any> => {
-        return {
-          ok: true,
-          response: {
-            start_index: 0,
-            total_hits: 1,
-            total_hit_relation: "eq",
-            channel_list: [
-              {
-                config_id: "1",
-                name: "channel1",
-                description: "2",
-                config_type: "chime",
-                is_enabled: true,
-              },
-            ],
-          },
-        };
-      }
-    );
+      return {
+        ok: true,
+        response: {},
+      };
+    });
+    browserServicesMock.notificationService.getChannels = jest.fn(async (): Promise<any> => {
+      return {
+        ok: true,
+        response: {
+          start_index: 0,
+          total_hits: 1,
+          total_hit_relation: "eq",
+          channel_list: [
+            {
+              config_id: "1",
+              name: "channel1",
+              description: "2",
+              config_type: "chime",
+              is_enabled: true,
+            },
+          ],
+        },
+      };
+    });
   });
 
   it("renders", async () => {
@@ -138,43 +134,41 @@ describe("<Notifications /> spec", () => {
 
     await userEvent.click(getByText("Save"));
     await waitFor(() => {
-      expect(coreServicesMock.notifications.toasts.addSuccess).toBeCalledWith(
+      expect(coreServicesMock.notifications.toasts.addSuccess).toHaveBeenCalledWith(
         "Notifications settings for index operations have been successfully updated."
       );
     });
   });
 
   it("View without permission", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        switch (payload.endpoint) {
-          case "transport.request": {
-            if (payload.data?.path?.startsWith("/_plugins/_im/lron")) {
-              return {
-                ok: false,
-                body: {
-                  status: 403,
-                },
-              };
-            } else {
-              return {
-                ok: true,
-                response: {},
-              };
-            }
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      switch (payload.endpoint) {
+        case "transport.request": {
+          if (payload.data?.path?.startsWith("/_plugins/_im/lron")) {
+            return {
+              ok: false,
+              body: {
+                status: 403,
+              },
+            };
+          } else {
+            return {
+              ok: true,
+              response: {},
+            };
           }
         }
-        return {
-          ok: true,
-          response: {},
-        };
       }
-    );
+      return {
+        ok: true,
+        response: {},
+      };
+    });
     const { findByText, container } = renderNotificationsWithRouter([ROUTES.NOTIFICATIONS]);
     await findByText("Error loading Notification settings");
     await waitFor(() => {
       expect(container).toMatchSnapshot();
-      expect(coreServicesMock.notifications.toasts.addDanger).toBeCalledWith({
+      expect(coreServicesMock.notifications.toasts.addDanger).toHaveBeenCalledWith({
         title: "You do not have permissions to view notification settings",
         text: "Contact your administrator to request permissions.",
       });
@@ -182,43 +176,41 @@ describe("<Notifications /> spec", () => {
   });
 
   it("Update without permission", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        switch (payload.endpoint) {
-          case "transport.request": {
-            if (payload.data?.path?.includes("?dry_run=true")) {
-              return {
-                ok: false,
-              };
-            } else if (payload.data?.path?.startsWith("/_plugins/_im/lron")) {
-              return {
-                ok: true,
-                response: {
-                  lron_configs: [],
-                  total_number: 0,
-                },
-              };
-            } else {
-              return {
-                ok: true,
-                response: {},
-              };
-            }
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      switch (payload.endpoint) {
+        case "transport.request": {
+          if (payload.data?.path?.includes("?dry_run=true")) {
+            return {
+              ok: false,
+            };
+          } else if (payload.data?.path?.startsWith("/_plugins/_im/lron")) {
+            return {
+              ok: true,
+              response: {
+                lron_configs: [],
+                total_number: 0,
+              },
+            };
+          } else {
+            return {
+              ok: true,
+              response: {},
+            };
           }
         }
-        return {
-          ok: true,
-          response: {},
-        };
       }
-    );
+      return {
+        ok: true,
+        response: {},
+      };
+    });
     const { findByText, getByTestId, getByText, queryByText } = renderNotificationsWithRouter([ROUTES.NOTIFICATIONS]);
     await findByText("reindex");
     await userEvent.click(getByTestId("dataSource.0.failure"));
     await findByText("Save");
     await userEvent.click(getByText("Save"));
     await waitFor(() =>
-      expect(coreServicesMock.notifications.toasts.addDanger).toBeCalledWith({
+      expect(coreServicesMock.notifications.toasts.addDanger).toHaveBeenCalledWith({
         title: "You do not have permissions to update notification settings",
         text: "Contact your administrator to request permissions.",
       })

--- a/public/pages/Notifications/containers/Notifications/__snapshots__/Notifications.test.tsx.snap
+++ b/public/pages/Notifications/containers/Notifications/__snapshots__/Notifications.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Notifications /> spec View without permission 1`] = `
 <div>

--- a/public/pages/Policies/components/PolicyControls/PolicyControls.test.tsx
+++ b/public/pages/Policies/components/PolicyControls/PolicyControls.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, fireEvent, waitFor } from "@testing-library/react";
 // @ts-ignore
 import userEventModule from "@testing-library/user-event";

--- a/public/pages/Policies/components/PolicyControls/__snapshots__/PolicyControls.test.tsx.snap
+++ b/public/pages/Policies/components/PolicyControls/__snapshots__/PolicyControls.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<PolicyControls /> spec renders the component 1`] = `
 <div

--- a/public/pages/Policies/components/PolicyEmptyPrompt/PolicyEmptyPrompt.test.tsx
+++ b/public/pages/Policies/components/PolicyEmptyPrompt/PolicyEmptyPrompt.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, fireEvent } from "@testing-library/react";
 import PolicyEmptyPrompt, { TEXT } from "./PolicyEmptyPrompt";
 

--- a/public/pages/Policies/components/PolicyEmptyPrompt/__snapshots__/PolicyEmptyPrompt.test.tsx.snap
+++ b/public/pages/Policies/components/PolicyEmptyPrompt/__snapshots__/PolicyEmptyPrompt.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<PolicyEmptyPrompt /> spec renders the component 1`] = `
 <div

--- a/public/pages/Policies/containers/Policies/Policies.test.tsx
+++ b/public/pages/Policies/containers/Policies/Policies.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 // @ts-ignore
 import userEventModule from "@testing-library/user-event";

--- a/public/pages/Policies/containers/Policies/__snapshots__/Policies.test.tsx.snap
+++ b/public/pages/Policies/containers/Policies/__snapshots__/Policies.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<IndexPolicies /> spec renders the component 1`] = `
 <div

--- a/public/pages/PolicyDetails/components/DeleteModal/DeleteModal.test.tsx
+++ b/public/pages/PolicyDetails/components/DeleteModal/DeleteModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { screen, render } from "@testing-library/react";
 import DeleteModal from "./DeleteModal";
 import { fireEvent } from "@testing-library/dom";

--- a/public/pages/PolicyDetails/components/DeleteModal/__snapshots__/DeleteModal.test.tsx.snap
+++ b/public/pages/PolicyDetails/components/DeleteModal/__snapshots__/DeleteModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DeleteModal /> spec renders the component 1`] = `
 <body

--- a/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.test.tsx
+++ b/public/pages/PolicyDetails/components/PolicySettings/PolicySettings.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import PolicySettings from "./PolicySettings";
 

--- a/public/pages/PolicyDetails/components/PolicySettings/__snapshots__/PolicySettings.test.tsx.snap
+++ b/public/pages/PolicyDetails/components/PolicySettings/__snapshots__/PolicySettings.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<PolicySettings /> spec renders the component 1`] = `
 <div

--- a/public/pages/Reindex/components/CreateIndexFlyout/__snapshots__/CreateIndexFlyout.test.tsx.snap
+++ b/public/pages/Reindex/components/CreateIndexFlyout/__snapshots__/CreateIndexFlyout.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreateIndexFlyout /> spec renders the component 1`] = `
 Object {
@@ -200,7 +200,7 @@ Object {
                                       value=""
                                     />
                                     <div
-                                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                                     />
                                   </div>
                                 </div>

--- a/public/pages/Reindex/components/IndexSelect/__snapshots__/IndexSelect.test.tsx.snap
+++ b/public/pages/Reindex/components/IndexSelect/__snapshots__/IndexSelect.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<IndexSelect /> spec renders the component 1`] = `
 Object {
@@ -40,7 +40,7 @@ Object {
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>
@@ -106,7 +106,7 @@ Object {
                   value=""
                 />
                 <div
-                  style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                  style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                 />
               </div>
             </div>

--- a/public/pages/Reindex/components/ReindexAdvancedOptions/ReindexAdvancedOptions.test.tsx
+++ b/public/pages/Reindex/components/ReindexAdvancedOptions/ReindexAdvancedOptions.test.tsx
@@ -96,6 +96,6 @@ describe("<ReindexAdvancedOptions /> spec", () => {
 
     // wait for one tick
     await waitFor(() => {});
-    expect(getPipeline).toBeCalledTimes(1);
+    expect(getPipeline).toHaveBeenCalledTimes(1);
   });
 });

--- a/public/pages/Reindex/components/ReindexAdvancedOptions/__snapshots__/ReindexAdvancedOptions.test.tsx.snap
+++ b/public/pages/Reindex/components/ReindexAdvancedOptions/__snapshots__/ReindexAdvancedOptions.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ReindexAdvancedOptions /> spec renders the component 1`] = `
 Object {
@@ -362,7 +362,7 @@ Object {
                         value=""
                       />
                       <div
-                        style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                        style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                       />
                     </div>
                   </div>
@@ -744,7 +744,7 @@ Object {
                       value=""
                     />
                     <div
-                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                     />
                   </div>
                 </div>

--- a/public/pages/Reindex/container/Reindex/Reindex.test.tsx
+++ b/public/pages/Reindex/container/Reindex/Reindex.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, fireEvent, waitFor } from "@testing-library/react";
 import userEventModule from "@testing-library/user-event";
 import { Route, RouteComponentProps, Switch } from "react-router-dom";
@@ -571,7 +571,7 @@ describe("<Reindex /> spec", () => {
 
     await waitFor(() => {});
 
-    expect(coreServicesMock.notifications.toasts.addDanger).toBeCalled();
+    expect(coreServicesMock.notifications.toasts.addDanger).toHaveBeenCalled();
   });
 
   it("show subset query editor", async () => {
@@ -627,7 +627,7 @@ describe("<Reindex /> spec", () => {
     await userEvent.click(getByTestId("advanceOptionToggle"));
     await waitFor(() => {});
 
-    expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+    expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
       endpoint: "ingest.getPipeline",
     });
   });

--- a/public/pages/Reindex/container/Reindex/__snapshots__/Reindex.test.tsx.snap
+++ b/public/pages/Reindex/container/Reindex/__snapshots__/Reindex.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Reindex /> spec renders the component 1`] = `
 <div
@@ -126,7 +126,7 @@ exports[`<Reindex /> spec renders the component 1`] = `
                       value=""
                     />
                     <div
-                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                     />
                   </div>
                 </div>
@@ -304,7 +304,7 @@ exports[`<Reindex /> spec renders the component 1`] = `
                           value=""
                         />
                         <div
-                          style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                          style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                         />
                       </div>
                     </div>

--- a/public/pages/Rollover/containers/Rollover/Rollover.test.tsx
+++ b/public/pages/Rollover/containers/Rollover/Rollover.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import { MemoryRouter as Router } from "react-router";
 import { Route, RouteComponentProps, Switch } from "react-router-dom";

--- a/public/pages/Rollover/containers/Rollover/__snapshots__/Rollover.test.tsx.snap
+++ b/public/pages/Rollover/containers/Rollover/__snapshots__/Rollover.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`container <Rollover /> spec render the component 1`] = `
 <div
@@ -113,7 +113,7 @@ exports[`container <Rollover /> spec render the component 1`] = `
                         value=""
                       />
                       <div
-                        style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                        style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                       />
                     </div>
                   </div>

--- a/public/pages/RollupDetails/containers/RollupDetails/__snapshots__/RollupDetails.test.tsx.snap
+++ b/public/pages/RollupDetails/containers/RollupDetails/__snapshots__/RollupDetails.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<RollupDetails /> spec renders the component 1`] = `
 <div>

--- a/public/pages/Rollups/containers/Rollups/__snapshots__/Rollups.test.tsx.snap
+++ b/public/pages/Rollups/containers/Rollups/__snapshots__/Rollups.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Rollups /> spec renders the component 1`] = `
 <div

--- a/public/pages/ShrinkIndex/container/ShrinkIndex/ShrinkIndex.test.tsx
+++ b/public/pages/ShrinkIndex/container/ShrinkIndex/ShrinkIndex.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, fireEvent, waitFor, act } from "@testing-library/react";
 import userEventModule from "@testing-library/user-event";
 import { Route, RouteComponentProps, Switch } from "react-router-dom";
@@ -151,117 +151,115 @@ const mockApi = () => {
     response: { indices: args.search.length > 0 ? indices.filter((index) => index.index.startsWith(args.search)) : indices },
   }));
 
-  browserServicesMock.commonService.apiCaller = jest.fn(
-    async (payload): Promise<any> => {
-      switch (payload.endpoint) {
-        case "cat.indices":
+  browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+    switch (payload.endpoint) {
+      case "cat.indices":
+        return {
+          ok: true,
+          response: indices.filter((indexItem) => indexItem.index === payload.data.index[0]),
+        };
+      case "indices.getSettings":
+        if (payload.data.index === "test2") {
           return {
             ok: true,
-            response: indices.filter((indexItem) => indexItem.index === payload.data.index[0]),
+            response: {
+              test2: {
+                settings: {
+                  "index.blocks.write": false,
+                },
+              },
+            },
           };
-        case "indices.getSettings":
-          if (payload.data.index === "test2") {
-            return {
-              ok: true,
-              response: {
-                test2: {
-                  settings: {
-                    "index.blocks.write": false,
-                  },
-                },
-              },
-            };
-          } else if (payload.data.index === "test3") {
-            return {
-              ok: true,
-              response: {
-                test3: {
-                  settings: {
-                    "index.blocks.write": true,
-                    "index.routing.allocation.require._name": "node1",
-                  },
-                },
-              },
-            };
-          } else if (payload.data.index === "test6") {
-            return {
-              ok: true,
-              response: {
-                test6: {
-                  settings: {
-                    "index.blocks.write": true,
-                    "index.blocks.read_only": true,
-                  },
-                },
-              },
-            };
-          } else if (payload.data.index === "test7") {
-            return {
-              ok: true,
-              response: {
-                test6: {
-                  settings: {
-                    "index.blocks.read_only": true,
-                  },
-                },
-              },
-            };
-          } else {
-            return {
-              ok: true,
-              response: {},
-            };
-          }
-        case "indices.putSettings":
-          if (payload.data.index === "test7") {
-            return {
-              ok: false,
-              error: "[cluster_block_exception] index [test7] blocked by: [FORBIDDEN/5/index read-only (api)];",
-            };
-          } else {
-            return {
-              ok: true,
-              response: {},
-            };
-          }
-        case "transport.request":
-          if (payload.data.path.startsWith("/test7/_open")) {
-            return {
-              ok: false,
-              error: "[cluster_block_exception] index [test7] blocked by: [FORBIDDEN/5/index read-only (api)];",
-            };
-          } else {
-            return {
-              ok: true,
-              response: {},
-            };
-          }
-        case "cat.aliases":
+        } else if (payload.data.index === "test3") {
           return {
             ok: true,
-            response: [
-              {
-                alias: "a1",
-                index: "acvxcvxc",
-                filter: "-",
-                "routing.index": "-",
-                "routing.search": "-",
-                is_write_index: "-",
+            response: {
+              test3: {
+                settings: {
+                  "index.blocks.write": true,
+                  "index.routing.allocation.require._name": "node1",
+                },
               },
-            ],
+            },
           };
-        case "indices.shrink":
+        } else if (payload.data.index === "test6") {
+          return {
+            ok: true,
+            response: {
+              test6: {
+                settings: {
+                  "index.blocks.write": true,
+                  "index.blocks.read_only": true,
+                },
+              },
+            },
+          };
+        } else if (payload.data.index === "test7") {
+          return {
+            ok: true,
+            response: {
+              test6: {
+                settings: {
+                  "index.blocks.read_only": true,
+                },
+              },
+            },
+          };
+        } else {
           return {
             ok: true,
             response: {},
           };
-      }
-      return {
-        ok: true,
-        response: {},
-      };
+        }
+      case "indices.putSettings":
+        if (payload.data.index === "test7") {
+          return {
+            ok: false,
+            error: "[cluster_block_exception] index [test7] blocked by: [FORBIDDEN/5/index read-only (api)];",
+          };
+        } else {
+          return {
+            ok: true,
+            response: {},
+          };
+        }
+      case "transport.request":
+        if (payload.data.path.startsWith("/test7/_open")) {
+          return {
+            ok: false,
+            error: "[cluster_block_exception] index [test7] blocked by: [FORBIDDEN/5/index read-only (api)];",
+          };
+        } else {
+          return {
+            ok: true,
+            response: {},
+          };
+        }
+      case "cat.aliases":
+        return {
+          ok: true,
+          response: [
+            {
+              alias: "a1",
+              index: "acvxcvxc",
+              filter: "-",
+              "routing.index": "-",
+              "routing.search": "-",
+              is_write_index: "-",
+            },
+          ],
+        };
+      case "indices.shrink":
+        return {
+          ok: true,
+          response: {},
+        };
     }
-  );
+    return {
+      ok: true,
+      response: {},
+    };
+  });
 };
 
 describe("<Shrink index /> spec", () => {

--- a/public/pages/ShrinkIndex/container/ShrinkIndex/__snapshots__/ShrinkIndex.test.tsx.snap
+++ b/public/pages/ShrinkIndex/container/ShrinkIndex/__snapshots__/ShrinkIndex.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Shrink index /> spec renders the component 1`] = `
 <div>
@@ -442,7 +442,7 @@ exports[`<Shrink index /> spec renders the component 1`] = `
                           value=""
                         />
                         <div
-                          style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                          style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                         />
                       </div>
                     </div>

--- a/public/pages/Snapshots/components/AddPrefixInput/AddPrefixInput.test.tsx
+++ b/public/pages/Snapshots/components/AddPrefixInput/AddPrefixInput.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, screen, cleanup } from "@testing-library/react";
 import userEventModule from "@testing-library/user-event";
 import AddPrefixInput from "./AddPrefixInput";
@@ -41,6 +41,6 @@ describe("AddPrefixInput component", () => {
     await userEvent.type(screen.getByTestId("prefixInput"), "four");
 
     // getPrefix is prop sent from parent component to retrieve user input
-    expect(testProps.getPrefix).toBeCalledTimes(4);
+    expect(testProps.getPrefix).toHaveBeenCalledTimes(4);
   });
 });

--- a/public/pages/Snapshots/components/AddPrefixInput/__snapshots__/AddPrefixInput.test.tsx.snap
+++ b/public/pages/Snapshots/components/AddPrefixInput/__snapshots__/AddPrefixInput.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AddPrefixInput component renders without error 1`] = `
 <div>

--- a/public/pages/Snapshots/components/RenameInput/RenameInput.test.tsx
+++ b/public/pages/Snapshots/components/RenameInput/RenameInput.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, screen, cleanup } from "@testing-library/react";
 import userEventModule from "@testing-library/user-event";
 import RenameInput from "./RenameInput";
@@ -51,7 +51,7 @@ describe("RenameInput component", () => {
     await userEvent.type(screen.getByTestId("renamePatternInput"), "(.+)");
 
     // getRenamePattern is prop sent from parent component to retrieve user input
-    expect(testProps.getRenamePattern).toBeCalledTimes(4);
+    expect(testProps.getRenamePattern).toHaveBeenCalledTimes(4);
   });
 
   it("sends user input to parent component via getRenameReplacement", async () => {
@@ -59,6 +59,6 @@ describe("RenameInput component", () => {
     await userEvent.type(screen.getByTestId("renameReplacementInput"), "test_$1");
 
     // getRenamePattern is prop sent from parent component to retrieve user input
-    expect(testProps.getRenameReplacement).toBeCalledTimes(7);
+    expect(testProps.getRenameReplacement).toHaveBeenCalledTimes(7);
   });
 });

--- a/public/pages/Snapshots/components/RenameInput/__snapshots__/RenameInput.test.tsx.snap
+++ b/public/pages/Snapshots/components/RenameInput/__snapshots__/RenameInput.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`RenameInput component renders without error 1`] = `
 <div>

--- a/public/pages/Snapshots/components/SnapshotIndicesInput/SnapshotIndicesInput.test.tsx
+++ b/public/pages/Snapshots/components/SnapshotIndicesInput/SnapshotIndicesInput.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, screen, cleanup } from "@testing-library/react";
 import userEventModule from "@testing-library/user-event";
 import SnapshotIndicesInput from "./SnapshotIndicesInput";
@@ -43,7 +43,7 @@ describe("SnapshotIndicesInput component", () => {
 
     await userEvent.type(screen.getByRole("textbox"), "test*{enter}");
 
-    expect(testProps.onCreateOption).toBeCalledTimes(1);
+    expect(testProps.onCreateOption).toHaveBeenCalledTimes(1);
   });
 
   it("allows user to select indices to restore", async () => {
@@ -63,6 +63,6 @@ describe("SnapshotIndicesInput component", () => {
     await userEvent.click(screen.getByText("test_index_1"));
     await userEvent.click(screen.getByText("test_index_2"));
 
-    expect(testProps.onIndicesSelectionChange).toBeCalledTimes(2);
+    expect(testProps.onIndicesSelectionChange).toHaveBeenCalledTimes(2);
   });
 });

--- a/public/pages/Snapshots/components/SnapshotIndicesInput/__snapshots__/SnapshotIndicesInput.test.tsx.snap
+++ b/public/pages/Snapshots/components/SnapshotIndicesInput/__snapshots__/SnapshotIndicesInput.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SnapshotIndicesInput component renders without error 1`] = `
 <div>
@@ -54,7 +54,7 @@ exports[`SnapshotIndicesInput component renders without error 1`] = `
                   value=""
                 />
                 <div
-                  style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                  style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                 />
               </div>
             </div>

--- a/public/pages/Snapshots/components/SnapshotRenameOptions/SnapshotRenameOptions.test.tsx
+++ b/public/pages/Snapshots/components/SnapshotRenameOptions/SnapshotRenameOptions.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, screen, cleanup } from "@testing-library/react";
 import userEventModule from "@testing-library/user-event";
 import SnapshotRenameOptions from "./SnapshotRenameOptions";
@@ -41,11 +41,11 @@ describe("SnapshotRenameOptions component", () => {
 
     await userEvent.click(screen.getByLabelText("Add prefix to restored index names"));
 
-    expect(testProps.onAddPrefixToggle).toBeCalled();
+    expect(testProps.onAddPrefixToggle).toHaveBeenCalled();
 
     await userEvent.click(screen.getByLabelText("Rename using regular expression (Advanced)"));
 
-    expect(testProps.onRenameIndicesToggle).toBeCalled();
+    expect(testProps.onRenameIndicesToggle).toHaveBeenCalled();
 
     cleanup();
 
@@ -53,6 +53,6 @@ describe("SnapshotRenameOptions component", () => {
 
     await userEvent.click(screen.getByLabelText("Do not rename"));
 
-    expect(testProps.onDoNotRenameToggle).toBeCalled();
+    expect(testProps.onDoNotRenameToggle).toHaveBeenCalled();
   });
 });

--- a/public/pages/Snapshots/components/SnapshotRenameOptions/__snapshots__/SnapshotRenameOptions.test.tsx.snap
+++ b/public/pages/Snapshots/components/SnapshotRenameOptions/__snapshots__/SnapshotRenameOptions.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SnapshotRenameOptions component renders without error 1`] = `
 <div>

--- a/public/pages/Snapshots/components/SnapshotRestoreOption/SnapshotRestoreOption.test.tsx
+++ b/public/pages/Snapshots/components/SnapshotRestoreOption/SnapshotRestoreOption.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, screen, cleanup } from "@testing-library/react";
 import userEventModule from "@testing-library/user-event";
 import SnapshotRestoreOption from "./SnapshotRestoreOption";
@@ -36,7 +36,7 @@ describe("SnapshotRestoreOption component", () => {
 
     await userEvent.click(screen.getByLabelText("Restore specific indices"));
 
-    expect(testProps.onRestoreSpecificIndicesToggle).toBeCalled();
+    expect(testProps.onRestoreSpecificIndicesToggle).toHaveBeenCalled();
 
     cleanup();
 
@@ -44,6 +44,6 @@ describe("SnapshotRestoreOption component", () => {
 
     await userEvent.click(screen.getByLabelText("Restore all indices in snapshot"));
 
-    expect(testProps.onRestoreAllIndicesToggle).toBeCalled();
+    expect(testProps.onRestoreAllIndicesToggle).toHaveBeenCalled();
   });
 });

--- a/public/pages/Snapshots/components/SnapshotRestoreOption/__snapshots__/SnapshotRestoreOption.test.tsx.snap
+++ b/public/pages/Snapshots/components/SnapshotRestoreOption/__snapshots__/SnapshotRestoreOption.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SnapshotRestoreOption component renders without error 1`] = `
 <div>

--- a/public/pages/SplitIndex/container/SplitIndex/SplitIndex.test.tsx
+++ b/public/pages/SplitIndex/container/SplitIndex/SplitIndex.test.tsx
@@ -66,38 +66,36 @@ describe("<SplitIndex /> spec", () => {
   const userEvent = userEventModule.setup();
 
   it("renders the component", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cat.aliases") {
-          return {
-            ok: true,
-            response: [
-              {
-                alias: "testAlias",
-                index: "1",
-              },
-            ] as IAlias[],
-          };
-        } else if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: [
-              {
-                health: "green",
-                status: "open",
-                index: sourceIndexName,
-                pri: "1",
-                rep: "0",
-              },
-            ],
-          };
-        }
-
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cat.aliases") {
         return {
           ok: true,
+          response: [
+            {
+              alias: "testAlias",
+              index: "1",
+            },
+          ] as IAlias[],
+        };
+      } else if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: [
+            {
+              health: "green",
+              status: "open",
+              index: sourceIndexName,
+              pri: "1",
+              rep: "0",
+            },
+          ],
         };
       }
-    );
+
+      return {
+        ok: true,
+      };
+    });
 
     renderWithRouter([`${ROUTES.SPLIT_INDEX}?source=index-source`]);
 
@@ -121,38 +119,36 @@ describe("<SplitIndex /> spec", () => {
   });
 
   it("Successful split an index whose shards number is greater than 1", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cat.aliases") {
-          return {
-            ok: true,
-            response: [
-              {
-                alias: "testAlias",
-                index: "1",
-              },
-            ] as IAlias[],
-          };
-        } else if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: [
-              {
-                health: "green",
-                status: "open",
-                index: sourceIndexName,
-                pri: "2",
-                rep: "0",
-              },
-            ],
-          };
-        }
-
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cat.aliases") {
         return {
           ok: true,
+          response: [
+            {
+              alias: "testAlias",
+              index: "1",
+            },
+          ] as IAlias[],
+        };
+      } else if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: [
+            {
+              health: "green",
+              status: "open",
+              index: sourceIndexName,
+              pri: "2",
+              rep: "0",
+            },
+          ],
         };
       }
-    );
+
+      return {
+        ok: true,
+      };
+    });
 
     const { getByTestId, getByText } = renderWithRouter([`${ROUTES.SPLIT_INDEX}?source=$(sourceIndexName)`]);
 
@@ -170,7 +166,7 @@ describe("<SplitIndex /> spec", () => {
     await userEvent.click(getByTestId("splitButton"));
 
     await waitFor(() => {
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         endpoint: "transport.request",
         data: {
           path: `/source-index/_split/split_test_index-split?wait_for_completion=false`,
@@ -187,38 +183,36 @@ describe("<SplitIndex /> spec", () => {
   });
 
   it("Successful split an index whose shards number is 1", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cat.aliases") {
-          return {
-            ok: true,
-            response: [
-              {
-                alias: "testAlias",
-                index: "1",
-              },
-            ] as IAlias[],
-          };
-        } else if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: [
-              {
-                health: "green",
-                status: "open",
-                index: sourceIndexName,
-                pri: "1",
-                rep: "0",
-              },
-            ],
-          };
-        }
-
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cat.aliases") {
         return {
           ok: true,
+          response: [
+            {
+              alias: "testAlias",
+              index: "1",
+            },
+          ] as IAlias[],
+        };
+      } else if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: [
+            {
+              health: "green",
+              status: "open",
+              index: sourceIndexName,
+              pri: "1",
+              rep: "0",
+            },
+          ],
         };
       }
-    );
+
+      return {
+        ok: true,
+      };
+    });
 
     const { getByTestId, getByText } = renderWithRouter([`${ROUTES.SPLIT_INDEX}?source=$(sourceIndexName)`]);
 
@@ -237,7 +231,7 @@ describe("<SplitIndex /> spec", () => {
     await userEvent.click(getByTestId("splitButton"));
 
     await waitFor(() => {
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         endpoint: "transport.request",
         data: {
           path: `/source-index/_split/split_test_index-split?wait_for_completion=false`,
@@ -254,38 +248,36 @@ describe("<SplitIndex /> spec", () => {
   });
 
   it("Error message if number of shards is invalid", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cat.aliases") {
-          return {
-            ok: true,
-            response: [
-              {
-                alias: "testAlias",
-                index: "1",
-              },
-            ] as IAlias[],
-          };
-        } else if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: [
-              {
-                health: "green",
-                status: "open",
-                index: sourceIndexName,
-                pri: "3",
-                rep: "0",
-              },
-            ],
-          };
-        }
-
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cat.aliases") {
         return {
           ok: true,
+          response: [
+            {
+              alias: "testAlias",
+              index: "1",
+            },
+          ] as IAlias[],
+        };
+      } else if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: [
+            {
+              health: "green",
+              status: "open",
+              index: sourceIndexName,
+              pri: "3",
+              rep: "0",
+            },
+          ],
         };
       }
-    );
+
+      return {
+        ok: true,
+      };
+    });
 
     const { getByTestId, getByText } = renderWithRouter([`${ROUTES.SPLIT_INDEX}?source=$(sourceIndexName)`]);
 
@@ -335,32 +327,30 @@ describe("<SplitIndex /> spec", () => {
   });
 
   it("Red Index is not ready for split", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: [
-              {
-                health: "red",
-                status: "open",
-                index: sourceIndexName,
-                pri: "1",
-                rep: "0",
-                "docs.count": "1",
-                "docs.deleted": "0",
-                "store.size": "5.2kb",
-                "pri.store.size": "5.2kb",
-              },
-            ],
-          };
-        }
-
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cat.indices") {
         return {
           ok: true,
+          response: [
+            {
+              health: "red",
+              status: "open",
+              index: sourceIndexName,
+              pri: "1",
+              rep: "0",
+              "docs.count": "1",
+              "docs.deleted": "0",
+              "store.size": "5.2kb",
+              "pri.store.size": "5.2kb",
+            },
+          ],
         };
       }
-    );
+
+      return {
+        ok: true,
+      };
+    });
 
     const { getByTestId, queryByText } = renderWithRouter([`${ROUTES.SPLIT_INDEX}?source=$(sourceIndexName)`]);
 
@@ -371,37 +361,35 @@ describe("<SplitIndex /> spec", () => {
   });
 
   it("Closed Index is not ready for split", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: [
-              {
-                health: "green",
-                status: "close",
-                index: sourceIndexName,
-                pri: "2",
-                rep: "0",
-                "docs.count": "1",
-                "docs.deleted": "0",
-                "store.size": "5.2kb",
-                "pri.store.size": "5.2kb",
-              },
-            ],
-          };
-        } else if (payload.endpoint === "transport.request") {
-          return {
-            ok: true,
-            response: [{}],
-          };
-        }
-
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cat.indices") {
         return {
           ok: true,
+          response: [
+            {
+              health: "green",
+              status: "close",
+              index: sourceIndexName,
+              pri: "2",
+              rep: "0",
+              "docs.count": "1",
+              "docs.deleted": "0",
+              "store.size": "5.2kb",
+              "pri.store.size": "5.2kb",
+            },
+          ],
+        };
+      } else if (payload.endpoint === "transport.request") {
+        return {
+          ok: true,
+          response: [{}],
         };
       }
-    );
+
+      return {
+        ok: true,
+      };
+    });
 
     const { getByTestId, queryByText } = renderWithRouter([`${ROUTES.SPLIT_INDEX}?source=$(sourceIndexName)`]);
 
@@ -411,7 +399,7 @@ describe("<SplitIndex /> spec", () => {
     });
     await userEvent.click(getByTestId("open-index-button"));
     await waitFor(() => {});
-    expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+    expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
       endpoint: "transport.request",
       data: {
         method: "POST",
@@ -421,44 +409,42 @@ describe("<SplitIndex /> spec", () => {
   });
 
   it("blocks.write is not set to true, Index is not ready for split", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: [
-              {
-                health: "green",
-                status: "open",
-                index: sourceIndexName,
-                pri: "1",
-                rep: "0",
-                "docs.count": "1",
-                "docs.deleted": "0",
-                "store.size": "5.2kb",
-                "pri.store.size": "5.2kb",
-              },
-            ],
-          };
-        } else if (payload.endpoint === "indices.getSettings") {
-          return {
-            ok: true,
-            response: {
-              [sourceIndexName]: {
-                settings: {
-                  "index.blocks.write": "false",
-                },
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: [
+            {
+              health: "green",
+              status: "open",
+              index: sourceIndexName,
+              pri: "1",
+              rep: "0",
+              "docs.count": "1",
+              "docs.deleted": "0",
+              "store.size": "5.2kb",
+              "pri.store.size": "5.2kb",
+            },
+          ],
+        };
+      } else if (payload.endpoint === "indices.getSettings") {
+        return {
+          ok: true,
+          response: {
+            [sourceIndexName]: {
+              settings: {
+                "index.blocks.write": "false",
               },
             },
-          };
-        } else if (payload.endpoint === "indices.putSettings") {
-          return {
-            ok: true,
-            response: [{}],
-          };
-        }
+          },
+        };
+      } else if (payload.endpoint === "indices.putSettings") {
+        return {
+          ok: true,
+          response: [{}],
+        };
       }
-    );
+    });
 
     const { getByTestId, queryByText } = renderWithRouter([`${ROUTES.SPLIT_INDEX}?source=$(sourceIndexName)`]);
 
@@ -469,7 +455,7 @@ describe("<SplitIndex /> spec", () => {
 
     await userEvent.click(getByTestId("set-indexsetting-button"));
     await waitFor(() =>
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         endpoint: "indices.putSettings",
         method: "PUT",
         data: {
@@ -486,42 +472,40 @@ describe("<SplitIndex /> spec", () => {
   });
 
   it("blocks.write is not set, Index is not ready for split", async () => {
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.endpoint === "cat.indices") {
-          return {
-            ok: true,
-            response: [
-              {
-                health: "green",
-                status: "open",
-                index: sourceIndexName,
-                pri: "1",
-                rep: "0",
-                "docs.count": "1",
-                "docs.deleted": "0",
-                "store.size": "5.2kb",
-                "pri.store.size": "5.2kb",
-              },
-            ],
-          };
-        } else if (payload.endpoint === "indices.getSettings") {
-          return {
-            ok: true,
-            response: {
-              [sourceIndexName]: {
-                settings: {},
-              },
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.endpoint === "cat.indices") {
+        return {
+          ok: true,
+          response: [
+            {
+              health: "green",
+              status: "open",
+              index: sourceIndexName,
+              pri: "1",
+              rep: "0",
+              "docs.count": "1",
+              "docs.deleted": "0",
+              "store.size": "5.2kb",
+              "pri.store.size": "5.2kb",
             },
-          };
-        } else if (payload.endpoint === "indices.putSettings") {
-          return {
-            ok: true,
-            response: [{}],
-          };
-        }
+          ],
+        };
+      } else if (payload.endpoint === "indices.getSettings") {
+        return {
+          ok: true,
+          response: {
+            [sourceIndexName]: {
+              settings: {},
+            },
+          },
+        };
+      } else if (payload.endpoint === "indices.putSettings") {
+        return {
+          ok: true,
+          response: [{}],
+        };
       }
-    );
+    });
 
     const { getByTestId, queryByText } = renderWithRouter([`${ROUTES.SPLIT_INDEX}?source=$(sourceIndexName)`]);
 
@@ -532,7 +516,7 @@ describe("<SplitIndex /> spec", () => {
 
     await userEvent.click(getByTestId("set-indexsetting-button"));
     await waitFor(() =>
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         endpoint: "indices.putSettings",
         method: "PUT",
         data: {

--- a/public/pages/SplitIndex/container/SplitIndex/__snapshots__/SplitIndex.test.tsx.snap
+++ b/public/pages/SplitIndex/container/SplitIndex/__snapshots__/SplitIndex.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SplitIndex /> spec renders the component 1`] = `
 HTMLCollection [

--- a/public/pages/Templates/components/IndexControls/IndexControls.test.tsx
+++ b/public/pages/Templates/components/IndexControls/IndexControls.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 // @ts-ignore
 import userEventModule from "@testing-library/user-event";
@@ -42,8 +42,8 @@ describe("<IndexControls /> spec", () => {
 
     await userEvent.type(getByPlaceholderText("Search..."), "test");
     await waitFor(() => {
-      expect(onSearchChangeMock).toBeCalledTimes(4);
-      expect(onSearchChangeMock).toBeCalledWith({
+      expect(onSearchChangeMock).toHaveBeenCalledTimes(4);
+      expect(onSearchChangeMock).toHaveBeenCalledWith({
         search: "test",
       });
     });

--- a/public/pages/Templates/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
+++ b/public/pages/Templates/components/IndexControls/__snapshots__/IndexControls.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<IndexControls /> spec renders the component 1`] = `
 <div

--- a/public/pages/Templates/containers/AssociatedComponentsModal/AssociatedComponentsModal.test.tsx
+++ b/public/pages/Templates/containers/AssociatedComponentsModal/AssociatedComponentsModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import AssociatedComponentsModal, { AssociatedComponentsModalProps } from "./AssociatedComponentsModal";
 import { ServicesContext } from "../../../../services";
@@ -44,38 +44,36 @@ describe("<AssociatedComponentsModal /> spec", () => {
 
   it("renders the component", async () => {
     let time = 0;
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.data?.path?.startsWith("/_component_template/")) {
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.data?.path?.startsWith("/_component_template/")) {
+        return {
+          ok: true,
+          response: {},
+        };
+      } else if (payload.data?.path?.startsWith("/_index_template")) {
+        if (payload.data?.method === "POST") {
+          time++;
           return {
-            ok: true,
-            response: {},
-          };
-        } else if (payload.data?.path?.startsWith("/_index_template")) {
-          if (payload.data?.method === "POST") {
-            time++;
-            return {
-              ok: time !== 1,
-              error: "error",
-            };
-          }
-          return {
-            ok: true,
-            response: {
-              index_templates: [
-                {
-                  name: "test_template",
-                  index_template: {
-                    composed_of: ["test_component_template"],
-                  },
-                },
-              ],
-            },
+            ok: time !== 1,
+            error: "error",
           };
         }
-        return { ok: true, response: {} };
+        return {
+          ok: true,
+          response: {
+            index_templates: [
+              {
+                name: "test_template",
+                index_template: {
+                  composed_of: ["test_component_template"],
+                },
+              },
+            ],
+          },
+        };
       }
-    );
+      return { ok: true, response: {} };
+    });
     const unlinkHandlerMock = jest.fn();
     const { findByText, findByTestId, getByTestId, queryByText } = renderWithServices({
       template: {
@@ -108,17 +106,17 @@ describe("<AssociatedComponentsModal /> spec", () => {
     await findByText("Unlink from test_template?");
     await userEvent.click(getByTestId("Unlink from test_template?-confirm"));
     await waitFor(() => {
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(2);
-      expect(coreServicesMock.notifications.toasts.addDanger).toBeCalledWith("error");
-      expect(unlinkHandlerMock).toBeCalledTimes(0);
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(2);
+      expect(coreServicesMock.notifications.toasts.addDanger).toHaveBeenCalledWith("error");
+      expect(unlinkHandlerMock).toHaveBeenCalledTimes(0);
     });
     await userEvent.click(getByTestId("Unlink from test_template?-confirm"));
     await waitFor(() => {
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(4);
-      expect(coreServicesMock.notifications.toasts.addSuccess).toBeCalledWith(
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(4);
+      expect(coreServicesMock.notifications.toasts.addSuccess).toHaveBeenCalledWith(
         "test_component_template has been successfully unlinked from test_template."
       );
-      expect(unlinkHandlerMock).toBeCalledWith("test_component_template");
+      expect(unlinkHandlerMock).toHaveBeenCalledWith("test_component_template");
     });
     await userEvent.click(getByTestId("euiFlyoutCloseButton"));
     await waitFor(() => {

--- a/public/pages/Templates/containers/AssociatedComponentsModal/__snapshots__/AssociatedComponentsModal.test.tsx.snap
+++ b/public/pages/Templates/containers/AssociatedComponentsModal/__snapshots__/AssociatedComponentsModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<AssociatedComponentsModal /> spec renders the component 1`] = `
 HTMLCollection [

--- a/public/pages/Templates/containers/DeleteTemplatesModal/DeleteTemplateModal.test.tsx
+++ b/public/pages/Templates/containers/DeleteTemplatesModal/DeleteTemplateModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import DeleteTemplateModal from "./DeleteTemplateModal";
 

--- a/public/pages/Templates/containers/DeleteTemplatesModal/__snapshots__/DeleteTemplateModal.test.tsx.snap
+++ b/public/pages/Templates/containers/DeleteTemplatesModal/__snapshots__/DeleteTemplateModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DeleteTemplateModal /> spec renders the component 1`] = `
 HTMLCollection [

--- a/public/pages/Templates/containers/Templates/Templates.test.tsx
+++ b/public/pages/Templates/containers/Templates/Templates.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import { Redirect, Route, Switch } from "react-router-dom";
 import { HashRouter as Router } from "react-router-dom";
@@ -88,12 +88,12 @@ describe("<Templates /> spec", () => {
 
     expect(container.firstChild).toMatchSnapshot();
     await waitFor(() => {
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(1);
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(1);
     });
     await userEvent.click(getByTestId("tableHeaderCell_name_0").querySelector("button") as Element);
     await waitFor(() => {
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(4);
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(4);
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         data: { format: "json", name: `**`, s: "name:asc" },
         endpoint: "cat.templates",
       });
@@ -102,11 +102,11 @@ describe("<Templates /> spec", () => {
 
   it("with some actions", async () => {
     const { getByPlaceholderText } = renderWithRouter();
-    expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(1);
+    expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(1);
     await userEvent.type(getByPlaceholderText("Search..."), `${testTemplateId}{enter}`);
     await waitFor(() => {
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledTimes(4);
-      expect(browserServicesMock.commonService.apiCaller).toBeCalledWith({
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledTimes(4);
+      expect(browserServicesMock.commonService.apiCaller).toHaveBeenCalledWith({
         data: { format: "json", name: `*${testTemplateId}*`, s: "name:desc" },
         endpoint: "cat.templates",
       });

--- a/public/pages/Templates/containers/Templates/__snapshots__/Templates.test.tsx.snap
+++ b/public/pages/Templates/containers/Templates/__snapshots__/Templates.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Templates /> spec renders the component 1`] = `
 <div

--- a/public/pages/Templates/containers/TemplatesActions/TemplatesActions.test.tsx
+++ b/public/pages/Templates/containers/TemplatesActions/TemplatesActions.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import userEventModule from "@testing-library/user-event";
 import { browserServicesMock, coreServicesMock } from "../../../../../test/mocks";
@@ -89,25 +89,23 @@ describe("<TemplatesActions /> spec", () => {
   it("delete templates by calling commonService", async () => {
     const onDelete = jest.fn();
     let times = 0;
-    browserServicesMock.commonService.apiCaller = jest.fn(
-      async (payload): Promise<any> => {
-        if (payload.data?.path?.startsWith("/_index_template/")) {
-          if (times >= 1) {
-            return {
-              ok: true,
-              response: {},
-            };
-          } else {
-            times++;
-            return {
-              ok: false,
-              error: "test error",
-            };
-          }
+    browserServicesMock.commonService.apiCaller = jest.fn(async (payload): Promise<any> => {
+      if (payload.data?.path?.startsWith("/_index_template/")) {
+        if (times >= 1) {
+          return {
+            ok: true,
+            response: {},
+          };
+        } else {
+          times++;
+          return {
+            ok: false,
+            error: "test error",
+          };
         }
-        return { ok: true, response: {} };
       }
-    );
+      return { ok: true, response: {} };
+    });
     const { container, getByTestId, getByPlaceholderText } = renderWithRouter({
       selectedItems: [
         {
@@ -154,7 +152,7 @@ describe("<TemplatesActions /> spec", () => {
 
     await userEvent.click(document.querySelector('[data-test-subj="moreAction"] button') as Element);
     await userEvent.click(getByTestId("editAction"));
-    await waitFor(() => expect(historyPushMock).toBeCalledTimes(1), {
+    await waitFor(() => expect(historyPushMock).toHaveBeenCalledTimes(1), {
       timeout: 3000,
     });
   }, 30000);

--- a/public/pages/Templates/containers/TemplatesActions/__snapshots__/TemplatesActions.test.tsx.snap
+++ b/public/pages/Templates/containers/TemplatesActions/__snapshots__/TemplatesActions.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<TemplatesActions /> spec delete templates by calling commonService 1`] = `
 <div

--- a/public/pages/Transforms/containers/Transforms/__snapshots__/EditTransform.test.tsx.snap
+++ b/public/pages/Transforms/containers/Transforms/__snapshots__/EditTransform.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<EditTransform /> spec renders the component 1`] = `
 <div

--- a/public/pages/Transforms/containers/Transforms/__snapshots__/TransformDetails.test.tsx.snap
+++ b/public/pages/Transforms/containers/Transforms/__snapshots__/TransformDetails.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<TransformDetails /> spec renders the component 1`] = `
 <div>

--- a/public/pages/Transforms/containers/Transforms/__snapshots__/Transforms.test.tsx.snap
+++ b/public/pages/Transforms/containers/Transforms/__snapshots__/Transforms.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Transforms /> spec renders the component 1`] = `
 <div

--- a/public/pages/VisualCreatePolicy/components/Badge/Badge.test.tsx
+++ b/public/pages/VisualCreatePolicy/components/Badge/Badge.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import Badge from "./Badge";
 

--- a/public/pages/VisualCreatePolicy/components/Badge/__snapshots__/Badge.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/Badge/__snapshots__/Badge.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Badge /> spec renders the component 1`] = `
 <div

--- a/public/pages/VisualCreatePolicy/components/ChannelNotification/ChannelNotification.test.tsx
+++ b/public/pages/VisualCreatePolicy/components/ChannelNotification/ChannelNotification.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import ChannelNotification from "./ChannelNotification";
 import { fireEvent, queryByTestId } from "@testing-library/dom";

--- a/public/pages/VisualCreatePolicy/components/ChannelNotification/__snapshots__/ChannelNotification.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/ChannelNotification/__snapshots__/ChannelNotification.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ChannelNotification /> spec renders the component 1`] = `
 <div>

--- a/public/pages/VisualCreatePolicy/components/DraggableItem/DraggableItem.test.tsx
+++ b/public/pages/VisualCreatePolicy/components/DraggableItem/DraggableItem.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import { EuiDragDropContext, EuiDroppable } from "@elastic/eui";
 import DraggableItem from "./DraggableItem";

--- a/public/pages/VisualCreatePolicy/components/DraggableItem/__snapshots__/DraggableItem.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/DraggableItem/__snapshots__/DraggableItem.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DraggableItem /> spec renders the component 1`] = `
 <div

--- a/public/pages/VisualCreatePolicy/components/EuiFormCustomLabel/EuiFormCustomLabel.test.tsx
+++ b/public/pages/VisualCreatePolicy/components/EuiFormCustomLabel/EuiFormCustomLabel.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import EuiFormCustomLabel from "./EuiFormCustomLabel";
 

--- a/public/pages/VisualCreatePolicy/components/EuiFormCustomLabel/__snapshots__/EuiFormCustomLabel.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/EuiFormCustomLabel/__snapshots__/EuiFormCustomLabel.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<EuiFormCustomLabel /> spec renders the component 1`] = `
 <div>

--- a/public/pages/VisualCreatePolicy/components/FlyoutFooter/FlyoutFooter.test.tsx
+++ b/public/pages/VisualCreatePolicy/components/FlyoutFooter/FlyoutFooter.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import FlyoutFooter from "./FlyoutFooter";
 import { fireEvent } from "@testing-library/dom";

--- a/public/pages/VisualCreatePolicy/components/FlyoutFooter/__snapshots__/FlyoutFooter.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/FlyoutFooter/__snapshots__/FlyoutFooter.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<FlyoutFooter /> spec renders the component 1`] = `
 <div

--- a/public/pages/VisualCreatePolicy/components/ISMTemplate/ISMTemplate.test.tsx
+++ b/public/pages/VisualCreatePolicy/components/ISMTemplate/ISMTemplate.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import ISMTemplate from "./ISMTemplate";
 import { fireEvent } from "@testing-library/dom";

--- a/public/pages/VisualCreatePolicy/components/ISMTemplate/__snapshots__/ISMTemplate.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/ISMTemplate/__snapshots__/ISMTemplate.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ISMTemplate /> spec renders the component 1`] = `
 <div
@@ -68,7 +68,7 @@ exports[`<ISMTemplate /> spec renders the component 1`] = `
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>

--- a/public/pages/VisualCreatePolicy/components/ISMTemplates/ISMTemplates.test.tsx
+++ b/public/pages/VisualCreatePolicy/components/ISMTemplates/ISMTemplates.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import ISMTemplates from "./ISMTemplates";
 import { DEFAULT_POLICY } from "../../utils/constants";

--- a/public/pages/VisualCreatePolicy/components/ISMTemplates/__snapshots__/ISMTemplates.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/ISMTemplates/__snapshots__/ISMTemplates.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ISMTemplates /> spec renders the component 1`] = `
 <div

--- a/public/pages/VisualCreatePolicy/components/LegacyNotification/LegacyNotification.test.tsx
+++ b/public/pages/VisualCreatePolicy/components/LegacyNotification/LegacyNotification.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import LegacyNotification from "./LegacyNotification";
 import { DEFAULT_LEGACY_ERROR_NOTIFICATION } from "../../utils/constants";

--- a/public/pages/VisualCreatePolicy/components/LegacyNotification/__snapshots__/LegacyNotification.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/LegacyNotification/__snapshots__/LegacyNotification.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<LegacyNotification /> spec renders the component 1`] = `
 <div

--- a/public/pages/VisualCreatePolicy/components/PolicyInfo/PolicyInfo.test.tsx
+++ b/public/pages/VisualCreatePolicy/components/PolicyInfo/PolicyInfo.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import PolicyInfo from "./PolicyInfo";
 import { fireEvent } from "@testing-library/dom";

--- a/public/pages/VisualCreatePolicy/components/PolicyInfo/__snapshots__/PolicyInfo.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/PolicyInfo/__snapshots__/PolicyInfo.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<PolicyInfo /> spec renders the component 1`] = `
 <div

--- a/public/pages/VisualCreatePolicy/components/States/State.test.tsx
+++ b/public/pages/VisualCreatePolicy/components/States/State.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { screen, render } from "@testing-library/react";
 import State from "./State";
 import { State as StateData } from "../../../../../models/interfaces";

--- a/public/pages/VisualCreatePolicy/components/States/States.test.tsx
+++ b/public/pages/VisualCreatePolicy/components/States/States.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import States from "./States";
 import { DEFAULT_POLICY } from "../../utils/constants";

--- a/public/pages/VisualCreatePolicy/components/States/__snapshots__/State.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/States/__snapshots__/State.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<State /> spec renders the component 1`] = `
 <div

--- a/public/pages/VisualCreatePolicy/components/States/__snapshots__/States.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/States/__snapshots__/States.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<States /> spec renders the component 1`] = `
 <div

--- a/public/pages/VisualCreatePolicy/components/TimeoutRetrySettings/TimeoutRetrySettings.test.tsx
+++ b/public/pages/VisualCreatePolicy/components/TimeoutRetrySettings/TimeoutRetrySettings.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import TimeoutRetrySettings from "./TimeoutRetrySettings";
 import { RolloverUIAction } from "../UIActions";

--- a/public/pages/VisualCreatePolicy/components/TimeoutRetrySettings/__snapshots__/TimeoutRetrySettings.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/TimeoutRetrySettings/__snapshots__/TimeoutRetrySettings.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<TimeoutRetrySettings /> spec renders the component 1`] = `
 <div

--- a/public/pages/VisualCreatePolicy/components/Transition/Transition.test.tsx
+++ b/public/pages/VisualCreatePolicy/components/Transition/Transition.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import Transition from "./Transition";
 

--- a/public/pages/VisualCreatePolicy/components/Transition/TransitionContent.test.tsx
+++ b/public/pages/VisualCreatePolicy/components/Transition/TransitionContent.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import TransitionContent from "./TransitionContent";
 

--- a/public/pages/VisualCreatePolicy/components/Transition/__snapshots__/Transition.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/Transition/__snapshots__/Transition.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Transition /> spec renders the component 1`] = `
 <div>

--- a/public/pages/VisualCreatePolicy/components/Transition/__snapshots__/TransitionContent.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/Transition/__snapshots__/TransitionContent.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<TransitionContent /> spec renders the component 1`] = `
 <div

--- a/public/pages/VisualCreatePolicy/components/UIActions/AliasUIAction/__snapshots__/AliasUIAction.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/components/UIActions/AliasUIAction/__snapshots__/AliasUIAction.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AliasUIAction component renders with blank action 1`] = `
 <div>
@@ -90,7 +90,7 @@ exports[`AliasUIAction component renders with blank action 1`] = `
                   value=""
                 />
                 <div
-                  style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                  style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                 />
               </div>
             </div>
@@ -199,7 +199,7 @@ exports[`AliasUIAction component renders with blank action 1`] = `
                   value=""
                 />
                 <div
-                  style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                  style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                 />
               </div>
             </div>
@@ -415,7 +415,7 @@ exports[`AliasUIAction component renders with pre-defined actions 1`] = `
                   value=""
                 />
                 <div
-                  style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                  style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                 />
               </div>
             </div>
@@ -619,7 +619,7 @@ exports[`AliasUIAction component renders with pre-defined actions 1`] = `
                   value=""
                 />
                 <div
-                  style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                  style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                 />
               </div>
             </div>

--- a/public/pages/VisualCreatePolicy/containers/CreateAction/CreateAction.test.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateAction/CreateAction.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import CreateAction from "./CreateAction";
 import { RolloverUIAction } from "../../components/UIActions";

--- a/public/pages/VisualCreatePolicy/containers/CreateAction/__snapshots__/CreateAction.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateAction/__snapshots__/CreateAction.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreateAction /> spec renders the component 1`] = `
 <div

--- a/public/pages/VisualCreatePolicy/containers/CreateState/Actions.test.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/Actions.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import Actions from "./Actions";
 import { UIAction } from "../../../../../models/interfaces";

--- a/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.test.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/CreateState.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import CreateState from "./CreateState";
 import { DEFAULT_POLICY } from "../../utils/constants";

--- a/public/pages/VisualCreatePolicy/containers/CreateState/Transitions.test.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/Transitions.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import Transitions from "./Transitions";
 import { UITransition } from "../../../../../models/interfaces";

--- a/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/Actions.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/Actions.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Actions /> spec renders the component 1`] = `
 <div>

--- a/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/CreateState.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/CreateState.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreateState /> spec renders the component 1`] = `
 <div

--- a/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/Transitions.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateState/__snapshots__/Transitions.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Transitions /> spec renders the component 1`] = `
 <div>

--- a/public/pages/VisualCreatePolicy/containers/CreateTransition/CreateTransition.test.tsx
+++ b/public/pages/VisualCreatePolicy/containers/CreateTransition/CreateTransition.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import CreateTransition from "./CreateTransition";
 import { UITransition } from "../../../../../models/interfaces";

--- a/public/pages/VisualCreatePolicy/containers/CreateTransition/__snapshots__/CreateTransition.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/CreateTransition/__snapshots__/CreateTransition.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreateTransition /> spec renders the component 1`] = `
 <div
@@ -109,7 +109,7 @@ exports[`<CreateTransition /> spec renders the component 1`] = `
                       value=""
                     />
                     <div
-                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                     />
                   </div>
                 </div>

--- a/public/pages/VisualCreatePolicy/containers/ErrorNotification/ErrorNotification.test.tsx
+++ b/public/pages/VisualCreatePolicy/containers/ErrorNotification/ErrorNotification.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import ErrorNotification, { ErrorNotificationProps } from "./ErrorNotification";
 import { ServicesConsumer, ServicesContext } from "../../../../services";

--- a/public/pages/VisualCreatePolicy/containers/ErrorNotification/__snapshots__/ErrorNotification.test.tsx.snap
+++ b/public/pages/VisualCreatePolicy/containers/ErrorNotification/__snapshots__/ErrorNotification.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ErrorNotification /> spec renders the component 1`] = `
 <div

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -6,8 +6,7 @@
 module.exports = {
   rootDir: "../",
   setupFiles: ["<rootDir>/test/polyfills.ts", "<rootDir>/test/setupTests.ts"],
-  setupFilesAfterEnv: ["<rootDir>/test/setup.jest.ts"],
-  setupFilesAfterEnv: ["<rootDir>/test/setup.jest.ts", "<rootDir>../../src/dev/jest/setup/monaco_mock.js"],
+  setupFilesAfterEnv: ["jest-location-mock", "<rootDir>/test/setup.jest.ts", "<rootDir>../../src/dev/jest/setup/monaco_mock.js"],
   roots: ["<rootDir>"],
   coverageDirectory: "./coverage",
   moduleNameMapper: {
@@ -41,7 +40,23 @@ module.exports = {
     "!**/components/JSONDiffEditor/**",
   ],
   clearMocks: true,
+  transformIgnorePatterns: [
+    // ignore all node_modules except those which are published as ESM-only and
+    // therefore need babel transforms to be usable under Jest.
+    "[/\\\\]node_modules(?![\\/\\\\](query-string|decode-uri-component|filter-obj|split-on-first))[/\\\\].+\\.js$",
+  ],
   testPathIgnorePatterns: ["<rootDir>/build/", "<rootDir>/node_modules/"],
   modulePathIgnorePatterns: ["indexManagementDashboards"],
   testEnvironment: "jsdom",
+  testEnvironmentOptions: {
+    // Set the default URL so window.location.origin is 'http://localhost:5601' rather than
+    // 'http://localhost', avoiding the need for tests to mock window.location.origin.
+    url: "http://localhost:5601",
+  },
+  // Retain Jest 28 snapshot defaults; Jest 29 flipped escapeString and printBasicPrototype to false,
+  // which would invalidate existing snapshots. See https://jestjs.io/docs/29.0/upgrading-to-jest29
+  snapshotFormat: {
+    escapeString: true,
+    printBasicPrototype: true,
+  },
 };

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -54,7 +54,7 @@ module.exports = {
     url: "http://localhost:5601",
   },
   // Retain Jest 28 snapshot defaults; Jest 29 flipped escapeString and printBasicPrototype to false,
-  // which would invalidate existing snapshots. See https://jestjs.io/docs/29.0/upgrading-to-jest29
+  // which would invalidate existing snapshots. See https://jestjs.io/docs/upgrading-to-jest29
   snapshotFormat: {
     escapeString: true,
     printBasicPrototype: true,

--- a/test/setup.jest.ts
+++ b/test/setup.jest.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { configure } from "@testing-library/react";
 
 configure({
@@ -26,12 +26,10 @@ window.Worker = function () {
   this.terminate = () => {};
 };
 
-// @ts-ignore
-window.URL = {
-  createObjectURL: () => {
-    return "";
-  },
-};
+// Only stub createObjectURL; keep the real URL constructor intact. jsdom 26 and
+// query-string rely on `new URL(...)`, so replacing window.URL wholesale with a
+// plain object breaks them ("URL is not a constructor").
+window.URL.createObjectURL = () => "";
 
 // https://github.com/elastic/eui/issues/2530
 jest.mock("@elastic/eui/lib/eui_components/icon", () => ({
@@ -44,3 +42,38 @@ jest.mock("@elastic/eui/lib/eui_components/icon", () => ({
 }));
 
 jest.setTimeout(60000); // in milliseconds
+
+// jest-location-mock uses process.env.HOST as the base URL for its window.location mock.
+// Set it to match testEnvironmentOptions.url so window.location.origin is 'http://localhost:5601'.
+process.env.HOST = "http://localhost:5601";
+
+// Mock window.matchMedia (used by Monaco editor and EUI). Keep configurable so
+// individual tests can override it without hitting "Cannot redefine property".
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  configurable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // Deprecated
+    removeListener: jest.fn(), // Deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
+// jsdom 26 marks window.localStorage and window.sessionStorage as non-configurable.
+// Re-declare them as configurable once here so individual tests can override them
+// with Object.defineProperty without hitting "Cannot redefine property" errors.
+["localStorage", "sessionStorage"].forEach((key) => {
+  const descriptor = Object.getOwnPropertyDescriptor(window, key);
+  if (descriptor && !descriptor.configurable) {
+    Object.defineProperty(window, key, {
+      configurable: true,
+      writable: true,
+      value: descriptor.value,
+    });
+  }
+});


### PR DESCRIPTION
Closes #1458

### Description

Migrate this plugin's Jest test suite to run under **Jest 30.4.2 + jsdom 26.1.0**, following the
core OpenSearch-Dashboards upgrade in opensearch-project/OpenSearch-Dashboards#12381. The plugin
runs its tests against the parent repo's jest binary, so it breaks once the core upgrade lands.

**Result:** full suite green — `161 suites / 653 tests / 208 snapshots passed`, exit 0.

#### Common changes (shared across the plugin-migration campaign)
- **Config (`test/jest.config.js`):** added `jest-location-mock` as the first `setupFilesAfterEnv`
  entry; added `testEnvironmentOptions: { url: 'http://localhost:5601' }`; added the
  `snapshotFormat: { escapeString: true, printBasicPrototype: true }` compatibility shim (Jest 29
  flipped these defaults).
- **Setup (`test/setup.jest.ts`):** added a configurable `matchMedia` mock (used by Monaco/EUI);
  set `process.env.HOST = 'http://localhost:5601'` so jest-location-mock's base URL matches
  `testEnvironmentOptions.url`; re-declared non-configurable `localStorage`/`sessionStorage` as
  configurable (jsdom 26) so tests can override them without "Cannot redefine property".
- **jest-dom import fix:** replaced the removed `@testing-library/jest-dom/extend-expect` entry
  point with `@testing-library/jest-dom` (in `test/setup.jest.ts` and 91 test files).
- **Matcher codemod:** `toBeCalled*` → `toHaveBeenCalled*` across ~109 test files (Jest 30 removed
  the aliases).
- **Snapshots:** bulk-updated the snapshot header URL (`goo.gl/fbAQLP` →
  `jestjs.io/docs/snapshot-testing`) across 137 `.snap` files — Jest 30 refuses to load the old
  header. Of those, 107 are header-only; 30 also regenerated content, and every non-header diff was
  verified to be jsdom-26 CSS serialization only (dropped `font-family: -webkit-small-control` from
  EUI's hidden text-measurement `<div>`), no content regressions.

#### Plugin-specific changes
- **`window.URL` constructor fix (`test/setup.jest.ts`):** the old setup replaced `window.URL`
  wholesale with a plain object `{ createObjectURL }`, which breaks `new URL(...)` under jsdom 26
  and in `query-string` ("URL is not a constructor"). Changed it to keep the real `URL` constructor
  and only stub `window.URL.createObjectURL = () => ""`.
- **ESM dependency transform (`test/jest.config.js`):** added a `transformIgnorePatterns` override
  that allowlists `query-string`, `decode-uri-component`, `filter-obj`, and `split-on-first` for
  Babel transformation — these are now published as ESM-only and fail to parse under Jest otherwise.
- **Stale duplicate `setupFilesAfterEnv` key (`test/jest.config.js`):** the config declared the
  `setupFilesAfterEnv` key twice, so the first (`[setup.jest.ts]`) was silently dead and only the
  second (`[setup.jest.ts, monaco_mock.js]`) took effect. Merged into a single array
  (`jest-location-mock`, `setup.jest.ts`, `monaco_mock.js`) to remove the shadowed key.

No `package.json` change needed — the plugin inherits the parent repo's Jest 30 stack.

### Issues Resolved

Part of the Jest 30 + jsdom 26 migration campaign (core: opensearch-project/OpenSearch-Dashboards#12381).
<!-- Closes #<issue> -->

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
